### PR TITLE
Change generated builder's open() method to consume self

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -648,8 +648,8 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
             pub obj_builder: libbpf_rs::ObjectBuilder,
         }}
 
-        impl {name}SkelBuilder {{
-            pub fn open(&mut self) -> libbpf_rs::Result<Open{name}Skel> {{
+        impl<'a> {name}SkelBuilder {{
+            pub fn open(mut self) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
                 let mut skel_config = build_skel_config()?;
                 let open_opts = self.obj_builder.opts(std::ptr::null());
 


### PR DESCRIPTION
Recently, I wanted to do something like the following to encapsulate program opening and loading logic within a single function in my project.
```rust
fn open_and_load<'a>(debug: bool) -> Result<ProgSkel<'a>> {
    let mut builder = ProgSkelBuilder::default();
    builder.obj_builder.debug(debug);

    bump_memlock_rlimit().context("Failed to bump rlimit")?;

    let open_skel = builder.open().context("Failed to open skeleton")?;

    let mut skel = open_skel.load().context("Failed to load BPF objects")?;

    skel.attach()
        .context("Failed to attach BPF objects to events")?;

    Ok(skel)
}
```
However, the borrow checker would complain under the current code generation logic, wherein the builder's open() method takes a mutable reference to self.

This pull request fixes this behaviour by changing the generated open() method to consume self rather than taking a mutable reference to self. This is also in line with the way the load() function works for the generated OpenSkel.