### PR TITLE
libbpf-cargo: gen: Fix skeletons with short object names

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -165,7 +165,7 @@ fn gen_skel_c_skel_constructor(
         {{
             let mut builder = libbpf_rs::skeleton::ObjectSkeletonConfigBuilder::new(DATA);
             builder
-                .name("{name}_bpf")
+                .name("{name}")
         "#,
         name = name
     )?;
@@ -626,13 +626,19 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
         "#
     )?;
 
+    // The name we'll always hand to libbpf
+    //
+    // Note it's important this remains consistent b/c libbpf infers map/prog names from this name
+    let libbpf_obj_name = format!("{}_bpf", raw_obj_name);
+    // We'll use `obj_name` as the rust-ified object name
+    let obj_name = capitalize_first_letter(raw_obj_name);
+
     // Open bpf_object so we can iterate over maps and progs
     let file = File::open(obj_file_path)?;
     let mmap = unsafe { Mmap::map(&file)? };
-    let object = open_bpf_object(raw_obj_name, &*mmap)?;
-    let obj_name = capitalize_first_letter(raw_obj_name);
+    let object = open_bpf_object(&libbpf_obj_name, &*mmap)?;
 
-    gen_skel_c_skel_constructor(&mut skel, object, &raw_obj_name)?;
+    gen_skel_c_skel_constructor(&mut skel, object, &libbpf_obj_name)?;
 
     write!(
         skel,


### PR DESCRIPTION
When we opened the object file to generate the skeleton, we used `{name}`.
The generated skeleton then opens the object with `{name}_bpf`. Since
libbpf uses the object name to derive the map/prog names, this skew can
cause issues.

The issue is sometimes covered up by the fact that libbpf truncates the
object name to a certain number of characters. So for longer object
names, this issue doesn't show up. For shorter object names, this issue
occurs.

This closes #57 .