### PR TITLE
libbpf-cargo: gen: Remove ObjectBuilder options in skeleton builder

### DIFF
--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
 
     let mut skel_builder = RunqslowerSkelBuilder::default();
     if opts.verbose {
-        skel_builder.debug(true);
+        skel_builder.obj_builder.debug(true);
     }
 
     bump_memlock_rlimit()?;

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -421,22 +421,6 @@ fn gen_skel_contents(_debug: bool, obj: &UnprocessedObj) -> Result<String> {
         }}
 
         impl {name}SkelBuilder {{
-            pub fn name<T: AsRef<str>>(&mut self, name: T) -> &mut Self {{
-                self.name = name.as_ref().to_string();
-                self.obj_builder.name(name);
-                self
-            }}
-
-            pub fn relaxed_maps(&mut self, relaxed_maps: bool) -> &mut Self {{
-                self.obj_builder.relaxed_maps(relaxed_maps);
-                self
-            }}
-
-            pub fn debug(&mut self, dbg: bool) -> &mut Self {{
-                self.obj_builder.debug(dbg);
-                self
-            }}
-
             pub fn open(&mut self) -> libbpf_rs::Result<Open{name}Skel> {{
                 Ok(Open{name}Skel {{
                     obj: self.obj_builder.open_memory(&self.name, DATA)?,


### PR DESCRIPTION
We already expose `obj_builder` member in SkelBuilder, so no need to
generate unnecessary code.