### PR TITLE
libbpf-rs: add attach_sockmap for Program

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -327,4 +327,15 @@ impl Program {
             Ok(Link::new(ptr))
         }
     }
+
+    /// Attach a verdict/parser to a [sockmap/sockhash](https://lwn.net/Articles/731133/)
+    pub fn attach_sockmap(&self, map_fd: i32) -> Result<()> {
+        let err =
+            unsafe { libbpf_sys::bpf_prog_attach(self.fd(), map_fd, self.attach_type() as u32, 0) };
+        if err != 0 {
+            Err(Error::System(err as i32))
+        } else {
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
This is required to support verdict/parser of SK_SKB programs. The programs must be attached to SOCKMAP/SOCKHASH for them to work.

References:
 - https://lwn.net/Articles/731133/
 - https://blog.cloudflare.com/sockmap-tcp-splicing-of-the-future/
 - https://blog.bolcsfoldi.com/posts/ebpf-sockmap/