### PR TITLE
libbpf-rs: Implement query API

### DIFF
--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -59,6 +59,7 @@ mod map;
 mod object;
 mod perf_buffer;
 mod program;
+pub mod query;
 mod util;
 
 pub use crate::error::{Error, Result};

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -1,0 +1,86 @@
+//! Query the host about BPF
+//!
+//! For example, to list the name of every bpf program running on the system:
+//! ```
+//! use std::str::from_utf8;
+//! use libbpf_rs::query::ProgInfoIter;
+//!
+//! let mut iter = ProgInfoIter::default();
+//! for prog in iter {
+//!     let converted_arr: Vec<u8> = prog.name
+//!         .iter()
+//!         .map(|x| *x as u8)
+//!         .collect();
+//!
+//!     println!("{}", from_utf8(&converted_arr).unwrap());
+//! }
+//! ```
+
+use core::ffi::c_void;
+use std::mem::size_of;
+
+use nix::{errno, unistd::close};
+
+macro_rules! gen_info_impl {
+    // This magic here allows us to embed doc comments into macro expansions
+    ($(#[$attr:meta])*
+     $name:ident, $info_ty:ty, $next_id:expr, $fd_by_id:expr) => {
+        $(#[$attr])*
+        #[derive(Default)]
+        pub struct $name {
+            cur_id: u32,
+        }
+
+        impl Iterator for $name {
+            type Item = $info_ty;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if unsafe { $next_id(self.cur_id, &mut self.cur_id) } != 0 {
+                    return None;
+                }
+
+                let fd = unsafe { $fd_by_id(self.cur_id) };
+                if fd < 0 && errno::errno() == errno::Errno::ENOENT as i32 {
+                    return None;
+                }
+
+                let mut item = <$info_ty>::default();
+                let item_ptr: *mut $info_ty = &mut item;
+                let mut len = size_of::<$info_ty>() as u32;
+
+                let ret = unsafe { libbpf_sys::bpf_obj_get_info_by_fd(fd, item_ptr as *mut c_void, &mut len) };
+                let _ = close(fd);
+                if ret != 0 {
+                    return None
+                } else {
+                    Some(item)
+                }
+
+            }
+        }
+    };
+}
+
+gen_info_impl!(
+    /// Iterator that returns information about bpf programs currently running on the system.
+    ProgInfoIter,
+    libbpf_sys::bpf_prog_info,
+    libbpf_sys::bpf_prog_get_next_id,
+    libbpf_sys::bpf_prog_get_fd_by_id
+);
+
+gen_info_impl!(
+    /// Iterator that returns information about bpf maps current created on the system.
+    MapInfoIter,
+    libbpf_sys::bpf_map_info,
+    libbpf_sys::bpf_map_get_next_id,
+    libbpf_sys::bpf_map_get_fd_by_id
+);
+
+gen_info_impl!(
+    /// Iterator that returns information about system BTF.
+    BtfInfoIter,
+    libbpf_sys::bpf_btf_info,
+    libbpf_sys::bpf_btf_get_next_id,
+    libbpf_sys::bpf_btf_get_fd_by_id
+);

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -2,29 +2,28 @@
 //!
 //! For example, to list the name of every bpf program running on the system:
 //! ```
-//! use std::str::from_utf8;
 //! use libbpf_rs::query::ProgInfoIter;
 //!
 //! let mut iter = ProgInfoIter::default();
 //! for prog in iter {
-//!     let converted_arr: Vec<u8> = prog.name
-//!         .iter()
-//!         .map(|x| *x as u8)
-//!         .collect();
-//!
-//!     println!("{}", from_utf8(&converted_arr).unwrap());
+//!     println!("{}", prog.name);
 //! }
 //! ```
 
 use core::ffi::c_void;
+use std::convert::TryFrom;
 use std::mem::size_of;
+use std::string::String;
+use std::time::Duration;
 
 use nix::{errno, unistd::close};
+
+use crate::*;
 
 macro_rules! gen_info_impl {
     // This magic here allows us to embed doc comments into macro expansions
     ($(#[$attr:meta])*
-     $name:ident, $info_ty:ty, $next_id:expr, $fd_by_id:expr) => {
+     $name:ident, $info_ty:ty, $uapi_info_ty:ty, $next_id:expr, $fd_by_id:expr) => {
         $(#[$attr])*
         #[derive(Default)]
         pub struct $name {
@@ -44,16 +43,16 @@ macro_rules! gen_info_impl {
                     return None;
                 }
 
-                let mut item = <$info_ty>::default();
-                let item_ptr: *mut $info_ty = &mut item;
-                let mut len = size_of::<$info_ty>() as u32;
+                let mut item = <$uapi_info_ty>::default();
+                let item_ptr: *mut $uapi_info_ty = &mut item;
+                let mut len = size_of::<$uapi_info_ty>() as u32;
 
                 let ret = unsafe { libbpf_sys::bpf_obj_get_info_by_fd(fd, item_ptr as *mut c_void, &mut len) };
                 let _ = close(fd);
                 if ret != 0 {
                     return None
                 } else {
-                    Some(item)
+                    Some(<$info_ty>::from_uapi(item))
                 }
 
             }
@@ -61,25 +60,189 @@ macro_rules! gen_info_impl {
     };
 }
 
+fn name_arr_to_string(a: &[i8], default: &str) -> String {
+    let converted_arr: Vec<u8> = a
+        .iter()
+        .take_while(|x| **x != 0)
+        .map(|x| *x as u8)
+        .collect();
+    if !converted_arr.is_empty() {
+        String::from_utf8(converted_arr).unwrap_or_else(|_| default.to_string())
+    } else {
+        default.to_string()
+    }
+}
+
+/// Information about a BPF program
+pub struct ProgramInfo {
+    pub name: String,
+    pub ty: ProgramType,
+    pub tag: [u8; 8],
+    pub id: u32,
+    pub jited_prog_len: u32,
+    pub xlated_prog_len: u32,
+    pub jited_prog_insns: u64,
+    pub xlated_prog_insns: u64,
+    /// Duration since system boot
+    pub load_time: Duration,
+    pub created_by_uid: u32,
+    pub nr_map_ids: u32,
+    pub map_ids: u64,
+    pub ifindex: u32,
+    pub gpl_compatible: bool,
+    pub netns_dev: u64,
+    pub netns_ino: u64,
+    pub nr_jited_ksyms: u32,
+    pub nr_jited_func_lens: u32,
+    pub jited_ksyms: u64,
+    pub jited_func_lens: u64,
+    pub btf_id: u32,
+    pub func_info_rec_size: u32,
+    pub func_info: u64,
+    pub nr_func_info: u32,
+    pub nr_line_info: u32,
+    pub line_info: u64,
+    pub jited_line_info: u64,
+    pub nr_jited_line_info: u32,
+    pub line_info_rec_size: u32,
+    pub jited_line_info_rec_size: u32,
+    pub nr_prog_tags: u32,
+    pub prog_tags: u64,
+    pub run_time_ns: u64,
+    pub run_cnt: u64,
+}
+
+impl ProgramInfo {
+    fn from_uapi(s: libbpf_sys::bpf_prog_info) -> Self {
+        let name = name_arr_to_string(&s.name, "(?)");
+        let ty = match ProgramType::try_from(s.type_) {
+            Ok(ty) => ty,
+            Err(_) => ProgramType::Unknown,
+        };
+
+        ProgramInfo {
+            name,
+            ty,
+            tag: s.tag,
+            id: s.id,
+            jited_prog_len: s.jited_prog_len,
+            xlated_prog_len: s.xlated_prog_len,
+            jited_prog_insns: s.jited_prog_insns,
+            xlated_prog_insns: s.xlated_prog_insns,
+            load_time: Duration::from_nanos(s.load_time),
+            created_by_uid: s.created_by_uid,
+            nr_map_ids: s.nr_map_ids,
+            map_ids: s.map_ids,
+            ifindex: s.ifindex,
+            gpl_compatible: s._bitfield_1.get_bit(0),
+            netns_dev: s.netns_dev,
+            netns_ino: s.netns_ino,
+            nr_jited_ksyms: s.nr_jited_ksyms,
+            nr_jited_func_lens: s.nr_jited_func_lens,
+            jited_ksyms: s.jited_ksyms,
+            jited_func_lens: s.jited_func_lens,
+            btf_id: s.btf_id,
+            func_info_rec_size: s.func_info_rec_size,
+            func_info: s.func_info,
+            nr_func_info: s.nr_func_info,
+            nr_line_info: s.nr_line_info,
+            line_info: s.line_info,
+            jited_line_info: s.jited_line_info,
+            nr_jited_line_info: s.nr_jited_line_info,
+            line_info_rec_size: s.line_info_rec_size,
+            jited_line_info_rec_size: s.jited_line_info_rec_size,
+            nr_prog_tags: s.nr_prog_tags,
+            prog_tags: s.prog_tags,
+            run_time_ns: s.run_time_ns,
+            run_cnt: s.run_cnt,
+        }
+    }
+}
+
 gen_info_impl!(
-    /// Iterator that returns information about bpf programs currently running on the system.
+    /// Iterator that returns [`ProgramInfo`]s.
     ProgInfoIter,
+    ProgramInfo,
     libbpf_sys::bpf_prog_info,
     libbpf_sys::bpf_prog_get_next_id,
     libbpf_sys::bpf_prog_get_fd_by_id
 );
 
+/// Information about a BPF map
+pub struct MapInfo {
+    pub name: String,
+    pub ty: MapType,
+    pub id: u32,
+    pub key_size: u32,
+    pub value_size: u32,
+    pub max_entries: u32,
+    pub map_flags: u32,
+    pub ifindex: u32,
+    pub btf_vmlinux_value_type_id: u32,
+    pub netns_dev: u64,
+    pub netns_ino: u64,
+    pub btf_id: u32,
+    pub btf_key_type_id: u32,
+    pub btf_value_type_id: u32,
+}
+
+impl MapInfo {
+    fn from_uapi(s: libbpf_sys::bpf_map_info) -> Self {
+        let name = name_arr_to_string(&s.name, "(?)");
+        let ty = match MapType::try_from(s.type_) {
+            Ok(ty) => ty,
+            Err(_) => MapType::Unknown,
+        };
+
+        Self {
+            name,
+            ty,
+            id: s.id,
+            key_size: s.key_size,
+            value_size: s.value_size,
+            max_entries: s.max_entries,
+            map_flags: s.map_flags,
+            ifindex: s.ifindex,
+            btf_vmlinux_value_type_id: s.btf_vmlinux_value_type_id,
+            netns_dev: s.netns_dev,
+            netns_ino: s.netns_ino,
+            btf_id: s.btf_id,
+            btf_key_type_id: s.btf_key_type_id,
+            btf_value_type_id: s.btf_value_type_id,
+        }
+    }
+}
+
 gen_info_impl!(
-    /// Iterator that returns information about bpf maps current created on the system.
+    /// Iterator that returns [`MapInfo`]s.
     MapInfoIter,
+    MapInfo,
     libbpf_sys::bpf_map_info,
     libbpf_sys::bpf_map_get_next_id,
     libbpf_sys::bpf_map_get_fd_by_id
 );
 
+/// Information about BPF type format
+pub struct BtfInfo {
+    pub btf: u64,
+    pub btf_size: u32,
+    pub id: u32,
+}
+
+impl BtfInfo {
+    fn from_uapi(s: libbpf_sys::bpf_btf_info) -> Self {
+        Self {
+            btf: s.btf,
+            btf_size: s.btf_size,
+            id: s.id,
+        }
+    }
+}
+
 gen_info_impl!(
-    /// Iterator that returns information about system BTF.
+    /// Iterator that returns [`BtfInfo`]s.
     BtfInfoIter,
+    BtfInfo,
     libbpf_sys::bpf_btf_info,
     libbpf_sys::bpf_btf_get_next_id,
     libbpf_sys::bpf_btf_get_fd_by_id


### PR DESCRIPTION
This commit implements an iterator for prog, map, and btf information.
The code was all pretty similar so I used a `macro_rules!` to generate
it. This makes it easy to add new iterators if libbpf (the C library)
follows the same convention for future query APIs.