### PR TITLE
runqslower: Don't redefine `struct event` in rust code

### DIFF
--- a/examples/runqslower/src/bpf/runqslower.bpf.c
+++ b/examples/runqslower/src/bpf/runqslower.bpf.c
@@ -10,6 +10,9 @@ const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
 
+// Dummy instance to get skeleton to generate definition for `struct event`
+struct event _event = {0};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 10240);

--- a/examples/runqslower/src/bpf/runqslower.h
+++ b/examples/runqslower/src/bpf/runqslower.h
@@ -5,7 +5,7 @@
 #define TASK_COMM_LEN 16
 
 struct event {
-	char task[TASK_COMM_LEN];
+	u8 task[TASK_COMM_LEN];
 	__u64 delta_us;
 	pid_t pid;
 };

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -28,15 +28,7 @@ struct Command {
     verbose: bool,
 }
 
-#[repr(C)]
-#[derive(Default)]
-struct Event {
-    pub task: [u8; 16],
-    pub delta_us: u64,
-    pub pid: i32,
-}
-
-unsafe impl Plain for Event {}
+unsafe impl Plain for runqslower_bss_types::event {}
 
 fn bump_memlock_rlimit() -> Result<()> {
     let rlimit = libc::rlimit {
@@ -52,7 +44,7 @@ fn bump_memlock_rlimit() -> Result<()> {
 }
 
 fn handle_event(_cpu: i32, data: &[u8]) {
-    let mut event = Event::default();
+    let mut event = runqslower_bss_types::event::default();
     plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
 
     let now = Local::now();

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -344,7 +344,12 @@ impl<'a> Btf<'a> {
                     let aggregate_type = if t.is_struct { "struct" } else { "union" };
                     let packed_repr = if packed { ", packed" } else { "" };
 
-                    writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
+                    if t.is_struct {
+                        writeln!(def, r#"#[derive(Debug, Default, Copy, Clone)]"#)?;
+                    } else {
+                        writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
+                    }
+
                     writeln!(def, r#"#[repr(C{})]"#, packed_repr)?;
                     writeln!(
                         def,

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -805,7 +805,7 @@ fn test_btf_dump_basic() {
             .expect("Failed to generate myglobal decl")
     );
 
-    let foo_defn = r#"#[derive(Debug, Copy, Clone)]
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
@@ -897,7 +897,7 @@ fn test_btf_dump_struct_definition() {
 
     // Note how there's 6 bytes of padding. It's not necessary on 64 bit archs but
     // we've assumed 32 bit arch during padding generation.
-    let foo_defn = r#"#[derive(Debug, Copy, Clone)]
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub ip: *mut i32,
@@ -909,7 +909,7 @@ pub struct Foo {
     pub cv: i64,
     pub r: *mut i8,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Bar {
     pub x: u16,
@@ -989,7 +989,7 @@ fn test_btf_dump_definition_packed_struct() {
 
     assert!(struct_foo.is_some());
 
-    let foo_defn = r#"#[derive(Debug, Copy, Clone)]
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
 #[repr(C, packed)]
 pub struct Foo {
     pub x: i32,
@@ -1306,13 +1306,13 @@ fn test_btf_dump_definition_shared_dependent_types() {
 
     assert!(struct_foo.is_some());
 
-    let foo_defn = r#"#[derive(Debug, Copy, Clone)]
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub bar: Bar,
     pub bartwo: Bar,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Bar {
     pub x: u16,
@@ -1404,7 +1404,7 @@ fn test_btf_dump_definition_datasec() {
 pub struct bss {
     pub foo: Foo,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
@@ -1516,7 +1516,7 @@ pub struct bss {
     pub foo2: Foo,
     pub foo3: Foo,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub x: i32,


### PR DESCRIPTION
It's better to define a type in one place so things don't get out of
sync.