### PR TITLE
build: Remove symlink step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install deps
       run: sudo apt-get install -y clang-10 libelf-dev
     - name: Symlink clang
-      run: sudo ln -s /usr/bin/clang-10 /bin/clang
+      run: sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-10 /bin/clang
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
     - name: Run tests


### PR DESCRIPTION
I guess there was an OS update and it was installing the "alternatives"
thing into /bin/clang.