### PR TITLE
libbpf-rs: Fix is_power_two implementation

### DIFF
--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use crate::*;
 
-fn is_power_two(i: usize) -> bool {
-    i > 0 && (!(i & (i - 1))) > 0
+fn is_power_of_two(i: usize) -> bool {
+    i > 0 && (i & (i - 1)) == 0
 }
 
 // Workaround for `trait_alias`
@@ -83,7 +83,7 @@ impl<'a> PerfBufferBuilder<'a> {
             ));
         }
 
-        if !is_power_two(self.pages) {
+        if !is_power_of_two(self.pages) {
             return Err(Error::InvalidInput(
                 "Page count must be power of two".to_string(),
             ));
@@ -166,6 +166,33 @@ impl Drop for PerfBuffer {
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::perf_buffer__free(self.ptr);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_power_of_two_slow(i: usize) -> bool {
+        if i == 0 {
+            return false;
+        }
+
+        let mut n = i;
+        while n > 1 {
+            if n & 0x01 as usize == 1 {
+                return false;
+            }
+            n >>= 1;
+        }
+        true
+    }
+
+    #[test]
+    fn test_is_power_of_two() {
+        for i in 0..=256 {
+            assert_eq!(is_power_of_two(i), is_power_of_two_slow(i));
         }
     }
 }


### PR DESCRIPTION
The function `fn is_power_two` in `perf_buffer.rs` don't work as expected (It works in C++ though).
This PR fixes that and add a small test.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>