### PR TITLE
Fix clippy warnings

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -22,9 +22,12 @@ pub struct Btf<'a> {
 impl<'a> Btf<'a> {
     pub fn new(name: &str, object_file: &[u8]) -> Result<Option<Self>> {
         let cname = CString::new(name)?;
-        let mut obj_opts = libbpf_sys::bpf_object_open_opts::default();
-        obj_opts.sz = std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t;
-        obj_opts.object_name = cname.as_ptr();
+        let obj_opts = libbpf_sys::bpf_object_open_opts {
+            sz: std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
+            object_name: cname.as_ptr(),
+            ..Default::default()
+        };
+
         let bpf_obj = unsafe {
             libbpf_sys::bpf_object__open_mem(
                 object_file.as_ptr() as *const c_void,

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -538,9 +538,12 @@ fn gen_skel_link_getter(
 
 fn open_bpf_object(name: &str, data: &[u8]) -> Result<*mut libbpf_sys::bpf_object> {
     let cname = CString::new(name)?;
-    let mut obj_opts = libbpf_sys::bpf_object_open_opts::default();
-    obj_opts.sz = std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t;
-    obj_opts.object_name = cname.as_ptr();
+    let obj_opts = libbpf_sys::bpf_object_open_opts {
+        sz: std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
+        object_name: cname.as_ptr(),
+        ..Default::default()
+    };
+
     let object = unsafe {
         libbpf_sys::bpf_object__open_mem(
             data.as_ptr() as *const c_void,

--- a/libbpf-cargo/src/metadata.rs
+++ b/libbpf-cargo/src/metadata.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -33,7 +34,7 @@ pub struct UnprocessedObj {
 fn get_package(
     debug: bool,
     package: &Package,
-    workspace_target_dir: &PathBuf,
+    workspace_target_dir: &Path,
 ) -> Result<Vec<UnprocessedObj>> {
     if debug {
         println!("Metadata for package={}", package.name);
@@ -65,7 +66,7 @@ fn get_package(
     };
 
     // Respect custom target directories specified by package
-    let mut target_dir = workspace_target_dir.clone();
+    let mut target_dir = workspace_target_dir.to_path_buf();
     let out_dir = if let Some(d) = package_metadata.target_dir {
         if debug {
             println!("Custom target_dir={}", d.to_string_lossy());

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -165,10 +165,10 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
         // Holds `CString`s alive so pointers to them stay valid
         let mut string_pool = Vec::new();
 
-        // NB: use default() to zero out struct
-        let mut s = bpf_object_skeleton::default();
-
-        s.sz = size_of::<bpf_object_skeleton>() as u64;
+        let mut s = libbpf_sys::bpf_object_skeleton {
+            sz: size_of::<bpf_object_skeleton>() as u64,
+            ..Default::default()
+        };
 
         if let Some(ref n) = self.name {
             s.name = str_to_cstring_and_pool(&n, &mut string_pool)?;


### PR DESCRIPTION
@danobi I took a quick stab at getting rid of all warnings.

There were a bunch of errors in [`examples/runqslower`](https://github.com/libbpf/libbpf-rs/tree/master/examples/runqslower), but it didn't quite make sense to add Clippy ignore's in there, since people are likely going to copy/paste from that code. Let me know if I got that wrong.

Otherwise, this is pretty much my first Rust code ever, so let me know what I should fix!