### PR TITLE
cargo-libbpf: make: Add `make` subcommand 

### DIFF
--- a/examples/runqslower/README.md
+++ b/examples/runqslower/README.md
@@ -7,11 +7,8 @@ effectively.
 
 To build the project:
 ```shell
-$ pwd
-/home/daniel/dev/libbpf-rs/examples/runqslower
-$ cargo libbpf build
-$ cargo libbpf gen
-$ cargo build
+$ cd examples/runqslower
+$ cargo libbpf make
 $ sudo ../../target/debug/runqslower 1000
 Tracing run queue latency higher than 1000 us
 TIME     COMM             TID     LAT(us)

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 #[doc(hidden)]
 mod build;
 mod gen;
+mod make;
 mod metadata;
 #[cfg(test)]
 mod test;
@@ -81,6 +82,23 @@ enum Command {
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
     },
+    Make {
+        #[structopt(short, long)]
+        debug: bool,
+        #[structopt(long, parse(from_os_str))]
+        /// Path to top level Cargo.toml
+        manifest_path: Option<PathBuf>,
+        #[structopt(long, parse(from_os_str), default_value = "clang")]
+        /// Path to clang binary
+        clang_path: PathBuf,
+        #[structopt(long)]
+        /// Skip clang version checks
+        skip_clang_version_checks: bool,
+        /// Arguments to pass to `cargo build`
+        ///
+        /// Example: cargo libbpf build -- --package mypackage
+        cargo_build_args: Vec<String>,
+    },
 }
 
 #[doc(hidden)]
@@ -104,6 +122,19 @@ fn main() {
                 debug,
                 manifest_path,
             } => gen::gen(debug, manifest_path.as_ref()),
+            Command::Make {
+                debug,
+                manifest_path,
+                clang_path,
+                skip_clang_version_checks,
+                cargo_build_args,
+            } => make::make(
+                debug,
+                manifest_path.as_ref(),
+                clang_path.as_path(),
+                skip_clang_version_checks,
+                cargo_build_args,
+            ),
         },
     };
 

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -1,0 +1,52 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::{build, gen};
+
+pub fn make(
+    debug: bool,
+    manifest_path: Option<&PathBuf>,
+    clang: &Path,
+    skip_clang_version_checks: bool,
+    cargo_build_args: Vec<String>,
+) -> i32 {
+    println!("Compiling BPF objects");
+    let mut ret = build::build(debug, manifest_path, clang, skip_clang_version_checks);
+    if ret != 0 {
+        eprintln!("Failed to compile BPF objects");
+        return ret;
+    }
+
+    println!("Generating skeletons");
+    ret = gen::gen(debug, manifest_path);
+    if ret != 0 {
+        eprintln!("Failed to generate skeletons");
+        return ret;
+    }
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build");
+    for arg in cargo_build_args {
+        cmd.arg(arg);
+    }
+
+    let status = match cmd.status() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to spawn child: {}", e);
+            return 1;
+        }
+    };
+
+    if !status.success() {
+        let reason = match status.code() {
+            Some(rc) => format!("exit code {}", rc),
+            None => "killed by signal".to_string(),
+        };
+
+        eprintln!("Failed to `cargo build`: {}", reason);
+        return 1;
+    }
+
+    0
+}


### PR DESCRIPTION
The `cargo libbpf make` subcommand runs:

* cargo libbpf build
* cargo libbpf gen
* cargo build

in sequence, bailing at the first error. The idea is to help prevent
users from forgetting a step. If a step is forgotten, the end results
are unpredictable.