### PR TITLE
Implement progs_iter and maps_iter for Object and OpenObject

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -662,7 +662,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
                     return Err(libbpf_rs::Error::System(-ret));
                 }}
 
-                let obj = unsafe {{ libbpf_rs::OpenObject::from_ptr(skel_config.object_ptr()) }};
+                let obj = unsafe {{ libbpf_rs::OpenObject::from_ptr(skel_config.object_ptr())? }};
 
                 Ok(Open{name}Skel {{
                     obj,
@@ -693,7 +693,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
                     return Err(libbpf_rs::Error::System(-ret));
                 }}
 
-                let obj = unsafe {{ libbpf_rs::Object::from_ptr(self.obj.take_ptr()) }};
+                let obj = unsafe {{ libbpf_rs::Object::from_ptr(self.obj.take_ptr())? }};
 
                 Ok({name}Skel {{
                     obj,

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -27,11 +27,3 @@ pub fn c_ptr_to_string(p: *const c_char) -> Result<String> {
         .map_err(|e| Error::Internal(e.to_string()))?
         .to_owned())
 }
-
-pub fn ptr_to_option<T>(p: *mut T) -> Option<*mut T> {
-    if p.is_null() {
-        None
-    } else {
-        Some(p)
-    }
-}

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -349,10 +349,7 @@ fn test_object_reuse_pined_map() {
     builder.debug(true);
     let mut open_obj = builder.open_file(obj_path).expect("failed to open object");
 
-    let start = open_obj
-        .map("start")
-        .expect("error finding map")
-        .expect("failed to find map");
+    let start = open_obj.map("start").expect("failed to find map");
     assert!(start.reuse_pinned_map("/asdf").is_err());
     start.reuse_pinned_map(path).expect("failed to reuse map");
 


### PR DESCRIPTION
I want to be able to easily iterate over all BPF programs and maps in my libbpf_rs project. My use case is for easy pinning/unpinning but I imagine this capability could be useful for other use cases as well.

This PR implements `progs_iter` and `maps_iter` for `OpenObject` and `Object` to address this use case. It also adds a simple smoke test and some documentation for previously undocumented getters.

Fixes #77 Closes #79 