### PR TITLE
libbpf-cargo: gen: Improve error message when missing rustfmt

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::ptr;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use memmap::Mmap;
 
 use crate::btf;
@@ -69,9 +69,12 @@ fn rustfmt(s: &str, rustfmt_path: Option<&PathBuf>) -> Result<String> {
     }
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
-    .spawn()?;
+    .spawn()
+    .context("Failed to spawn rustfmt")?;
     write!(cmd.stdin.take().unwrap(), "{}", s)?;
-    let output = cmd.wait_with_output()?;
+    let output = cmd
+        .wait_with_output()
+        .context("Failed to execute rustfmt")?;
 
     Ok(String::from_utf8(output.stdout)?)
 }


### PR DESCRIPTION
Old error:
```
$ cargo libbpf gen --rustfmt-path /bin/asdf
Warning: unrecognized map: .maps
Warning: unrecognized map: license
Failed to generate skeleton for /home/daniel/dev/libbpf-rs/examples/runqslower/src/bpf/runqslower.bpf.c: No such file or directory (os error 2)
```

New error:
```
$ cargo libbpf gen --rustfmt-path /bin/asdf
Warning: unrecognized map: .maps
Warning: unrecognized map: license
Failed to generate skeleton for /home/daniel/dev/libbpf-rs/examples/runqslower/src/bpf/runqslower.bpf.c: Failed to spawn rustfmt
```

This closes #68.