### PR TITLE
libbpf-cargo: gen.rs: Remove _bpf suffix from skeleton name

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -165,7 +165,7 @@ fn gen_skel_c_skel_constructor(
         {{
             let mut builder = libbpf_rs::skeleton::ObjectSkeletonConfigBuilder::new(DATA);
             builder
-                .name("{name}_bpf")
+                .name("{name}")
         "#,
         name = name
     )?;


### PR DESCRIPTION
The `_bpf` suffix in the generated skeleton name was causing naming conflicts for very short skeleton names. Remove the `_bpf` suffix in the generated skeleton to make names consistent. Fixes #57 