### PR TITLE
Allow usage of anonymous structs and unions

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -584,9 +584,8 @@ impl<'a> Btf<'a> {
     fn load_struct(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count);
                 self.anon_agg_count += 1;
-                n
+                format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count)
             }
             n => n.to_string(),
         };
@@ -601,9 +600,8 @@ impl<'a> Btf<'a> {
     fn load_union(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count);
                 self.anon_agg_count += 1;
-                n
+                format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count)
             }
             n => n.to_string(),
         };

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -12,16 +12,14 @@ use scroll::Pread;
 use crate::btf::c_types::*;
 use crate::btf::*;
 
-const ANON_STRUCT_PREFIX: &str = "__anon_struct_";
-const ANON_UNION_PREFIX: &str = "__anon_union_";
+const ANON_AGGREGATE_PREFIX: &str = "__anon_";
 
 pub struct Btf<'a> {
     types: Vec<BtfType<'a>>,
     ptr_size: u32,
     string_table: &'a [u8],
     bpf_obj: *mut libbpf_sys::bpf_object,
-    anon_union_count: u32,
-    anon_struct_count: u32,
+    anon_agg_count: u32,
 }
 
 impl<'a> Btf<'a> {
@@ -97,8 +95,7 @@ impl<'a> Btf<'a> {
             ptr_size: ptr_size as u32,
             string_table: str_data,
             bpf_obj,
-            anon_union_count: 0u32,
-            anon_struct_count: 0u32,
+            anon_agg_count: 0u32,
         };
 
         // Load all types
@@ -587,8 +584,8 @@ impl<'a> Btf<'a> {
     fn load_struct(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("{}{}", ANON_STRUCT_PREFIX, self.anon_struct_count);
-                self.anon_struct_count += 1;
+                let n = format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count);
+                self.anon_agg_count += 1;
                 n
             }
             n => n.to_string(),
@@ -604,8 +601,8 @@ impl<'a> Btf<'a> {
     fn load_union(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("{}{}", ANON_UNION_PREFIX, self.anon_union_count);
-                self.anon_union_count += 1;
+                let n = format!("{}{}", ANON_AGGREGATE_PREFIX, self.anon_agg_count);
+                self.anon_agg_count += 1;
                 n
             }
             n => n.to_string(),

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -5,7 +5,6 @@ use std::ffi::{c_void, CStr, CString};
 use std::fmt::Write;
 use std::mem::size_of;
 use std::slice;
-use std::sync::Mutex;
 
 use anyhow::{bail, ensure, Result};
 use scroll::Pread;
@@ -18,8 +17,8 @@ pub struct Btf<'a> {
     ptr_size: u32,
     string_table: &'a [u8],
     bpf_obj: *mut libbpf_sys::bpf_object,
-    anon_union_count: Mutex<u32>,
-    anon_struct_count: Mutex<u32>,
+    anon_union_count: u32,
+    anon_struct_count: u32,
 }
 
 impl<'a> Btf<'a> {
@@ -95,8 +94,8 @@ impl<'a> Btf<'a> {
             ptr_size: ptr_size as u32,
             string_table: str_data,
             bpf_obj,
-            anon_union_count: Mutex::new(0),
-            anon_struct_count: Mutex::new(0),
+            anon_union_count: 0u32,
+            anon_struct_count: 0u32,
         };
 
         // Load all types
@@ -524,24 +523,7 @@ impl<'a> Btf<'a> {
         }
     }
 
-    fn get_name_or_anonymous_string(
-        &self,
-        name_off: usize,
-        counter: &Mutex<u32>,
-        prefix: &str,
-    ) -> Result<String> {
-        let mut count = counter.lock().unwrap();
-        Ok(match self.get_btf_str(name_off)? {
-            "" => {
-                let rc = String::from(prefix) + &count.to_string();
-                *count += 1;
-                rc
-            }
-            n => String::from(n),
-        })
-    }
-
-    fn load_type(&self, data: &'a [u8]) -> Result<BtfType<'a>> {
+    fn load_type(&mut self, data: &'a [u8]) -> Result<BtfType<'a>> {
         let t = data.pread::<btf_type>(0)?;
         let extra = &data[size_of::<btf_type>()..];
         let kind = (t.info >> 24) & 0xf;
@@ -599,12 +581,15 @@ impl<'a> Btf<'a> {
         }))
     }
 
-    fn load_struct(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
-        let name = self.get_name_or_anonymous_string(
-            t.name_off as usize,
-            &self.anon_struct_count,
-            "anon_struct_",
-        )?;
+    fn load_struct(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let name = match self.get_btf_str(t.name_off as usize)? {
+            "" => {
+                let n = format!("anon_struct_{}", self.anon_struct_count);
+                self.anon_struct_count += 1;
+                n
+            }
+            n => n.to_string(),
+        };
         Ok(BtfType::Struct(BtfComposite {
             name: name,
             is_struct: true,
@@ -613,12 +598,15 @@ impl<'a> Btf<'a> {
         }))
     }
 
-    fn load_union(&self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
-        let name = self.get_name_or_anonymous_string(
-            t.name_off as usize,
-            &self.anon_union_count,
-            "anon_union_",
-        )?;
+    fn load_union(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
+        let name = match self.get_btf_str(t.name_off as usize)? {
+            "" => {
+                let n = format!("anon_union_{}", self.anon_union_count);
+                self.anon_union_count += 1;
+                n
+            }
+            n => n.to_string(),
+        };
         Ok(BtfType::Union(BtfComposite {
             name: name,
             is_struct: false,

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -12,6 +12,9 @@ use scroll::Pread;
 use crate::btf::c_types::*;
 use crate::btf::*;
 
+const ANON_STRUCT_PREFIX: &str = "__anon_struct_";
+const ANON_UNION_PREFIX: &str = "__anon_union_";
+
 pub struct Btf<'a> {
     types: Vec<BtfType<'a>>,
     ptr_size: u32,
@@ -584,7 +587,7 @@ impl<'a> Btf<'a> {
     fn load_struct(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("anon_struct_{}", self.anon_struct_count);
+                let n = format!("{}{}", ANON_STRUCT_PREFIX, self.anon_struct_count);
                 self.anon_struct_count += 1;
                 n
             }
@@ -601,7 +604,7 @@ impl<'a> Btf<'a> {
     fn load_union(&mut self, t: &btf_type, extra: &'a [u8]) -> Result<BtfType<'a>> {
         let name = match self.get_btf_str(t.name_off as usize)? {
             "" => {
-                let n = format!("anon_union_{}", self.anon_union_count);
+                let n = format!("{}{}", ANON_UNION_PREFIX, self.anon_union_count);
                 self.anon_union_count += 1;
                 n
             }

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -62,7 +62,7 @@ pub struct BtfMember<'a> {
 
 #[derive(Debug)]
 pub struct BtfComposite<'a> {
-    pub name: &'a str,
+    pub name: String,
     pub is_struct: bool,
     pub size: u32,
     pub members: Vec<BtfMember<'a>>,

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1641,7 +1641,6 @@ pub union anon_union_1 {
     pub u: *mut u64,
 }
 "#;
-    println!("{}", btf.type_definition(struct_foo.unwrap()).unwrap());
     assert_eq!(
         foo_defn,
         btf.type_definition(struct_foo.unwrap())

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1623,20 +1623,20 @@ fn test_btf_dump_definition_struct_inner_anon_union() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: anon_union_0,
+    pub bar: __anon_union_0,
     __pad_36: [u8; 4],
-    pub baz: anon_union_1,
+    pub baz: __anon_union_1,
     pub w: i32,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union anon_union_0 {
+pub union __anon_union_0 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union anon_union_1 {
+pub union __anon_union_1 {
     pub w: u32,
     pub u: *mut u64,
 }
@@ -1726,19 +1726,19 @@ fn test_btf_dump_definition_struct_inner_anon_struct() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: anon_struct_0,
-    pub baz: anon_struct_1,
+    pub bar: __anon_struct_0,
+    pub baz: __anon_struct_1,
     pub w: i32,
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct anon_struct_0 {
+pub struct __anon_struct_0 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct anon_struct_1 {
+pub struct __anon_struct_1 {
     pub w: u32,
     __pad_4: [u8; 4],
     pub u: *mut u64,

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1623,20 +1623,20 @@ fn test_btf_dump_definition_struct_inner_anon_union() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: __anon_0,
+    pub bar: __anon_1,
     __pad_36: [u8; 4],
-    pub baz: __anon_1,
+    pub baz: __anon_2,
     pub w: i32,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_0 {
+pub union __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_1 {
+pub union __anon_2 {
     pub w: u32,
     pub u: *mut u64,
 }
@@ -1726,19 +1726,19 @@ fn test_btf_dump_definition_struct_inner_anon_struct() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: __anon_0,
-    pub baz: __anon_1,
+    pub bar: __anon_1,
+    pub baz: __anon_2,
     pub w: i32,
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_0 {
+pub struct __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_1 {
+pub struct __anon_2 {
     pub w: u32,
     __pad_4: [u8; 4],
     pub u: *mut u64,
@@ -1837,35 +1837,35 @@ fn test_btf_dump_definition_struct_inner_anon_struct_and_union() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: __anon_0,
-    pub zerg: __anon_1,
-    pub baz: __anon_2,
+    pub bar: __anon_1,
+    pub zerg: __anon_2,
+    pub baz: __anon_3,
     pub w: i32,
     __pad_76: [u8; 4],
-    pub flarg: __anon_3,
+    pub flarg: __anon_4,
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_0 {
+pub struct __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_1 {
+pub union __anon_2 {
     pub a: *mut i8,
     pub b: i32,
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_2 {
+pub struct __anon_3 {
     pub w: u32,
     __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_3 {
+pub union __anon_4 {
     pub c: u8,
     pub d: [u64; 5],
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1623,20 +1623,20 @@ fn test_btf_dump_definition_struct_inner_anon_union() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: __anon_union_0,
+    pub bar: __anon_0,
     __pad_36: [u8; 4],
-    pub baz: __anon_union_1,
+    pub baz: __anon_1,
     pub w: i32,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_union_0 {
+pub union __anon_0 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub union __anon_union_1 {
+pub union __anon_1 {
     pub w: u32,
     pub u: *mut u64,
 }
@@ -1726,25 +1726,150 @@ fn test_btf_dump_definition_struct_inner_anon_struct() {
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    pub bar: __anon_struct_0,
-    pub baz: __anon_struct_1,
+    pub bar: __anon_0,
+    pub baz: __anon_1,
     pub w: i32,
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_struct_0 {
+pub struct __anon_0 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
-pub struct __anon_struct_1 {
+pub struct __anon_1 {
     pub w: u32,
     __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 "#;
-    println!("{}", btf.type_definition(struct_foo.unwrap()).unwrap());
+    assert_eq!(
+        foo_defn,
+        btf.type_definition(struct_foo.unwrap())
+            .expect("Failed to generate struct Foo defn")
+    );
+}
+
+#[test]
+fn test_btf_dump_definition_struct_inner_anon_struct_and_union() {
+    let (_dir, proj_dir, cargo_toml) = setup_temp_project();
+
+    // Add prog dir
+    create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
+
+    // Add a prog
+    let mut prog = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(proj_dir.join("src/bpf/prog.bpf.c"))
+        .expect("failed to open prog.bpf.c");
+
+    write!(
+        prog,
+        r#"
+        #include "vmlinux.h"
+        #include "bpf_helpers.h"
+
+        struct Foo {{
+            int x;
+            struct {{
+                u8 y[10];
+                u16 z[16];
+            }} bar;
+            union {{
+                char *a;
+                int b;
+            }} zerg;
+            struct {{
+                u32 w;
+                u64 *u;
+            }} baz;
+            int w;
+            union {{
+                u8 c;
+                u64 d[5];
+            }} flarg;
+        }};
+
+        struct Foo foo;
+        "#,
+    )
+    .expect("failed to write prog.bpf.c");
+
+    // Lay down the necessary header files
+    add_bpf_headers(&proj_dir);
+
+    // Build the .bpf.o
+    assert_eq!(
+        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
+        0
+    );
+
+    let obj = OpenOptions::new()
+        .read(true)
+        .open(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path())
+        .expect("failed to open object file");
+    let mmap = unsafe { Mmap::map(&obj) }.expect("Failed to mmap object file");
+    let btf = Btf::new("prog", &*mmap)
+        .expect("Failed to initialize Btf")
+        .expect("Did not find .BTF section");
+
+    assert!(btf.types().len() > 0);
+
+    // Find our struct
+    let mut struct_foo: Option<u32> = None;
+    for (idx, ty) in btf.types().iter().enumerate() {
+        match ty {
+            btf::BtfType::Struct(t) => {
+                if t.name == "Foo" {
+                    assert!(struct_foo.is_none()); // No duplicates
+                    struct_foo = Some(idx.try_into().unwrap());
+                }
+            }
+            _ => (),
+        }
+    }
+
+    assert!(struct_foo.is_some());
+
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct Foo {
+    pub x: i32,
+    pub bar: __anon_0,
+    pub zerg: __anon_1,
+    pub baz: __anon_2,
+    pub w: i32,
+    __pad_76: [u8; 4],
+    pub flarg: __anon_3,
+}
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct __anon_0 {
+    pub y: [u8; 10],
+    pub z: [u16; 16],
+}
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub union __anon_1 {
+    pub a: *mut i8,
+    pub b: i32,
+}
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct __anon_2 {
+    pub w: u32,
+    __pad_4: [u8; 4],
+    pub u: *mut u64,
+}
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub union __anon_3 {
+    pub c: u8,
+    pub d: [u64; 5],
+}
+"#;
     assert_eq!(
         foo_defn,
         btf.type_definition(struct_foo.unwrap())

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1748,6 +1748,6 @@ pub struct __anon_struct_1 {
     assert_eq!(
         foo_defn,
         btf.type_definition(struct_foo.unwrap())
-            .expect("Failed to generate union Foo defn")
+            .expect("Failed to generate struct Foo defn")
     );
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1544,3 +1544,211 @@ pub struct rodata {
             .expect("Failed to generate rodata")
     );
 }
+
+#[test]
+fn test_btf_dump_definition_struct_inner_anon_union() {
+    let (_dir, proj_dir, cargo_toml) = setup_temp_project();
+
+    // Add prog dir
+    create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
+
+    // Add a prog
+    let mut prog = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(proj_dir.join("src/bpf/prog.bpf.c"))
+        .expect("failed to open prog.bpf.c");
+
+    write!(
+        prog,
+        r#"
+        #include "vmlinux.h"
+        #include "bpf_helpers.h"
+
+        struct Foo {{
+            int x;
+            union {{
+                u8 y[10];
+                u16 z[16];
+            }} bar;
+            union {{
+                u32 w;
+                u64 *u;
+            }} baz;
+            int w;
+        }};
+
+        struct Foo foo;
+        "#,
+    )
+    .expect("failed to write prog.bpf.c");
+
+    // Lay down the necessary header files
+    add_bpf_headers(&proj_dir);
+
+    // Build the .bpf.o
+    assert_eq!(
+        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
+        0
+    );
+
+    let obj = OpenOptions::new()
+        .read(true)
+        .open(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path())
+        .expect("failed to open object file");
+    let mmap = unsafe { Mmap::map(&obj) }.expect("Failed to mmap object file");
+    let btf = Btf::new("prog", &*mmap)
+        .expect("Failed to initialize Btf")
+        .expect("Did not find .BTF section");
+
+    assert!(btf.types().len() > 0);
+
+    // Find our struct
+    let mut struct_foo: Option<u32> = None;
+    for (idx, ty) in btf.types().iter().enumerate() {
+        match ty {
+            btf::BtfType::Struct(t) => {
+                if t.name == "Foo" {
+                    assert!(struct_foo.is_none()); // No duplicates
+                    struct_foo = Some(idx.try_into().unwrap());
+                }
+            }
+            _ => (),
+        }
+    }
+
+    assert!(struct_foo.is_some());
+
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct Foo {
+    pub x: i32,
+    pub bar: anon_union_0,
+    __pad_36: [u8; 4],
+    pub baz: anon_union_1,
+    pub w: i32,
+}
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub union anon_union_0 {
+    pub y: [u8; 10],
+    pub z: [u16; 16],
+}
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub union anon_union_1 {
+    pub w: u32,
+    pub u: *mut u64,
+}
+"#;
+    println!("{}", btf.type_definition(struct_foo.unwrap()).unwrap());
+    assert_eq!(
+        foo_defn,
+        btf.type_definition(struct_foo.unwrap())
+            .expect("Failed to generate union Foo defn")
+    );
+}
+
+#[test]
+fn test_btf_dump_definition_struct_inner_anon_struct() {
+    let (_dir, proj_dir, cargo_toml) = setup_temp_project();
+
+    // Add prog dir
+    create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
+
+    // Add a prog
+    let mut prog = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(proj_dir.join("src/bpf/prog.bpf.c"))
+        .expect("failed to open prog.bpf.c");
+
+    write!(
+        prog,
+        r#"
+        #include "vmlinux.h"
+        #include "bpf_helpers.h"
+
+        struct Foo {{
+            int x;
+            struct {{
+                u8 y[10];
+                u16 z[16];
+            }} bar;
+            struct {{
+                u32 w;
+                u64 *u;
+            }} baz;
+            int w;
+        }};
+
+        struct Foo foo;
+        "#,
+    )
+    .expect("failed to write prog.bpf.c");
+
+    // Lay down the necessary header files
+    add_bpf_headers(&proj_dir);
+
+    // Build the .bpf.o
+    assert_eq!(
+        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
+        0
+    );
+
+    let obj = OpenOptions::new()
+        .read(true)
+        .open(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path())
+        .expect("failed to open object file");
+    let mmap = unsafe { Mmap::map(&obj) }.expect("Failed to mmap object file");
+    let btf = Btf::new("prog", &*mmap)
+        .expect("Failed to initialize Btf")
+        .expect("Did not find .BTF section");
+
+    assert!(btf.types().len() > 0);
+
+    // Find our struct
+    let mut struct_foo: Option<u32> = None;
+    for (idx, ty) in btf.types().iter().enumerate() {
+        match ty {
+            btf::BtfType::Struct(t) => {
+                if t.name == "Foo" {
+                    assert!(struct_foo.is_none()); // No duplicates
+                    struct_foo = Some(idx.try_into().unwrap());
+                }
+            }
+            _ => (),
+        }
+    }
+
+    assert!(struct_foo.is_some());
+
+    let foo_defn = r#"#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct Foo {
+    pub x: i32,
+    pub bar: anon_struct_0,
+    pub baz: anon_struct_1,
+    pub w: i32,
+}
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct anon_struct_0 {
+    pub y: [u8; 10],
+    pub z: [u16; 16],
+}
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct anon_struct_1 {
+    pub w: u32,
+    __pad_4: [u8; 4],
+    pub u: *mut u64,
+}
+"#;
+    println!("{}", btf.type_definition(struct_foo.unwrap()).unwrap());
+    assert_eq!(
+        foo_defn,
+        btf.type_definition(struct_foo.unwrap())
+            .expect("Failed to generate union Foo defn")
+    );
+}


### PR DESCRIPTION
Anonymous structs and unions cannot be used in a libbpf-rs project as the structs and unions are not named.

Name anonymous structs as "anon_struct_X" where X is an increasing integer, and anonymous unions as "anon_union_X"