### PR TITLE
libbpf-rs: Add Map::keys() iterator

### DIFF
--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -154,6 +155,57 @@ fn test_object_map_lookup_flags() {
     assert!(start
         .update(&[1, 2, 3, 4], &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::NO_EXIST)
         .is_err());
+}
+
+#[test]
+fn test_object_map_key_iter() {
+    bump_rlimit_mlock();
+
+    let mut obj = get_test_object();
+    let start = obj
+        .map("start")
+        .expect("error finding map")
+        .expect("failed to find map");
+
+    let key1 = vec![1, 2, 3, 4];
+    let key2 = vec![1, 2, 3, 5];
+    let key3 = vec![1, 2, 3, 6];
+
+    start
+        .update(&key1, &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::empty())
+        .expect("failed to write");
+    start
+        .update(&key2, &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::empty())
+        .expect("failed to write");
+    start
+        .update(&key3, &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::empty())
+        .expect("failed to write");
+
+    let mut keys = HashSet::new();
+    for key in start.keys() {
+        keys.insert(key);
+    }
+    assert_eq!(keys.len(), 3);
+    assert!(keys.contains(&key1));
+    assert!(keys.contains(&key2));
+    assert!(keys.contains(&key3));
+}
+
+#[test]
+fn test_object_map_key_iter_empty() {
+    bump_rlimit_mlock();
+
+    let mut obj = get_test_object();
+    let start = obj
+        .map("start")
+        .expect("error finding map")
+        .expect("failed to find map");
+
+    let mut count = 0;
+    for _ in start.keys() {
+        count += 1;
+    }
+    assert_eq!(count, 0);
 }
 
 #[test]


### PR DESCRIPTION
Add iterator over keys in a map. This provides the user a way to iterate
over the keys in a map.

Note it was a deliberate decision to _not_ provide map values.  The
reason is that we can race between getting the key and the prog deleting
the entry in the map. It's difficult to propagate this error so let the
user handle it instead.

This closes #53.