### PR TITLE
BPF programs will not run unless there is a map existing.

### DIFF
--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -252,7 +252,7 @@ impl<'a> ObjectSkeletonConfig<'a> {
     ///
     /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
     pub fn prog_link_ptr(&mut self, index: usize) -> Result<*mut bpf_link> {
-        if index >= self.maps.len() {
+        if index >= self.progs.len() {
             return Err(Error::Internal(format!("Invalid prog index: {}", index)));
         }
 


### PR DESCRIPTION
This change allows BPF programs without maps.