### PR TITLE
Ensure buffer for bpf_obj_get_info_by_fd() is fully zeroed

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -61,7 +61,12 @@ macro_rules! gen_info_impl {
                     None => return None,
                 };
 
-                let mut item = <$uapi_info_ty>::default();
+                // We need to use std::mem::zeroed() instead of just using
+                // ::default() because padding bytes need to be zero as well.
+                // Old kernels which know about fewer fields than we do will
+                // check to make sure every byte past what they know is zero
+                // and will return E2BIG otherwise.
+                let mut item: $uapi_info_ty = unsafe { std::mem::zeroed() };
                 let item_ptr: *mut $uapi_info_ty = &mut item;
                 let mut len = size_of::<$uapi_info_ty>() as u32;
 


### PR DESCRIPTION
The `bpf_obj_get_info_by_fd()` function is used to retrieve information about a BPF object. This is done by passing the provided buffer straight down through the `bpf()` syscall so the kernel can fill it in. However, new members are regularly added to the end of the info structs, which means that old kernels may not fill every member. When this happens, the kernel will fill in the bytes it knows about and leave the rest unchanged. However, it will only do this after [verifying][1] that the entire buffer is zeroed. If the buffer isn't zeroed, it will assume we're trying to use an extension it doesn't support and fail with `E2BIG`.

We currently use Rust's `::default()` to initialize the struct we ask the kernel to fill. Although the default values of all the numeric types in the struct are indeed zero, `::default()` does not make any guarantee about the value of padding bytes. Since the kernel requires all bytes, including padding, to be zero, we can't use `::default()` and need to use `mem::zeroed()` instead. Make that change.

[1]: https://elixir.bootlin.com/linux/v4.14.180/source/kernel/bpf/syscall.c#L60