### PR TITLE
libbpf-rs: Return correct errno for attach_sockmap

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -333,7 +333,7 @@ impl Program {
         let err =
             unsafe { libbpf_sys::bpf_prog_attach(self.fd(), map_fd, self.attach_type() as u32, 0) };
         if err != 0 {
-            Err(Error::System(err as i32))
+            Err(Error::System(errno::errno()))
         } else {
             Ok(())
         }


### PR DESCRIPTION
bpf_prog_attach() has the following code path:

    bpf_prog_attach(..)
      bpf_prog_attach_xattr(..)
        sys_bpf(..)
          syscall(__NR_bpf, ..)

syscall(2) returns -1 on error and stores errno in `errno`. So I think
we need to explicitly get errno() for attach_sockmap().