### PR TITLE
Generate impl Default functionality for structures which cannot use #[derive(Default)]

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -247,7 +247,7 @@ impl<'a> Btf<'a> {
 
         Ok(match ty {
             BtfType::Void => "std::ffi::c_void::default()".to_string(),
-            BtfType::Int(_) => format!("{}::default()", self.type_declaration(type_id)?),
+            BtfType::Int(_) => format!("{}::default()", self.type_declaration(stripped_type_id)?),
             BtfType::Ptr(_) => "std::ptr::null_mut()".to_string(),
             BtfType::Array(t) => {
                 let val_ty = self.type_declaration(t.val_type_id)?;

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -444,9 +444,9 @@ impl<'a> Btf<'a> {
                                         field_ty_str = def
                                     ));
                                 }
-                                Err(_) => {
+                                Err(e) => {
                                     if gen_impl_default {
-                                        bail!("Could not construct a necessary Default Impl");
+                                        bail!("Could not construct a necessary Default Impl: {}", e);
                                     }
                                 }
                             };

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -446,7 +446,10 @@ impl<'a> Btf<'a> {
                                 }
                                 Err(e) => {
                                     if gen_impl_default {
-                                        bail!("Could not construct a necessary Default Impl: {}", e);
+                                        bail!(
+                                            "Could not construct a necessary Default Impl: {}",
+                                            e
+                                        );
                                     }
                                 }
                             };

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -1,4 +1,3 @@
-use anyhow::{bail, Result};
 use std::fmt;
 
 use num_enum::TryFromPrimitive;
@@ -39,26 +38,6 @@ pub struct BtfInt<'a> {
     pub bits: u8,
     pub offset: u8,
     pub encoding: BtfIntEncoding,
-}
-
-impl<'a> BtfInt<'a> {
-    /// Returns the rust-ified type declaration of an integer
-    pub fn type_declaration(&self) -> Result<String> {
-        let width = match (self.bits + 7) / 8 {
-            1 => "8",
-            2 => "16",
-            4 => "32",
-            8 => "64",
-            16 => "128",
-            _ => bail!("Invalid integer width"),
-        };
-
-        if self.encoding == BtfIntEncoding::Signed {
-            Ok(format!("i{}", width))
-        } else {
-            Ok(format!("u{}", width))
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, Result};
 use std::fmt;
 
 use num_enum::TryFromPrimitive;
@@ -38,6 +39,26 @@ pub struct BtfInt<'a> {
     pub bits: u8,
     pub offset: u8,
     pub encoding: BtfIntEncoding,
+}
+
+impl<'a> BtfInt<'a> {
+    /// Returns the rust-ified type declaration of an integer
+    pub fn type_declaration(&self) -> Result<String> {
+        let width = match (self.bits + 7) / 8 {
+            1 => "8",
+            2 => "16",
+            4 => "32",
+            8 => "64",
+            16 => "128",
+            _ => bail!("Invalid integer width"),
+        };
+
+        if self.encoding == BtfIntEncoding::Signed {
+            Ok(format!("i{}", width))
+        } else {
+            Ok(format!("u{}", width))
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1804,22 +1804,15 @@ fn test_btf_dump_definition_datasec_long_array() {
         r#"
         #include "vmlinux.h"
         #include "bpf_helpers.h"
-<<<<<<< HEAD
-=======
 
->>>>>>> 9bf3168b67500cc2cd750b848e8dc8c884365444
         struct Foo {{
             int x;
             char y[33];
             void *z;
         }};
-<<<<<<< HEAD
-        struct Foo foo = {{0}};
-=======
 
         struct Foo foo = {{0}};
 
->>>>>>> 9bf3168b67500cc2cd750b848e8dc8c884365444
         const int myconstglobal = 0;
         "#,
     )
@@ -2034,26 +2027,17 @@ fn test_btf_dump_definition_datasec_multiple_long_array() {
         r#"
         #include "vmlinux.h"
         #include "bpf_helpers.h"
-<<<<<<< HEAD
-=======
 
->>>>>>> 9bf3168b67500cc2cd750b848e8dc8c884365444
         struct Foo {{
             int x;
             char y[33];
             void *z;
         }};
-<<<<<<< HEAD
-        struct Foo foo = {{0}};
-        struct Foo foo2 = {{0}};
-        struct Foo foo3 = {{0}};
-=======
 
         struct Foo foo = {{0}};
         struct Foo foo2 = {{0}};
         struct Foo foo3 = {{0}};
 
->>>>>>> 9bf3168b67500cc2cd750b848e8dc8c884365444
         const int ci = 0;
         const int ci2 = 0;
         const int ci3 = 0;


### PR DESCRIPTION
If an array has length > 32, #[derive(Default)] will fail to compile.

This PR modifies libbpf-cargo so that it no longer generates skeleton code which will fail to compile
due to the array size limitation of #[derive(Default)].

Determine if a structure contains an array longer than 32.  If it does, output both the structure definition
and also an impl Default for the structure.  If a structure does not contain an array longer than 32 use #[derive(Default)]
for output