### PR TITLE
Don't assume the width and signedness of C types

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -32,7 +32,7 @@ impl OpenMap {
             libbpf_sys::bpf_map__set_initial_value(
                 self.ptr,
                 data.as_ptr() as *const std::ffi::c_void,
-                data.len() as u64,
+                data.len() as libbpf_sys::size_t,
             )
         };
 

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -133,7 +133,9 @@ where
             ctx: callback_struct_ptr as *mut _,
         };
 
-        let ptr = unsafe { libbpf_sys::perf_buffer__new(self.map.fd(), self.pages as u64, &opts) };
+        let ptr = unsafe {
+            libbpf_sys::perf_buffer__new(self.map.fd(), self.pages as libbpf_sys::size_t, &opts)
+        };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {
             Err(Error::System(err as i32))

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -202,11 +202,17 @@ impl Program {
         retprobe: bool,
         pid: i32,
         binary_path: T,
-        func_offset: u64,
+        func_offset: usize,
     ) -> Result<Link> {
         let path = binary_path.as_ref().as_ptr() as *const c_char;
         let ptr = unsafe {
-            libbpf_sys::bpf_program__attach_uprobe(self.ptr, retprobe, pid, path, func_offset)
+            libbpf_sys::bpf_program__attach_uprobe(
+                self.ptr,
+                retprobe,
+                pid,
+                path,
+                func_offset as libbpf_sys::size_t,
+            )
         };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -13,6 +13,7 @@
 use core::ffi::c_void;
 use std::convert::TryFrom;
 use std::mem::size_of;
+use std::os::raw::c_char;
 use std::string::String;
 use std::time::Duration;
 
@@ -79,7 +80,7 @@ macro_rules! gen_info_impl {
     };
 }
 
-fn name_arr_to_string(a: &[i8], default: &str) -> String {
+fn name_arr_to_string(a: &[c_char], default: &str) -> String {
     let converted_arr: Vec<u8> = a
         .iter()
         .take_while(|x| **x != 0)
@@ -320,7 +321,7 @@ impl LinkInfo {
 
                 LinkTypeInfo::RawTracepoint(RawTracepointLinkInfo {
                     name: util::c_ptr_to_string(
-                        unsafe { s.__bindgen_anon_1.raw_tracepoint.tp_name } as *const i8,
+                        unsafe { s.__bindgen_anon_1.raw_tracepoint.tp_name } as *const c_char,
                     )
                     .unwrap_or_else(|_| "?".to_string()),
                 })

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -1,4 +1,5 @@
 use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 
 use crate::*;
 
@@ -6,7 +7,7 @@ pub fn str_to_cstring(s: &str) -> Result<CString> {
     CString::new(s).map_err(|e| Error::InvalidInput(e.to_string()))
 }
 
-pub fn c_ptr_to_string(p: *const i8) -> Result<String> {
+pub fn c_ptr_to_string(p: *const c_char) -> Result<String> {
     if p.is_null() {
         return Err(Error::Internal("Null string".to_owned()));
     }


### PR DESCRIPTION
In several places, we use a Rust type of `u64` to represent a C type that is actually pointer sized. This causes compilation errors when targeting 32-bit platforms. Similarly, we assume that `std::os::raw::c_char` is an `i8`, when in fact it can be either an `i8` or a `u8` depending on the platform we're targeting. Fix this by adding casts and using the `usize` Rust type where appropriate.

I don't claim that this commit fixes all such issues, but it does at least fix the ones that were preventing us from building for 32-bit ARM with musl libc. I have also confirmed that it does not regress compilation of a simple demo program on x86_64.