### PR TITLE
cargo-libbpf: Move docs to --help

### DIFF
--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,38 +1,3 @@
-//! # cargo libbpf
-//!
-//! `cargo libbpf` is a cargo subcommand that helps develop and build eBPF (BPF) programs.
-//!
-//! ### Configuration
-//!
-//! libbpf-cargo provides the following configuration options:
-//!
-//! ```
-//! [package.metadata.libbpf]
-//! prog_dir = "src/other_bpf_dir"
-//! target_dir = "other_target_dir"
-//! ```
-//!
-//! * `prog_dir`: path relative to package Cargo.toml to search for bpf progs
-//!     * default: `<manifest_directory>/src/bpf`
-//! * `target_dir`: path relative to workspace target directory to place compiled bpf progs
-//!     * default: `<target_dir>/bpf`
-//!
-//! These configuration options should be placed in your project's `Cargo.toml` file.
-//!
-//! ### `build` subcommand
-//!
-//! `cargo libbpf build` compiles `<NAME>.bpf.c` C files into corresponding `<NAME>.bpf.o` ELF
-//! object files. Each object file may contain one or more BPF programs, maps, and associated
-//! metadata. The object file may then be handed over to `libbpf-rs` for loading and interaction.
-//!
-//! cargo-libbpf-build enforces a few conventions:
-//!
-//! * source file names must be in the `<NAME>.bpf.c` format
-//! * object file names will be generated in `<NAME>.bpf.o` format
-//! * there may not be any two identical `<NAME>.bpf.c` file names in any two projects in a
-//!   cargo workspace
-//!
-//!
 use std::path::PathBuf;
 use std::process::exit;
 
@@ -68,8 +33,31 @@ enum Wrapper {
 
 #[doc(hidden)]
 #[derive(Debug, StructOpt)]
+#[structopt(verbatim_doc_comment)]
+///
+/// cargo-libbpf is a cargo subcommand that helps develop and build eBPF (BPF) programs.
+///
+/// libbpf-cargo provides the following Cargo.toml configuration options:
+///
+///     [package.metadata.libbpf]
+///     prog_dir = "src/other_bpf_dir"  # default: <manifest_directory>/src/bpf
+///     target_dir = "other_target_dir" # default: <target_dir>/bpf
+///
+/// `prog_dir`: path relative to package Cargo.toml to search for bpf progs
+/// `target_dir`: path relative to workspace target directory to place compiled bpf progs
 enum Command {
     /// Build bpf programs
+    ///
+    /// `cargo libbpf build` compiles `<NAME>.bpf.c` C files into corresponding `<NAME>.bpf.o` ELF
+    /// object files. Each object file may contain one or more BPF programs, maps, and associated
+    /// metadata. The object file may then be handed over to `libbpf-rs` for loading and interaction.
+    ///
+    /// cargo-libbpf-build enforces a few conventions:
+    ///
+    /// * source file names must be in the `<NAME>.bpf.c` format
+    /// * object file names will be generated in `<NAME>.bpf.o` format
+    /// * there may not be any two identical `<NAME>.bpf.c` file names in any two projects in a
+    ///   cargo workspace
     Build {
         #[structopt(short, long)]
         debug: bool,


### PR DESCRIPTION
docs.rs doesn't seem to generate documentation for non-library crates.
So the next best option is to provide the documentation in the --help
menus.