### PR TITLE
libbpf-cargo: gen: Add datasec mmap support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,10 @@ dependencies = [
  "cargo_metadata",
  "goblin",
  "libbpf-sys",
+ "num_enum",
  "regex",
+ "scroll",
+ "scroll_derive",
  "semver",
  "serde",
  "serde_json",
@@ -262,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -272,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "cargo_metadata",
  "goblin",
  "libbpf-sys",
+ "memmap",
  "num_enum",
  "regex",
  "scroll",
@@ -230,6 +231,16 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "nix"

--- a/examples/runqslower/src/bpf/runqslower.bpf.c
+++ b/examples/runqslower/src/bpf/runqslower.bpf.c
@@ -4,7 +4,11 @@
 #include <bpf/bpf_helpers.h>
 #include "runqslower.h"
 
-#define TASK_RUNNING 0
+#define TASK_RUNNING	0
+
+const volatile __u64 min_us = 0;
+const volatile pid_t targ_pid = 0;
+const volatile pid_t targ_tgid = 0;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -12,13 +16,6 @@ struct {
 	__type(key, u32);
 	__type(value, u64);
 } start SEC(".maps");
-
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, u64);
-} min_us SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
@@ -33,6 +30,10 @@ int trace_enqueue(u32 tgid, u32 pid)
 	u64 ts;
 
 	if (!pid)
+		return 0;
+	if (targ_tgid && targ_tgid != tgid)
+		return 0;
+	if (targ_pid && targ_pid != pid)
 		return 0;
 
 	ts = bpf_ktime_get_ns();
@@ -66,10 +67,10 @@ int handle__sched_switch(u64 *ctx)
 	 */
 	struct task_struct *prev = (struct task_struct *)ctx[1];
 	struct task_struct *next = (struct task_struct *)ctx[2];
-	u64 *tsp, delta_us, *min_us_val;
 	struct event event = {};
-	u32 pid, zero = 0;
+	u64 *tsp, delta_us;
 	long state;
+	u32 pid;
 
 	/* ivcsw: treat like an enqueue event and store timestamp */
 	if (prev->state == TASK_RUNNING)
@@ -82,14 +83,13 @@ int handle__sched_switch(u64 *ctx)
 	if (!tsp)
 		return 0;   /* missed enqueue */
 
-	min_us_val = bpf_map_lookup_elem(&min_us, &zero);
 	delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
-	if (!min_us_val || !*min_us_val || delta_us <= *min_us_val)
+	if (min_us && delta_us <= min_us)
 		return 0;
 
 	event.pid = pid;
 	event.delta_us = delta_us;
-	bpf_probe_read_str(&event.task, sizeof(event.task), next->comm);
+	bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
 
 	/* output */
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -24,7 +24,10 @@ path = "src/main.rs"
 anyhow = "1.0"
 cargo_metadata = "0.9"
 libbpf-sys = { version = "0.2.0-2" }
+num_enum = "0.5"
 regex = "1.4"
+scroll = "0.10"
+scroll_derive = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -36,3 +36,4 @@ semver = "0.9"
 [dev-dependencies]
 tempfile = "3.1"
 goblin = "0.2"
+memmap = "0.7"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 cargo_metadata = "0.9"
 libbpf-sys = { version = "0.2.0-2" }
+memmap = "0.7"
 num_enum = "0.5"
 regex = "1.4"
 scroll = "0.10"
@@ -36,4 +37,3 @@ semver = "0.9"
 [dev-dependencies]
 tempfile = "3.1"
 goblin = "0.2"
-memmap = "0.7"

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -1,0 +1,326 @@
+use std::convert::TryFrom;
+use std::ffi::{c_void, CStr, CString};
+use std::mem::size_of;
+use std::slice;
+
+use anyhow::{bail, ensure, Result};
+use scroll::Pread;
+
+use crate::btf::c_types::*;
+use crate::btf::*;
+
+pub struct Btf<'a> {
+    types: Vec<BtfType<'a>>,
+    ptr_size: u32,
+    string_table: &'a [u8],
+    bpf_obj: *mut libbpf_sys::bpf_object,
+}
+
+impl<'a> Btf<'a> {
+    pub fn new(name: &str, object_file: &[u8]) -> Result<Option<Self>> {
+        let cname = CString::new(name)?;
+        let mut obj_opts = libbpf_sys::bpf_object_open_opts::default();
+        obj_opts.sz = std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t;
+        obj_opts.object_name = cname.as_ptr();
+        let bpf_obj = unsafe {
+            libbpf_sys::bpf_object__open_mem(
+                object_file.as_ptr() as *const c_void,
+                object_file.len() as u64,
+                &obj_opts,
+            )
+        };
+        let err = unsafe { libbpf_sys::libbpf_get_error(bpf_obj as *const _) };
+        ensure!(err == 0, "Failed to bpf_object__open_mem: errno {}", err);
+
+        let bpf_obj_btf = unsafe { libbpf_sys::bpf_object__btf(bpf_obj) };
+        if bpf_obj_btf.is_null() {
+            return Ok(None);
+        }
+
+        let num: u32 = 0x1234;
+        let endianness = if num.to_le_bytes() == num.to_ne_bytes() {
+            libbpf_sys::BTF_LITTLE_ENDIAN
+        } else {
+            libbpf_sys::BTF_BIG_ENDIAN
+        };
+        ensure!(
+            unsafe { libbpf_sys::btf__set_endianness(bpf_obj_btf, endianness) } == 0,
+            "Failed to set BTF endianness"
+        );
+
+        let ptr_size = unsafe { libbpf_sys::btf__pointer_size(bpf_obj_btf) };
+        ensure!(ptr_size != 0, "Could not determine BTF pointer size");
+
+        let mut raw_data_size = 0;
+        let raw_data = unsafe { libbpf_sys::btf__get_raw_data(bpf_obj_btf, &mut raw_data_size) };
+        ensure!(
+            !raw_data.is_null() && raw_data_size > 0,
+            "Could not get raw BTF data"
+        );
+        // `data` is valid as long as `bpf_obj` ptr is valid, so we're safe to conjure up this
+        // `'a` lifetime
+        let data: &'a [u8] =
+            unsafe { slice::from_raw_parts(raw_data as *const u8, raw_data_size as usize) };
+
+        // Read section header
+        let hdr = data.pread::<btf_header>(0)?;
+        ensure!(hdr.magic == BTF_MAGIC, "Invalid BTF magic");
+        ensure!(
+            hdr.version == BTF_VERSION,
+            "Unsupported BTF version: {}",
+            hdr.version
+        );
+
+        // String table
+        let str_off = (hdr.hdr_len + hdr.str_off) as usize;
+        let str_end = str_off + (hdr.str_len as usize);
+        ensure!(str_end <= data.len(), "String table out of bounds");
+        let str_data = &data[str_off..str_end];
+
+        // Type table
+        let type_off = (hdr.hdr_len + hdr.type_off) as usize;
+        let type_end = type_off + (hdr.type_len as usize);
+        ensure!(type_end <= data.len(), "Type table out of bounds");
+        let type_data = &data[type_off..type_end];
+
+        let mut btf = Btf::<'a> {
+            // Type ID 0 is reserved for Void
+            types: vec![BtfType::Void],
+            ptr_size: ptr_size as u32,
+            string_table: str_data,
+            bpf_obj,
+        };
+
+        // Load all types
+        let mut off: usize = 0;
+        while off < hdr.type_len as usize {
+            let t = btf.load_type(&type_data[off..])?;
+            off += Btf::type_size(&t);
+            btf.types.push(t);
+        }
+
+        Ok(Some(btf))
+    }
+
+    fn load_type(&self, data: &'a [u8]) -> Result<BtfType<'a>> {
+        let t = data.pread::<btf_type>(0)?;
+        let extra = &data[size_of::<btf_type>()..];
+        let kind = (t.info >> 24) & 0xf;
+
+        match BtfKind::try_from(kind)? {
+            BtfKind::Void => {
+                let _ = BtfType::Void; // Silence unused variant warning
+                bail!("Cannot load Void type");
+            }
+            BtfKind::Int => self.load_int(&t, extra),
+            BtfKind::Ptr => Ok(BtfType::Ptr(BtfPtr {
+                pointee_type: t.type_id,
+            })),
+            BtfKind::Array => self.load_array(extra),
+            BtfKind::Struct => self.load_struct(&t, extra),
+            BtfKind::Union => self.load_union(&t, extra),
+            BtfKind::Enum => self.load_enum(&t, extra),
+            BtfKind::Fwd => self.load_fwd(&t),
+            BtfKind::Typedef => Ok(BtfType::Typedef(BtfTypedef {
+                name: self.get_btf_str(t.name_off as usize)?,
+                type_id: t.type_id,
+            })),
+            BtfKind::Volatile => Ok(BtfType::Volatile(BtfVolatile { type_id: t.type_id })),
+            BtfKind::Const => Ok(BtfType::Const(BtfConst { type_id: t.type_id })),
+            BtfKind::Restrict => Ok(BtfType::Restrict(BtfRestrict { type_id: t.type_id })),
+            BtfKind::Func => Ok(BtfType::Func(BtfFunc {
+                name: self.get_btf_str(t.name_off as usize)?,
+                type_id: t.type_id,
+            })),
+            BtfKind::FuncProto => self.load_func_proto(&t, extra),
+            BtfKind::Var => self.load_var(&t, extra),
+            BtfKind::Datasec => self.load_datasec(&t, extra),
+        }
+    }
+
+    fn load_int(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let info = extra.pread::<u32>(0)?;
+        let enc: u8 = ((info >> 24) & 0xf) as u8;
+        let off: u8 = ((info >> 16) & 0xff) as u8;
+        let bits: u8 = (info & 0xff) as u8;
+        Ok(BtfType::Int(BtfInt {
+            name: self.get_btf_str(t.name_off as usize)?,
+            bits,
+            offset: off,
+            encoding: BtfIntEncoding::try_from(enc)?,
+        }))
+    }
+
+    fn load_array(&self, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let info = extra.pread::<btf_array>(0)?;
+        Ok(BtfType::Array(BtfArray {
+            nelems: info.nelems,
+            index_type_id: info.idx_type_id,
+            val_type_id: info.val_type_id,
+        }))
+    }
+
+    fn load_struct(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        Ok(BtfType::Struct(BtfComposite {
+            name: self.get_btf_str(t.name_off as usize)?,
+            is_struct: true,
+            size: t.type_id,
+            members: self.load_members(t, extra)?,
+        }))
+    }
+
+    fn load_union(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        Ok(BtfType::Union(BtfComposite {
+            name: self.get_btf_str(t.name_off as usize)?,
+            is_struct: false,
+            size: t.type_id,
+            members: self.load_members(t, extra)?,
+        }))
+    }
+
+    fn load_members(&self, t: &btf_type, extra: &'a [u8]) -> Result<Vec<BtfMember<'a>>> {
+        let mut res = Vec::new();
+        let mut off: usize = 0;
+        let bits = Self::get_kind(t.info);
+
+        for _ in 0..Btf::get_vlen(t.info) {
+            let m = extra.pread::<btf_member>(off)?;
+            res.push(BtfMember {
+                name: self.get_btf_str(m.name_off as usize)?,
+                type_id: m.type_id,
+                bit_size: if bits { (m.offset >> 24) as u8 } else { 0 },
+                bit_offset: if bits { m.offset & 0xffffff } else { m.offset },
+            });
+
+            off += size_of::<btf_member>();
+        }
+
+        Ok(res)
+    }
+
+    fn load_enum(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let mut vals = Vec::new();
+        let mut off: usize = 0;
+
+        for _ in 0..Btf::get_vlen(t.info) {
+            let v = extra.pread::<btf_enum>(off)?;
+            vals.push(BtfEnumValue {
+                name: self.get_btf_str(v.name_off as usize)?,
+                value: v.val,
+            });
+
+            off += size_of::<btf_enum>();
+        }
+
+        Ok(BtfType::Enum(BtfEnum {
+            name: self.get_btf_str(t.name_off as usize)?,
+            size: t.type_id,
+            values: vals,
+        }))
+    }
+
+    fn load_fwd(&self, t: &btf_type) -> Result<BtfType<'a>> {
+        Ok(BtfType::Fwd(BtfFwd {
+            name: self.get_btf_str(t.name_off as usize)?,
+            kind: if Self::get_kind(t.info) {
+                BtfFwdKind::Union
+            } else {
+                BtfFwdKind::Struct
+            },
+        }))
+    }
+
+    fn load_func_proto(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let mut params = Vec::new();
+        let mut off: usize = 0;
+
+        for _ in 0..Btf::get_vlen(t.info) {
+            let p = extra.pread::<btf_param>(off)?;
+            params.push(BtfFuncParam {
+                name: self.get_btf_str(p.name_off as usize)?,
+                type_id: p.type_id,
+            });
+
+            off += size_of::<btf_param>();
+        }
+
+        Ok(BtfType::FuncProto(BtfFuncProto {
+            ret_type_id: t.type_id,
+            params,
+        }))
+    }
+
+    fn load_var(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let kind = extra.pread::<u32>(0)?;
+        Ok(BtfType::Var(BtfVar {
+            name: self.get_btf_str(t.name_off as usize)?,
+            type_id: t.type_id,
+            linkage: BtfVarLinkage::try_from(kind)?,
+        }))
+    }
+
+    fn load_datasec(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let mut vars = Vec::new();
+        let mut off: usize = 0;
+
+        for _ in 0..Btf::get_vlen(t.info) {
+            let v = extra.pread::<btf_datasec_var>(off)?;
+            vars.push(BtfDatasecVar {
+                type_id: v.type_id,
+                offset: v.offset,
+                size: v.size,
+            });
+
+            off += size_of::<btf_datasec_var>();
+        }
+
+        Ok(BtfType::Datasec(BtfDatasec {
+            name: self.get_btf_str(t.name_off as usize)?,
+            size: t.type_id,
+            vars,
+        }))
+    }
+
+    /// Returns size of type on disk in .BTF section
+    fn type_size(t: &BtfType) -> usize {
+        let common = size_of::<btf_type>();
+        match t {
+            BtfType::Void => 0,
+            BtfType::Ptr(_)
+            | BtfType::Fwd(_)
+            | BtfType::Typedef(_)
+            | BtfType::Volatile(_)
+            | BtfType::Const(_)
+            | BtfType::Restrict(_)
+            | BtfType::Func(_) => common,
+            BtfType::Int(_) | BtfType::Var(_) => common + size_of::<u32>(),
+            BtfType::Array(_) => common + size_of::<btf_array>(),
+            BtfType::Struct(t) => common + t.members.len() * size_of::<btf_member>(),
+            BtfType::Union(t) => common + t.members.len() * size_of::<btf_member>(),
+            BtfType::Enum(t) => common + t.values.len() * size_of::<btf_enum>(),
+            BtfType::FuncProto(t) => common + t.params.len() * size_of::<btf_param>(),
+            BtfType::Datasec(t) => common + t.vars.len() * size_of::<btf_datasec_var>(),
+        }
+    }
+
+    fn get_vlen(info: u32) -> u32 {
+        info & 0xffff
+    }
+
+    fn get_kind(info: u32) -> bool {
+        (info >> 31) == 1
+    }
+
+    fn get_btf_str(&self, offset: usize) -> Result<&'a str> {
+        let c_str = unsafe { CStr::from_ptr(&self.string_table[offset] as *const u8 as *const i8) };
+        Ok(c_str.to_str()?)
+    }
+}
+
+impl<'a> Drop for Btf<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            libbpf_sys::bpf_object__close(self.bpf_obj);
+        }
+    }
+}

--- a/libbpf-cargo/src/btf/c_types.rs
+++ b/libbpf-cargo/src/btf/c_types.rs
@@ -1,0 +1,64 @@
+use scroll_derive::{IOread, IOwrite, Pread as DerivePread, Pwrite, SizeWith};
+
+pub const BTF_MAGIC: u16 = 0xEB9F;
+pub const BTF_VERSION: u8 = 1;
+
+/// All offsets are in bytes relative to the end of this header
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_header {
+    pub magic: u16,
+    pub version: u8,
+    pub flags: u8,
+    pub hdr_len: u32,
+    pub type_off: u32,
+    pub type_len: u32,
+    pub str_off: u32,
+    pub str_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_type {
+    pub name_off: u32,
+    pub info: u32,
+    pub type_id: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_enum {
+    pub name_off: u32,
+    pub val: i32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_array {
+    pub val_type_id: u32,
+    pub idx_type_id: u32,
+    pub nelems: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_member {
+    pub name_off: u32,
+    pub type_id: u32,
+    pub offset: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_param {
+    pub name_off: u32,
+    pub type_id: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
+pub struct btf_datasec_var {
+    pub type_id: u32,
+    pub offset: u32,
+    pub size: u32,
+}

--- a/libbpf-cargo/src/btf/mod.rs
+++ b/libbpf-cargo/src/btf/mod.rs
@@ -1,0 +1,3 @@
+pub mod c_types;
+pub mod types;
+pub use types::*;

--- a/libbpf-cargo/src/btf/mod.rs
+++ b/libbpf-cargo/src/btf/mod.rs
@@ -1,3 +1,7 @@
+#[allow(clippy::module_inception)]
+pub mod btf;
 pub mod c_types;
 pub mod types;
+
+pub use btf::*;
 pub use types::*;

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -1,0 +1,227 @@
+use std::fmt;
+
+use num_enum::TryFromPrimitive;
+
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[repr(u32)]
+pub enum BtfKind {
+    Void = 0,
+    Int = 1,
+    Ptr = 2,
+    Array = 3,
+    Struct = 4,
+    Union = 5,
+    Enum = 6,
+    Fwd = 7,
+    Typedef = 8,
+    Volatile = 9,
+    Const = 10,
+    Restrict = 11,
+    Func = 12,
+    FuncProto = 13,
+    Var = 14,
+    Datasec = 15,
+}
+
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[repr(u8)]
+pub enum BtfIntEncoding {
+    None = 0,
+    Signed = 1 << 0,
+    Char = 1 << 1,
+    Bool = 1 << 2,
+}
+
+#[derive(Debug)]
+pub struct BtfInt<'a> {
+    pub name: &'a str,
+    pub bits: u8,
+    pub offset: u8,
+    pub encoding: BtfIntEncoding,
+}
+
+#[derive(Debug)]
+pub struct BtfPtr {
+    pub pointee_type: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfArray {
+    pub nelems: u32,
+    pub index_type_id: u32,
+    pub val_type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfMember<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+    pub bit_offset: u32,
+    pub bit_size: u8,
+}
+
+#[derive(Debug)]
+pub struct BtfComposite<'a> {
+    pub name: &'a str,
+    pub is_struct: bool,
+    pub size: u32,
+    pub members: Vec<BtfMember<'a>>,
+}
+
+#[derive(Debug)]
+pub struct BtfEnumValue<'a> {
+    pub name: &'a str,
+    pub value: i32,
+}
+
+#[derive(Debug)]
+pub struct BtfEnum<'a> {
+    pub name: &'a str,
+    pub size: u32,
+    pub values: Vec<BtfEnumValue<'a>>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum BtfFwdKind {
+    Struct,
+    Union,
+}
+
+#[derive(Debug)]
+pub struct BtfFwd<'a> {
+    pub name: &'a str,
+    pub kind: BtfFwdKind,
+}
+
+#[derive(Debug)]
+pub struct BtfTypedef<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfVolatile {
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfConst {
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfRestrict {
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfFunc<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfFuncParam<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfFuncProto<'a> {
+    pub ret_type_id: u32,
+    pub params: Vec<BtfFuncParam<'a>>,
+}
+
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[repr(u32)]
+pub enum BtfVarLinkage {
+    Static = 0,
+    GlobalAlloc = 1,
+    GlobalExtern = 2,
+}
+
+#[derive(Debug)]
+pub struct BtfVar<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+    pub linkage: BtfVarLinkage,
+}
+
+#[derive(Debug)]
+pub struct BtfDatasecVar {
+    pub type_id: u32,
+    pub offset: u32,
+    pub size: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfDatasec<'a> {
+    pub name: &'a str,
+    pub size: u32,
+    pub vars: Vec<BtfDatasecVar>,
+}
+
+pub enum BtfType<'a> {
+    Void,
+    Int(BtfInt<'a>),
+    Ptr(BtfPtr),
+    Array(BtfArray),
+    Struct(BtfComposite<'a>),
+    Union(BtfComposite<'a>),
+    Enum(BtfEnum<'a>),
+    Fwd(BtfFwd<'a>),
+    Typedef(BtfTypedef<'a>),
+    Volatile(BtfVolatile),
+    Const(BtfConst),
+    Restrict(BtfRestrict),
+    Func(BtfFunc<'a>),
+    FuncProto(BtfFuncProto<'a>),
+    Var(BtfVar<'a>),
+    Datasec(BtfDatasec<'a>),
+}
+
+impl<'a> BtfType<'a> {
+    pub fn kind(&self) -> BtfKind {
+        match self {
+            BtfType::Void => BtfKind::Void,
+            BtfType::Ptr(_) => BtfKind::Ptr,
+            BtfType::Fwd(_) => BtfKind::Fwd,
+            BtfType::Typedef(_) => BtfKind::Typedef,
+            BtfType::Volatile(_) => BtfKind::Volatile,
+            BtfType::Const(_) => BtfKind::Const,
+            BtfType::Restrict(_) => BtfKind::Restrict,
+            BtfType::Func(_) => BtfKind::Func,
+            BtfType::Int(_) => BtfKind::Int,
+            BtfType::Var(_) => BtfKind::Var,
+            BtfType::Array(_) => BtfKind::Array,
+            BtfType::Struct(_) => BtfKind::Struct,
+            BtfType::Union(_) => BtfKind::Union,
+            BtfType::Enum(_) => BtfKind::Enum,
+            BtfType::FuncProto(_) => BtfKind::FuncProto,
+            BtfType::Datasec(_) => BtfKind::Datasec,
+        }
+    }
+}
+
+impl<'a> fmt::Display for BtfType<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BtfType::Void => write!(f, "void"),
+            BtfType::Ptr(_) => write!(f, "ptr"),
+            BtfType::Fwd(_) => write!(f, "fwd"),
+            BtfType::Typedef(_) => write!(f, "typedef"),
+            BtfType::Volatile(_) => write!(f, "volatile"),
+            BtfType::Const(_) => write!(f, "const"),
+            BtfType::Restrict(_) => write!(f, "restrict"),
+            BtfType::Func(_) => write!(f, "func"),
+            BtfType::Int(_) => write!(f, "int"),
+            BtfType::Var(_) => write!(f, "var"),
+            BtfType::Array(_) => write!(f, "array"),
+            BtfType::Struct(_) => write!(f, "struct"),
+            BtfType::Union(_) => write!(f, "union"),
+            BtfType::Enum(_) => write!(f, "enum"),
+            BtfType::FuncProto(_) => write!(f, "funcproto"),
+            BtfType::Datasec(_) => write!(f, "datasec"),
+        }
+    }
+}

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -67,6 +67,21 @@ fn rustfmt(s: &str, rustfmt_path: Option<&PathBuf>) -> Result<String> {
     Ok(String::from_utf8(output.stdout)?)
 }
 
+fn capitalize_first_letter(s: &str) -> String {
+    let mut ret = String::new();
+
+    if s.is_empty() {
+        return ret;
+    }
+
+    ret += &s.chars().next().unwrap().to_uppercase().to_string();
+    if s.len() > 1 {
+        ret += &s[1..];
+    }
+
+    ret
+}
+
 fn get_raw_map_name(map: *const libbpf_sys::bpf_map) -> Result<String> {
     let name_ptr = unsafe { libbpf_sys::bpf_map__name(map) };
     if name_ptr.is_null() {
@@ -501,16 +516,9 @@ fn gen_skel_contents(_debug: bool, obj: &UnprocessedObj) -> Result<String> {
         obj_file_path.as_path().display()
     )?;
 
-    // Capitalize object name
-    let mut obj_name = String::new();
-    // Unwrap is safe b/c already checked that `obj.name` contains chars
-    obj_name += &obj.name.chars().next().unwrap().to_uppercase().to_string();
-    if obj.name.len() > 1 {
-        obj_name += &obj.name[1..];
-    }
-
     // Open bpf_object so we can iterate over maps and progs
     let object = open_object_file(obj_file_path.as_path())?;
+    let obj_name = capitalize_first_letter(&obj.name);
 
     gen_skel_c_skel_constructor(&mut skel, object, &obj.name)?;
 

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 
 use structopt::StructOpt;
 
+mod btf;
 #[doc(hidden)]
 mod build;
 mod gen;

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -109,6 +109,30 @@ fn get_libbpf_rs_path() -> PathBuf {
         .expect("failed to canonicalize libbpf-rs")
 }
 
+/// Add bpf headers (eg vmlinux.h and bpf_helpers.h) into `project`'s src/bpf dir
+fn add_bpf_headers(project: &Path) {
+    let mut vmlinux = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(project.join("src/bpf/vmlinux.h"))
+        .expect("failed to open vmlinux.h");
+    write!(vmlinux, "{}", VMLINUX).expect("failed to write vmlinux.h");
+
+    let mut bpf_helpers = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(project.join("src/bpf/bpf_helpers.h"))
+        .expect("failed to open bpf_helpers.h");
+    write!(bpf_helpers, "{}", BPF_HELPERS).expect("failed to write bpf_helpers.h");
+
+    let mut bpf_helper_defs = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(project.join("src/bpf/bpf_helper_defs.h"))
+        .expect("failed to open bpf_helper_defs.h");
+    write!(bpf_helper_defs, "{}", BPF_HELPER_DEFS).expect("failed to write bpf_helper_defs.h");
+}
+
 #[test]
 fn test_build_default() {
     let (_dir, proj_dir, cargo_toml) = setup_temp_project();
@@ -484,26 +508,7 @@ fn test_skeleton_basic() {
     .expect("failed to write prog.bpf.c");
 
     // Lay down the necessary header files
-    let mut vmlinux = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(proj_dir.join("src/bpf/vmlinux.h"))
-        .expect("failed to open vmlinux.h");
-    write!(vmlinux, "{}", VMLINUX).expect("failed to write vmlinux.h");
-
-    let mut bpf_helpers = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(proj_dir.join("src/bpf/bpf_helpers.h"))
-        .expect("failed to open bpf_helpers.h");
-    write!(bpf_helpers, "{}", BPF_HELPERS).expect("failed to write bpf_helpers.h");
-
-    let mut bpf_helper_defs = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(proj_dir.join("src/bpf/bpf_helper_defs.h"))
-        .expect("failed to open bpf_helper_defs.h");
-    write!(bpf_helper_defs, "{}", BPF_HELPER_DEFS).expect("failed to write bpf_helper_defs.h");
+    add_bpf_headers(&proj_dir);
 
     assert_eq!(
         make(

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -16,9 +16,9 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 thiserror = "1.0"
 bitflags = "1.2"
-nix = "0.17"
-num_enum = "0.4"
 libbpf-sys = { version = "0.2.0-2" }
+nix = "0.17"
+num_enum = "0.5"
 strum_macros = "0.18"
 vsprintf = "1.0"
 


### PR DESCRIPTION
This PR adds support for mmap'd datasec fields. Userspace can now
share data with progs via simple variable reads/writes. See the final
commit for the user facing interface.

See individual commits for details.