### PR TITLE
PerfBufferBuilder: use concrete types for ::new

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -109,10 +109,11 @@ fn main() {
     println!("{:8} {:16} {:7} {:14}", "TIME", "COMM", "TID", "LAT(us)");
 
     let events = obj.map_unwrap("events");
-    let mut perf_builder = PerfBufferBuilder::new(events);
-    perf_builder.set_sample_cb(handle_event);
-    perf_builder.set_lost_cb(handle_lost_events);
-    let perf = perf_builder.build().unwrap();
+    let perf = PerfBufferBuilder::new(events)
+        .with_sample_cb(handle_event)
+        .with_lost_cb(handle_lost_events)
+        .build()
+        .unwrap();
 
     loop {
         let ret = perf.poll(Duration::from_millis(100));


### PR DESCRIPTION
This allows PerfBufferBuilder to build when the user does not specify
one of the callbacks, because there is no longer any ambiguity about
function type to infer if one is missing.

The mutators also now have to modify the type, as they replace the
callback function type on-demand -- they now take self by move, and
return a new PerfBufferBuilder with the right types.