### PR TITLE
libbpf-rs: Slim down number of error variants

### DIFF
--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::result;
 
 use thiserror::Error;
@@ -6,14 +5,8 @@ use thiserror::Error;
 /// Canonical error type for this crate.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("I/O error")]
-    Io(#[from] io::Error),
     #[error("System error, errno: {0}")]
     System(i32),
-    #[error("Invalid binary: {0}")]
-    InvalidObjectFile(String),
-    #[error("Invalid map: {0}")]
-    InvalidMap(String),
     #[error("Input input: {0}")]
     InvalidInput(String),
     #[error("Internal error: {0}")]

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -97,7 +97,7 @@ where
 
     pub fn build(self) -> Result<PerfBuffer> {
         if self.map.map_type() != MapType::PerfEventArray {
-            return Err(Error::InvalidMap(
+            return Err(Error::InvalidInput(
                 "Must use a PerfEventArray map".to_string(),
             ));
         }


### PR DESCRIPTION
There was a bunch before. I think we can cover all the cases with just 3
without losing much context:

* Error::System variant for syscall or syscall-like operation failures
* Error::InvalidInput for invalid input into libbpf-rs
* Error::Internal for internal non-recoverable errors