### PR TITLE
libbpf-rs: Add OpenMap::reuse_map() API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "libc",
  "nix",
  "num_enum",
+ "scopeguard",
  "strum_macros",
  "thiserror",
  "vsprintf",
@@ -459,6 +460,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -24,3 +24,4 @@ vsprintf = "1.0"
 
 [dev-dependencies]
 libc = "0.2"
+scopeguard = "1.1"


### PR DESCRIPTION
Useful for interacting with pinned maps.

This closes #52.