### PR TITLE
Fix 32 bit build

### DIFF
--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_void;
 use std::boxed::Box;
+use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
 use std::time::Duration;
@@ -104,7 +105,7 @@ impl RingBufferBuilder {
         Ok(RingBuffer { ptr, _cbs: cbs })
     }
 
-    unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: u64) -> i32 {
+    unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: c_ulong) -> i32 {
         let callback_struct = ctx as *mut RingBufferCallback;
         let callback = (*callback_struct).cb.as_mut();
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -3,7 +3,7 @@ use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::boxed::Box;
 use std::ffi::CString;
 use std::mem::size_of;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_ulong};
 use std::ptr;
 
 use libbpf_sys::{
@@ -166,7 +166,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
         let mut string_pool = Vec::new();
 
         let mut s = libbpf_sys::bpf_object_skeleton {
-            sz: size_of::<bpf_object_skeleton>() as u64,
+            sz: size_of::<bpf_object_skeleton>() as c_ulong,
             ..Default::default()
         };
 
@@ -176,7 +176,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 
         // libbpf_sys will use it as const despite the signature
         s.data = self.data.as_ptr() as *mut c_void;
-        s.data_sz = self.data.len() as u64;
+        s.data_sz = self.data.len() as c_ulong;
 
         s.obj = &mut *self.p;
 


### PR DESCRIPTION
Use c_ulong instead of u64 where applicable. This should not be an API
breaking change because on 64 bit systems c_ulong is already u64. It'd
technically be a breaking change on 32 bit systems but this project
never built on 32 bit in the first place so it's a moot point.