### PR TITLE
cargo: update version pins

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.9"
-libbpf-sys = { version = "0.2.0-2" }
+libbpf-sys = { version = "0.3.0-2" }
 memmap = "0.7"
 num_enum = "0.5"
 regex = "1.4"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -16,11 +16,11 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 thiserror = "1.0"
 bitflags = "1.2"
-libbpf-sys = { version = "0.2.0-3" }
+libbpf-sys = { version = "0.3.0-2" }
 nix = "0.17"
 num_enum = "0.5"
 strum_macros = "0.18"
-vsprintf = "1.0"
+vsprintf = "2.0"
 
 [dev-dependencies]
 libc = "0.2"


### PR DESCRIPTION
Bump versions for `vsprintf` and `libbpf-sys`. Needed for the Fedora packaging (see https://bugzilla.redhat.com/show_bug.cgi?id=1958352)