### PR TITLE
Remove docs link for `libbpf-cago`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,3 @@ To use:
 $ cargo install libbpf-cargo
 $ cargo libbpf --help
 ```
-
-See [full documentation here](https://docs.rs/crate/libbpf-cargo).


### PR DESCRIPTION
Rustdoc doesn't generate docs for binary crates