### PR TITLE
libbpf-cargo: Add SkeletonBuilder library for use in build scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "libbpf-cargo",
  "libbpf-rs",
  "libc",
  "plain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/examples/runqslower/.gitignore
+++ b/examples/runqslower/.gitignore
@@ -1,2 +1,1 @@
 src/bpf/mod.rs
-src/bpf/*.skel.rs

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -11,3 +11,6 @@ libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
 structopt = "0.3"
+
+[build-dependencies]
+libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/runqslower/README.md
+++ b/examples/runqslower/README.md
@@ -8,7 +8,7 @@ effectively.
 To build the project:
 ```shell
 $ cd examples/runqslower
-$ cargo libbpf make
+$ cargo build
 $ sudo ../../target/debug/runqslower 1000
 Tracing run queue latency higher than 1000 us
 TIME     COMM             TID     LAT(us)

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use libbpf_cargo::SkeletonBuilder;
+
+const SRC: &str = "./src/bpf/runqslower.bpf.c";
+
+fn main() {
+    // It's unfortunate we cannot use `OUT_DIR` to store the generated skeleton.
+    // Reasons are because the generated skeleton contains compiler attributes
+    // that cannot be `include!()`ed via macro. And we cannot use the `#[path = "..."]`
+    // trick either because you cannot yet `concat!(env!("OUT_DIR"), "/skel.rs")` inside
+    // the path attribute either (see https://github.com/rust-lang/rust/pull/83366).
+    //
+    // However, there is hope! When the above feature stabilizes we can clean this
+    // all up.
+    let skel = Path::new("./src/bpf/mod.rs");
+    SkeletonBuilder::new(SRC).generate(&skel).unwrap();
+    println!("cargo:rerun-if-changed={}", SRC);
+}

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -20,6 +20,9 @@ maintenance = { status = "actively-developed" }
 name = "cargo-libbpf"
 path = "src/main.rs"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.9"
@@ -33,7 +36,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 semver = "0.9"
+tempfile = "3.1"
+thiserror = "1.0"
 
 [dev-dependencies]
-tempfile = "3.1"
 goblin = "0.2"

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -107,6 +107,7 @@ pub struct SkeletonBuilder {
     debug: bool,
     source: PathBuf,
     clang: PathBuf,
+    clang_args: String,
     skip_clang_version_check: bool,
     rustfmt: PathBuf,
 }
@@ -119,6 +120,7 @@ impl SkeletonBuilder {
             debug: false,
             source: source.as_ref().to_path_buf(),
             clang: "clang".into(),
+            clang_args: String::new(),
             skip_clang_version_check: false,
             rustfmt: "rustfmt".into(),
         }
@@ -137,6 +139,23 @@ impl SkeletonBuilder {
     /// Default searchs `$PATH` for `clang`
     pub fn clang<P: AsRef<Path>>(&mut self, clang: P) -> &mut SkeletonBuilder {
         self.clang = clang.as_ref().to_path_buf();
+        self
+    }
+
+    /// Pass additional arguments to `clang` when buildling BPF object file
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use libbpf_cargo::SkeletonBuilder;
+    ///
+    /// SkeletonBuilder::new("myobject.bpf.c")
+    ///     .clang_args("-DMACRO=value -I/some/include/dir")
+    ///     .generate("/output/path")
+    ///     .unwrap();
+    /// ```
+    pub fn clang_args<S: AsRef<str>>(&mut self, opts: S) -> &mut SkeletonBuilder {
+        self.clang_args = opts.as_ref().to_string();
         self
     }
 
@@ -182,6 +201,7 @@ impl SkeletonBuilder {
             &objfile,
             &self.clang,
             self.skip_clang_version_check,
+            &self.clang_args,
         )
         .map_err(|e| Error::Build(e.to_string()))?;
 

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -9,8 +9,6 @@ mod build;
 mod gen;
 mod make;
 mod metadata;
-#[cfg(test)]
-mod test;
 
 #[doc(hidden)]
 #[derive(Debug, StructOpt)]

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use std::process::exit;
 
+use anyhow::Result;
 use structopt::StructOpt;
 
 mod btf;
@@ -98,10 +98,10 @@ enum Command {
 }
 
 #[doc(hidden)]
-fn main() {
+fn main() -> Result<()> {
     let opts = Opt::from_args();
 
-    let rc = match opts.wrapper {
+    match opts.wrapper {
         Wrapper::Libbpf(cmd) => match cmd {
             Command::Build {
                 debug,
@@ -143,7 +143,5 @@ fn main() {
                 rustfmt_path.as_ref(),
             ),
         },
-    };
-
-    exit(rc);
+    }
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -141,26 +141,17 @@ fn test_build_default() {
     let (_dir, proj_dir, cargo_toml) = setup_temp_project();
 
     // No bpf progs yet
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 
     // Add a prog
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -178,10 +169,7 @@ fn test_build_invalid_prog() {
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
     writeln!(prog_file, "1").expect("write to prog file failed");
 
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 }
 
 #[test]
@@ -200,20 +188,14 @@ fn test_build_custom() {
         .expect("write to Cargo.toml failed");
 
     // No bpf progs yet
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 
     // Add a prog
     create_dir(proj_dir.join("src/other_bpf_dir")).expect("failed to create prog dir");
     let _prog_file = File::create(proj_dir.join("src/other_bpf_dir/prog.bpf.c"))
         .expect("failed to create prog file");
 
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     // Validate generated object file
     validate_bpf_o(
@@ -230,24 +212,15 @@ fn test_enforce_file_extension() {
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 
     let _prog_file = File::create(proj_dir.join("src/bpf/prog_BAD_EXTENSION.c"))
         .expect("failed to create prog file");
-    assert_ne!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap_err();
 
     let _prog_file_again = File::create(proj_dir.join("src/bpf/prog_GOOD_EXTENSION.bpf.c"))
         .expect("failed to create prog file");
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 }
 
 #[test]
@@ -255,15 +228,13 @@ fn test_build_workspace() {
     let (_dir, _, workspace_cargo_toml, proj_one_dir, proj_two_dir) = setup_temp_workspace();
 
     // No bpf progs yet
-    assert_ne!(
-        build(
-            true,
-            Some(&workspace_cargo_toml),
-            Path::new("/bin/clang"),
-            true
-        ),
-        0
-    );
+    build(
+        true,
+        Some(&workspace_cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+    )
+    .unwrap_err();
 
     // Create bpf prog for project one
     create_dir(proj_one_dir.join("src/bpf")).expect("failed to create prog dir");
@@ -275,15 +246,13 @@ fn test_build_workspace() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog2.bpf.c"))
         .expect("failed to create prog file 2");
 
-    assert_eq!(
-        build(
-            true,
-            Some(&workspace_cargo_toml),
-            Path::new("/bin/clang"),
-            true
-        ),
-        0
-    );
+    build(
+        true,
+        Some(&workspace_cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -300,15 +269,13 @@ fn test_build_workspace_collision() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to create prog file 2");
 
-    assert_ne!(
-        build(
-            true,
-            Some(&workspace_cargo_toml),
-            Path::new("/bin/clang"),
-            true
-        ),
-        0
-    );
+    build(
+        true,
+        Some(&workspace_cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+    )
+    .unwrap_err();
 }
 
 #[test]
@@ -322,18 +289,16 @@ fn test_make_basic() {
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    assert_eq!(
-        make(
-            true,
-            Some(&cargo_toml),
-            Path::new("/bin/clang"),
-            true,
-            true,
-            Vec::new(),
-            None,
-        ),
-        0
-    );
+    make(
+        true,
+        Some(&cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -361,18 +326,16 @@ fn test_make_workspace() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog2.bpf.c"))
         .expect("failed to create prog file 2");
 
-    assert_eq!(
-        make(
-            true,
-            Some(&workspace_cargo_toml),
-            Path::new("/bin/clang"),
-            true,
-            true,
-            Vec::new(),
-            None
-        ),
-        0
-    );
+    make(
+        true,
+        Some(&workspace_cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     // Validate generated object files
     validate_bpf_o(
@@ -412,18 +375,16 @@ fn test_skeleton_empty_source() {
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    assert_eq!(
-        make(
-            true,
-            Some(&cargo_toml),
-            Path::new("/bin/clang"),
-            true,
-            true,
-            Vec::new(),
-            None
-        ),
-        0
-    );
+    make(
+        true,
+        Some(&cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -513,18 +474,16 @@ fn test_skeleton_basic() {
     // Lay down the necessary header files
     add_bpf_headers(&proj_dir);
 
-    assert_eq!(
-        make(
-            true,
-            Some(&cargo_toml),
-            Path::new("/bin/clang"),
-            true,
-            true,
-            Vec::new(),
-            None
-        ),
-        0
-    );
+    make(
+        true,
+        Some(&cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -626,18 +585,16 @@ fn test_skeleton_datasec() {
     // Lay down the necessary header files
     add_bpf_headers(&proj_dir);
 
-    assert_eq!(
-        make(
-            true,
-            Some(&cargo_toml),
-            Path::new("/bin/clang"),
-            true,
-            true,
-            Vec::new(),
-            None
-        ),
-        0
-    );
+    make(
+        true,
+        Some(&cargo_toml),
+        Path::new("/bin/clang"),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -739,10 +696,7 @@ fn test_btf_dump_basic() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -863,10 +817,7 @@ fn test_btf_dump_struct_definition() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -957,10 +908,7 @@ fn test_btf_dump_definition_packed_struct() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1038,10 +986,7 @@ fn test_btf_dump_definition_bitfield_struct_fails() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1107,10 +1052,7 @@ fn test_btf_dump_definition_enum() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1189,10 +1131,7 @@ fn test_btf_dump_definition_union() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1274,10 +1213,7 @@ fn test_btf_dump_definition_shared_dependent_types() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1362,10 +1298,7 @@ fn test_btf_dump_definition_datasec() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)
@@ -1472,10 +1405,7 @@ fn test_btf_dump_definition_datasec_multiple() {
     add_bpf_headers(&proj_dir);
 
     // Build the .bpf.o
-    assert_eq!(
-        build(true, Some(&cargo_toml), Path::new("/bin/clang"), true),
-        0
-    );
+    build(true, Some(&cargo_toml), Path::new("/bin/clang"), true).unwrap();
 
     let obj = OpenOptions::new()
         .read(true)

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -12,25 +12,27 @@
 //!
 //! ## High level workflow
 //!
-//! 1. Install `libbpf-cargo` (`cargo install libbpf-cargo`)
 //! 1. Create new rust project (via `cargo new` or similar) at path `$PROJ_PATH`
 //! 1. Create directory `$PROJ_PATH/src/bpf`
 //! 1. Write CO-RE bpf code in `$PROJ_PATH/src/bpf/${MYFILE}.bpf.c`, where `$MYFILE` may be any
 //!    valid filename. Note the `.bpf.c` extension is required.
-//! 1. Build your bpf code by running `cargo libbpf build`
-//! 1. Generate skeleton code by running `cargo libbpf gen`
-//! 1. Write your userspace code by importing and using the module generated in
-//!    `$PROJ_PATH/src/bpf/mod.rs`. Your userspace code goes in `$PROJ_PATH/src/` as it would
-//!    in a normal rust project.
+//! 1. Create a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
+//!    that builds and generates a skeleton module using `libbpf_cargo::SkeletonBuilder`
+//! 1. Write your userspace code by importing and using the generated module. Import the
+//!    module by using the [path
+//!    attribute](https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute).
+//!    Your userspace code goes in `$PROJ_PATH/src/` as it would in a normal rust project.
 //! 1. Continue regular rust workflow (ie `cargo build`, `cargo run`, etc)
 //!
 //! ## Alternate workflow
 //!
 //! While using the skeleton is recommended, it is also possible to directly use libbpf-rs.
 //!
-//! 1. Follow steps 1-5 of "High level workflow"
+//! 1. Follow steps 1-3 of "High level workflow"
+//! 1. Generate a BPF object file. Options include manually invoking `clang`, creating a build
+//!    script to invoke `clang`, or using `libbpf-cargo` cargo plugins.
 //! 1. Write your userspace code in `$PROJ_PATH/src/` as you would a normal rust project and point
-//!    libbpf-rs at the object file generated at `$PROJ_PATH/target/bpf/${MYFILE}.bpf.o`
+//!    libbpf-rs at your BPF object file
 //! 1. Continue regular rust workflow (ie `cargo build`, `cargo run`, etc)
 //!
 //! ## Design


### PR DESCRIPTION
Build scripts are pretty standard for projects that have a codegen step
as part of the build. The current method is kind of strange (took a
while to realize) where we have the user run a custom cargo tool. It'd
be nicer to give users the option to encapsulate everything in a build
script such that `cargo build` "just works".

See 4th commit in series for how runqslower example looks with the
build script.

This closes #63.