### PR TITLE
example: Implement runqslower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "clap"
@@ -86,7 +103,12 @@ dependencies = [
 name = "example"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "chrono",
  "libbpf-rs",
+ "libc",
+ "plain",
+ "structopt",
 ]
 
 [[package]]
@@ -209,6 +231,25 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -520,6 +561,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,4 +5,9 @@ authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
+chrono = "0.4"
 libbpf-rs = { path = "../libbpf-rs" }
+libc = "0.2"
+plain = "0.2"
+structopt = "0.3"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,3 +1,127 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+use core::time::Duration;
+use std::path::PathBuf;
+use std::process::exit;
+
+use anyhow::{bail, Result};
+use chrono::Local;
+use libbpf_rs::{MapFlags, ObjectBuilder, PerfBufferBuilder};
+use plain::Plain;
+use structopt::StructOpt;
+
+/// Trace high run queue latency
+#[derive(Debug, StructOpt)]
+struct Command {
+    /// Trace latency higher than this value
+    #[structopt(default_value = "10000")]
+    latency: u64,
+    /// Verbose debug output
+    #[structopt(short, long)]
+    verbose: bool,
+    /// Path to runqslower bpf object file
+    #[structopt(short, long, default_value = "/bin/runqslower.bpf.o")]
+    obj_path: PathBuf,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct Event {
+    pub task: [u8; 16],
+    pub delta_us: u64,
+    pub pid: i32,
+}
+
+unsafe impl Plain for Event {}
+
+fn bump_memlock_rlimit() -> Result<()> {
+    let rlimit = libc::rlimit {
+        rlim_cur: 128 << 20,
+        rlim_max: 128 << 20,
+    };
+
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+        bail!("Failed to increase rlimit");
+    }
+
+    Ok(())
+}
+
+fn handle_event(_cpu: i32, data: &[u8]) {
+    let mut event = Event::default();
+    plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
+
+    let now = Local::now();
+    let task = std::str::from_utf8(&event.task).unwrap();
+
+    println!(
+        "{:8} {:16} {:<7} {:<14}",
+        now.format("%H:%M:%S"),
+        task.trim_end_matches(char::from(0)),
+        event.pid,
+        event.delta_us
+    );
+}
+
+fn handle_lost_events(cpu: i32, count: u64) {
+    eprintln!("Lost {} events on CPU {}", count, cpu);
+}
+
 fn main() {
-    println!("Hello, world!");
+    let opts = Command::from_args();
+
+    if !opts.obj_path.as_path().exists() {
+        eprintln!("{} does not exist", opts.obj_path.as_path().display());
+        exit(1);
+    }
+
+    let mut obj_builder = ObjectBuilder::default();
+    if opts.verbose {
+        obj_builder.set_debug(true);
+    }
+
+    bump_memlock_rlimit().unwrap();
+    let mut obj = obj_builder
+        .from_path(opts.obj_path)
+        .unwrap()
+        .load()
+        .unwrap();
+
+    // Write latency value into map
+    obj.map_unwrap("min_us")
+        .update(
+            &0u32.to_le_bytes(),
+            &opts.latency.to_le_bytes(),
+            MapFlags::empty(),
+        )
+        .unwrap();
+
+    // NB it's crucial that these are named underscore variables otherwise
+    // the link is immediately dropped and our progs aren't run.
+    let _wakup_link = obj.prog_unwrap("handle__sched_wakeup").attach().unwrap();
+    let _wakeup_new_link = obj
+        .prog_unwrap("handle__sched_wakeup_new")
+        .attach()
+        .unwrap();
+    let _switch_link = obj.prog_unwrap("handle__sched_switch").attach().unwrap();
+
+    println!("Tracing run queue latency higher than {} us", opts.latency);
+    println!("{:8} {:16} {:7} {:14}", "TIME", "COMM", "TID", "LAT(us)");
+
+    let events = obj.map_unwrap("events");
+    let mut perf_builder = PerfBufferBuilder::new(events);
+    perf_builder.set_sample_cb(handle_event);
+    perf_builder.set_lost_cb(handle_lost_events);
+    let perf = perf_builder.build().unwrap();
+
+    loop {
+        let ret = perf.poll(Duration::from_millis(100));
+        match ret {
+            Ok(()) => (),
+            Err(e) => {
+                eprintln!("Error polling perf buffer: {}", e);
+                exit(1);
+            }
+        };
+    }
 }


### PR DESCRIPTION
This commit implements runqslower using libbpf-rs.

Example output:
```
$ ./target/debug/example --help
example 0.1.0
Trace high run queue latency

USAGE:
    example [FLAGS] [OPTIONS] [latency]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Verbose debug output

OPTIONS:
    -o, --obj-path <obj-path>    Path to runqslower bpf object file [default: /bin/runqslower.bpf.o]

ARGS:
    <latency>    Trace latency higher than this value [default: 10000]

$ sudo ./target/debug/example -o ~/dev/libbpf-rs/target/bpf/runqslower.bpf.o 1000
Tracing run queue latency higher than 1000 us
TIME     COMM             TID     LAT(us)
13:32:43 Gecko_IOThread   961074  1009
13:32:43 Compositor       961132  2357
13:32:43 Gecko_IOThread   961074  1546
13:32:43 Compositor       961132  1464
13:32:43 Gecko_IOThread   961074  1763
13:32:43 example          1416001 3966
13:32:43 IPDL Background  961135  4084
13:32:43 rcu_sched        11      1387
13:32:43 rcu_sched        11      2051
13:32:43 scribbled        89060   2306
13:32:43 Compositor       961132  4550
13:32:43 scribbled        89060   1183
13:32:43 scribbled        89057   1082
^C
```