### PR TITLE
libbpf-rs: Add immutable getters

### DIFF
--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> Result<()> {
     println!("Tracing run queue latency higher than {} us", opts.latency);
     println!("{:8} {:16} {:7} {:14}", "TIME", "COMM", "TID", "LAT(us)");
 
-    let perf = PerfBufferBuilder::new(skel.maps().events())
+    let perf = PerfBufferBuilder::new(skel.maps_mut().events())
         .sample_cb(handle_event)
         .lost_cb(handle_lost_events)
         .build()?;

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -159,12 +159,8 @@ fn map_is_mmapable(map: *const libbpf_sys::bpf_map) -> bool {
 fn map_is_datasec(map: *const libbpf_sys::bpf_map) -> bool {
     let internal = unsafe { libbpf_sys::bpf_map__is_internal(map) };
     let mmapable = map_is_mmapable(map);
-    let has_datasec_name = match get_map_name(map).unwrap().as_ref().map(String::as_str) {
-        Some("rodata") | Some("data") | Some("bss") | Some("kconfig") => true,
-        _ => false,
-    };
 
-    internal && mmapable && has_datasec_name
+    internal && mmapable
 }
 
 fn map_is_readonly(map: *const libbpf_sys::bpf_map) -> bool {

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -284,7 +284,7 @@ fn gen_skel_map_defs(
             skel,
             r#"
             pub fn {map_name}(&mut self) -> &mut {return_ty} {{
-                self.inner.map_unwrap_mut("{raw_map_name}")
+                self.inner.map_mut("{raw_map_name}").unwrap()
             }}
             "#,
             map_name = map_name,
@@ -340,7 +340,7 @@ fn gen_skel_prog_defs(
             skel,
             r#"
             pub fn {prog_name}(&mut self) -> &mut {return_ty} {{
-                self.inner.prog_unwrap_mut("{prog_name}")
+                self.inner.prog_mut("{prog_name}").unwrap()
             }}
             "#,
             prog_name = get_prog_name(prog)?,

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -238,6 +238,10 @@ fn gen_skel_map_defs(
     open: bool,
     mutable: bool,
 ) -> Result<()> {
+    if MapIter::new(object).next().is_none() {
+        return Ok(());
+    }
+
     let (struct_suffix, mut_prefix, map_fn) = if mutable {
         ("Mut", "mut ", "map_mut")
     } else {

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -284,7 +284,7 @@ fn gen_skel_map_defs(
             skel,
             r#"
             pub fn {map_name}(&mut self) -> &mut {return_ty} {{
-                self.inner.map_unwrap("{raw_map_name}")
+                self.inner.map_unwrap_mut("{raw_map_name}")
             }}
             "#,
             map_name = map_name,
@@ -340,7 +340,7 @@ fn gen_skel_prog_defs(
             skel,
             r#"
             pub fn {prog_name}(&mut self) -> &mut {return_ty} {{
-                self.inner.prog_unwrap("{prog_name}")
+                self.inner.prog_unwrap_mut("{prog_name}")
             }}
             "#,
             prog_name = get_prog_name(prog)?,

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -532,12 +532,12 @@ fn gen_skel_map_getter(
     write!(
         skel,
         r#"
-    pub fn maps(&self) -> {return_ty} {{
-        {return_ty} {{
-            inner: &self.obj,
+        pub fn maps(&self) -> {return_ty} {{
+            {return_ty} {{
+                inner: &self.obj,
+            }}
         }}
-    }}
-    "#,
+        "#,
         return_ty = return_ty
     )?;
 
@@ -568,12 +568,12 @@ fn gen_skel_map_getter_mut(
     write!(
         skel,
         r#"
-    pub fn maps_mut(&mut self) -> {return_ty} {{
-        {return_ty} {{
-            inner: &mut self.obj,
+        pub fn maps_mut(&mut self) -> {return_ty} {{
+            {return_ty} {{
+                inner: &mut self.obj,
+            }}
         }}
-    }}
-    "#,
+        "#,
         return_ty = return_ty
     )?;
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -692,6 +692,9 @@ fn test_skeleton_builder_basic() {
             // Check that we can grab handles to open maps/progs
             let _open_map = open_skel.maps().mymap();
             let _open_prog = open_skel.progs().this_is_my_prog();
+            let _open_map_mut = open_skel.maps_mut().mymap();
+            let _open_prog_mut = open_skel.progs_mut().this_is_my_prog();
+
 
             let mut skel = open_skel
                 .load()
@@ -700,6 +703,8 @@ fn test_skeleton_builder_basic() {
             // Check that we can grab handles to loaded maps/progs
             let _map = skel.maps().mymap();
             let _prog = skel.progs().this_is_my_prog();
+            let _map_mut = skel.maps_mut().mymap();
+            let _prog_mut = skel.progs_mut().this_is_my_prog();
 
             // Check that attach() is generated
             skel.attach().expect("failed to attach progs");

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -476,6 +476,8 @@ fn test_skeleton_basic() {
             // Check that we can grab handles to open maps/progs
             let _open_map = open_skel.maps().mymap();
             let _open_prog = open_skel.progs().this_is_my_prog();
+            let _open_map_mut = open_skel.maps_mut().mymap();
+            let _open_prog_mut = open_skel.progs_mut().this_is_my_prog();
 
             let mut skel = open_skel
                 .load()
@@ -484,6 +486,8 @@ fn test_skeleton_basic() {
             // Check that we can grab handles to loaded maps/progs
             let _map = skel.maps().mymap();
             let _prog = skel.progs().this_is_my_prog();
+            let _map_mut = skel.maps_mut().mymap();
+            let _prog_mut = skel.progs_mut().this_is_my_prog();
 
             // Check that attach() is generated
             skel.attach().expect("failed to attach progs");

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -239,16 +239,6 @@ impl OpenObject {
         self.maps.get_mut(name.as_ref())
     }
 
-    /// Same as [`OpenObject::map`] except will panic if `Err` or `None` is encountered.
-    pub fn map_unwrap<T: AsRef<str>>(&self, name: T) -> &OpenMap {
-        self.map(name).unwrap()
-    }
-
-    /// Same as [`OpenObject::map_mut`] except will panic if `Err` or `None` is encountered.
-    pub fn map_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut OpenMap {
-        self.map_mut(name).unwrap()
-    }
-
     /// Get an iterator over references to all `OpenMap`s.
     /// Note that this will include automatically generated .data, .rodata, .bss, and
     /// .kconfig maps.
@@ -271,16 +261,6 @@ impl OpenObject {
     /// Get a mutable reference to `OpenProgram` with the name `name`, if one exists.
     pub fn prog_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut OpenProgram> {
         self.progs.get_mut(name.as_ref())
-    }
-
-    /// Same as [`OpenObject::prog`] except will panic if `Err` or `None` is encountered.
-    pub fn prog_unwrap<T: AsRef<str>>(&self, name: T) -> &OpenProgram {
-        self.prog(name).unwrap()
-    }
-
-    /// Same as [`OpenObject::prog_mut`] except will panic if `Err` or `None` is encountered.
-    pub fn prog_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut OpenProgram {
-        self.prog_mut(name).unwrap()
     }
 
     /// Get an iterator over references to all `OpenProgram`s.
@@ -432,16 +412,6 @@ impl Object {
         self.maps.get_mut(name.as_ref())
     }
 
-    /// Same as [`Object::map`] except will panic if `Err` or `None` is encountered.
-    pub fn map_unwrap<T: AsRef<str>>(&self, name: T) -> &Map {
-        self.map(name).unwrap()
-    }
-
-    /// Same as [`Object::map_mut`] except will panic if `Err` or `None` is encountered.
-    pub fn map_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut Map {
-        self.map_mut(name).unwrap()
-    }
-
     /// Get an iterator over references to all `Map`s.
     /// Note that this will include automatically generated .data, .rodata, .bss, and
     /// .kconfig maps. You may wish to filter this.
@@ -464,16 +434,6 @@ impl Object {
     /// Get a mutable reference to `Program` with the name `name`, if one exists.
     pub fn prog_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut Program> {
         self.progs.get_mut(name.as_ref())
-    }
-
-    /// Same as [`Object::prog`] except will panic if `Err` or `None` is encountered.
-    pub fn prog_unwrap<T: AsRef<str>>(&self, name: T) -> &Program {
-        self.prog(name).unwrap()
-    }
-
-    /// Same as [`Object::prog_mut`] except will panic if `Err` or `None` is encountered.
-    pub fn prog_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut Program {
-        self.prog_mut(name).unwrap()
     }
 
     /// Get an iterator over references to all `Program`s.

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -229,35 +229,67 @@ impl OpenObject {
         }
     }
 
+    /// Get a reference to `OpenMap` with the name `name`, if one exists.
+    pub fn map<T: AsRef<str>>(&self, name: T) -> Option<&OpenMap> {
+        self.maps.get(name.as_ref())
+    }
+
     /// Get a mutable reference to `OpenMap` with the name `name`, if one exists.
-    pub fn map<T: AsRef<str>>(&mut self, name: T) -> Option<&mut OpenMap> {
+    pub fn map_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut OpenMap> {
         self.maps.get_mut(name.as_ref())
     }
 
     /// Same as [`OpenObject::map`] except will panic if `Err` or `None` is encountered.
-    pub fn map_unwrap<T: AsRef<str>>(&mut self, name: T) -> &mut OpenMap {
+    pub fn map_unwrap<T: AsRef<str>>(&self, name: T) -> &OpenMap {
         self.map(name).unwrap()
+    }
+
+    /// Same as [`OpenObject::map_mut`] except will panic if `Err` or `None` is encountered.
+    pub fn map_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut OpenMap {
+        self.map_mut(name).unwrap()
     }
 
     /// Get an iterator over references to all `OpenMap`s.
     /// Note that this will include automatically generated .data, .rodata, .bss, and
     /// .kconfig maps.
-    pub fn maps_iter(&mut self) -> impl Iterator<Item = &mut OpenMap> {
+    pub fn maps_iter(&self) -> impl Iterator<Item = &OpenMap> {
+        self.maps.values()
+    }
+
+    /// Get an iterator over mutable references to all `OpenMap`s.
+    /// Note that this will include automatically generated .data, .rodata, .bss, and
+    /// .kconfig maps.
+    pub fn maps_iter_mut(&mut self) -> impl Iterator<Item = &mut OpenMap> {
         self.maps.values_mut()
     }
 
+    /// Get a reference to `OpenProgram` with the name `name`, if one exists.
+    pub fn prog<T: AsRef<str>>(&self, name: T) -> Option<&OpenProgram> {
+        self.progs.get(name.as_ref())
+    }
+
     /// Get a mutable reference to `OpenProgram` with the name `name`, if one exists.
-    pub fn prog<T: AsRef<str>>(&mut self, name: T) -> Option<&mut OpenProgram> {
+    pub fn prog_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut OpenProgram> {
         self.progs.get_mut(name.as_ref())
     }
 
     /// Same as [`OpenObject::prog`] except will panic if `Err` or `None` is encountered.
-    pub fn prog_unwrap<T: AsRef<str>>(&mut self, name: T) -> &mut OpenProgram {
+    pub fn prog_unwrap<T: AsRef<str>>(&self, name: T) -> &OpenProgram {
         self.prog(name).unwrap()
     }
 
+    /// Same as [`OpenObject::prog_mut`] except will panic if `Err` or `None` is encountered.
+    pub fn prog_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut OpenProgram {
+        self.prog_mut(name).unwrap()
+    }
+
     /// Get an iterator over references to all `OpenProgram`s.
-    pub fn progs_iter(&mut self) -> impl Iterator<Item = &mut OpenProgram> {
+    pub fn progs_iter(&self) -> impl Iterator<Item = &OpenProgram> {
+        self.progs.values()
+    }
+
+    /// Get an iterator over mutable references to all `OpenProgram`s.
+    pub fn progs_iter_mut(&mut self) -> impl Iterator<Item = &mut OpenProgram> {
         self.progs.values_mut()
     }
 
@@ -390,35 +422,67 @@ impl Object {
         Self::new(ptr)
     }
 
+    /// Get a reference to `Map` with the name `name`, if one exists.
+    pub fn map<T: AsRef<str>>(&self, name: T) -> Option<&Map> {
+        self.maps.get(name.as_ref())
+    }
+
     /// Get a mutable reference to `Map` with the name `name`, if one exists.
-    pub fn map<T: AsRef<str>>(&mut self, name: T) -> Option<&mut Map> {
+    pub fn map_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut Map> {
         self.maps.get_mut(name.as_ref())
+    }
+
+    /// Same as [`Object::map`] except will panic if `Err` or `None` is encountered.
+    pub fn map_unwrap<T: AsRef<str>>(&self, name: T) -> &Map {
+        self.map(name).unwrap()
+    }
+
+    /// Same as [`Object::map_mut`] except will panic if `Err` or `None` is encountered.
+    pub fn map_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut Map {
+        self.map_mut(name).unwrap()
     }
 
     /// Get an iterator over references to all `Map`s.
     /// Note that this will include automatically generated .data, .rodata, .bss, and
-    /// .kconfig maps. You may wish to filter these out depending on your use case.
-    pub fn maps_iter(&mut self) -> impl Iterator<Item = &mut Map> {
+    /// .kconfig maps. You may wish to filter this.
+    pub fn maps_iter(&self) -> impl Iterator<Item = &Map> {
+        self.maps.values()
+    }
+
+    /// Get an iterator over mutable references to all `Map`s.
+    /// Note that this will include automatically generated .data, .rodata, .bss, and
+    /// .kconfig maps. You may wish to filter this.
+    pub fn maps_iter_mut(&mut self) -> impl Iterator<Item = &mut Map> {
         self.maps.values_mut()
     }
 
-    /// Same as [`Object::map`] except will panic if `None` is encountered.
-    pub fn map_unwrap<T: AsRef<str>>(&mut self, name: T) -> &mut Map {
-        self.map(name).unwrap()
+    /// Get a reference to `Program` with the name `name`, if one exists.
+    pub fn prog<T: AsRef<str>>(&self, name: T) -> Option<&Program> {
+        self.progs.get(name.as_ref())
     }
 
     /// Get a mutable reference to `Program` with the name `name`, if one exists.
-    pub fn prog<T: AsRef<str>>(&mut self, name: T) -> Option<&mut Program> {
+    pub fn prog_mut<T: AsRef<str>>(&mut self, name: T) -> Option<&mut Program> {
         self.progs.get_mut(name.as_ref())
     }
 
-    /// Same as [`Object::prog`] except will panic if `None` is encountered.
-    pub fn prog_unwrap<T: AsRef<str>>(&mut self, name: T) -> &mut Program {
+    /// Same as [`Object::prog`] except will panic if `Err` or `None` is encountered.
+    pub fn prog_unwrap<T: AsRef<str>>(&self, name: T) -> &Program {
         self.prog(name).unwrap()
     }
 
+    /// Same as [`Object::prog_mut`] except will panic if `Err` or `None` is encountered.
+    pub fn prog_unwrap_mut<T: AsRef<str>>(&mut self, name: T) -> &mut Program {
+        self.prog_mut(name).unwrap()
+    }
+
     /// Get an iterator over references to all `Program`s.
-    pub fn progs_iter(&mut self) -> impl Iterator<Item = &mut Program> {
+    pub fn progs_iter(&self) -> impl Iterator<Item = &Program> {
+        self.progs.values()
+    }
+
+    /// Get an iterator over mutable references to all `Program`s.
+    pub fn progs_iter_mut(&mut self) -> impl Iterator<Item = &mut Program> {
         self.progs.values_mut()
     }
 }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -84,7 +84,7 @@ fn test_object_name() {
 fn test_object_maps() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     obj.map("start").expect("failed to find map");
     obj.map("events").expect("failed to find map");
     assert!(obj.map("asdf").is_none());
@@ -94,7 +94,7 @@ fn test_object_maps() {
 fn test_object_maps_iter() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     for map in obj.maps_iter() {
         eprintln!("{}", map.name());
     }
@@ -107,7 +107,7 @@ fn test_object_map_key_value_size() {
     bump_rlimit_mlock();
 
     let mut obj = get_test_object("runqslower.bpf.o");
-    let start = obj.map("start").expect("failed to find map");
+    let start = obj.map_mut("start").expect("failed to find map");
 
     assert!(start.lookup(&[1, 2, 3, 4, 5], MapFlags::empty()).is_err());
     assert!(start.delete(&[1]).is_err());
@@ -121,7 +121,7 @@ fn test_object_map_key_value_size() {
 fn test_object_map_empty_lookup() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     let start = obj.map("start").expect("failed to find map");
 
     assert!(start
@@ -135,7 +135,7 @@ fn test_object_map_mutation() {
     bump_rlimit_mlock();
 
     let mut obj = get_test_object("runqslower.bpf.o");
-    let start = obj.map("start").expect("failed to find map");
+    let start = obj.map_mut("start").expect("failed to find map");
 
     start
         .update(&[1, 2, 3, 4], &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::empty())
@@ -160,7 +160,7 @@ fn test_object_map_lookup_flags() {
     bump_rlimit_mlock();
 
     let mut obj = get_test_object("runqslower.bpf.o");
-    let start = obj.map("start").expect("failed to find map");
+    let start = obj.map_mut("start").expect("failed to find map");
 
     start
         .update(&[1, 2, 3, 4], &[1, 2, 3, 4, 5, 6, 7, 8], MapFlags::NO_EXIST)
@@ -176,7 +176,7 @@ fn test_object_map_key_iter() {
 
     let mut obj = get_test_object("runqslower.bpf.o");
 
-    let start = obj.map("start").expect("failed to find map");
+    let start = obj.map_mut("start").expect("failed to find map");
 
     let key1 = vec![1, 2, 3, 4];
     let key2 = vec![1, 2, 3, 5];
@@ -206,7 +206,7 @@ fn test_object_map_key_iter() {
 fn test_object_map_key_iter_empty() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     let start = obj.map("start").expect("failed to find map");
 
     let mut count = 0;
@@ -221,7 +221,7 @@ fn test_object_map_pin() {
     bump_rlimit_mlock();
 
     let mut obj = get_test_object("runqslower.bpf.o");
-    let map = obj.map("start").expect("failed to find map");
+    let map = obj.map_mut("start").expect("failed to find map");
 
     let path = "/sys/fs/bpf/mymap";
 
@@ -240,7 +240,7 @@ fn test_object_map_pin() {
 fn test_object_programs() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     obj.prog("handle__sched_wakeup")
         .expect("failed to find program");
     obj.prog("handle__sched_wakeup_new")
@@ -254,7 +254,7 @@ fn test_object_programs() {
 fn test_object_programs_iter_mut() {
     bump_rlimit_mlock();
 
-    let mut obj = get_test_object("runqslower.bpf.o");
+    let obj = get_test_object("runqslower.bpf.o");
     assert!(obj.progs_iter().count() == 3);
 }
 
@@ -264,7 +264,7 @@ fn test_object_program_pin() {
 
     let mut obj = get_test_object("runqslower.bpf.o");
     let prog = obj
-        .prog("handle__sched_wakeup")
+        .prog_mut("handle__sched_wakeup")
         .expect("failed to find program");
 
     let path = "/sys/fs/bpf/myprog";
@@ -293,7 +293,7 @@ fn test_object_link_pin() {
 
     let mut obj = get_test_object("runqslower.bpf.o");
     let prog = obj
-        .prog("handle__sched_wakeup")
+        .prog_mut("handle__sched_wakeup")
         .expect("failed to find program");
     let mut link = prog.attach().expect("failed to attach prog");
 
@@ -328,7 +328,7 @@ fn test_object_reuse_pined_map() {
     // Pin a map
     {
         let mut obj = get_test_object("runqslower.bpf.o");
-        let map = obj.map("start").expect("failed to find map");
+        let map = obj.map_mut("start").expect("failed to find map");
 
         map.update(&key, &val, MapFlags::empty())
             .expect("failed to write");
@@ -349,12 +349,12 @@ fn test_object_reuse_pined_map() {
     builder.debug(true);
     let mut open_obj = builder.open_file(obj_path).expect("failed to open object");
 
-    let start = open_obj.map("start").expect("failed to find map");
+    let start = open_obj.map_mut("start").expect("failed to find map");
     assert!(start.reuse_pinned_map("/asdf").is_err());
     start.reuse_pinned_map(path).expect("failed to reuse map");
 
     let mut obj = open_obj.load().expect("Failed to load object");
-    let reused_map = obj.map("start").expect("failed to find map");
+    let reused_map = obj.map_mut("start").expect("failed to find map");
 
     let found_val = reused_map
         .lookup(&key, MapFlags::empty())
@@ -373,7 +373,7 @@ fn test_object_ringbuf() {
 
     let mut obj = get_test_object("ringbuf.bpf.o");
     let prog = obj
-        .prog("handle__sys_enter_getpid")
+        .prog_mut("handle__sys_enter_getpid")
         .expect("failed to find program");
     let _link = prog.attach().expect("failed to attach prog");
 
@@ -457,7 +457,7 @@ fn test_object_ringbuf_closure() {
 
     let mut obj = get_test_object("ringbuf.bpf.o");
     let prog = obj
-        .prog("handle__sys_enter_getpid")
+        .prog_mut("handle__sys_enter_getpid")
         .expect("failed to find program");
     let _link = prog.attach().expect("failed to attach prog");
 
@@ -522,7 +522,7 @@ fn test_object_task_iter() {
     bump_rlimit_mlock();
 
     let mut obj = get_test_object("taskiter.bpf.o");
-    let prog = obj.prog("dump_pid").expect("Failed to find program");
+    let prog = obj.prog_mut("dump_pid").expect("Failed to find program");
     let link = prog.attach().expect("Failed to attach prog");
     let mut iter = Iter::new(&link).expect("Failed to create iterator");
 


### PR DESCRIPTION
This is a draft proposal to refactor existing Object and OpenObject getters into mutable and immutable variants. It is based on top of my PR for maps and program iterators and should not be landed until that is merged. Existing getters are renamed with the `_mut` suffix and new getters are created for the immutable variants, using the original names. For now, libbpf-cargo/gen.rs has been changed to emit `xxx_unwrap_mut()` instead of `xxx_unwrap()`.

I have a couple of points that I'd like to discuss before making any further progress on this.

1. We should probably add mutable/immutable variants to the generated skeleton in addition to Object and OpenObject.
    - As I see it, this could be done in one of two ways. Either add an extra struct like MapsMut that would be accessed using something like `maps_mut()` or add additional getters to Maps with the `_mut` suffix.
2. Perhaps it's also worth adding `xxx_iter()` and `xxx_iter_mut()` to the skeleton as a thin wrapper around the methods exposed by Object and OpenObject.
3. Is it even worth keeping the `xxx_unwrap()` convenience functions? Since the getters now only return an `Option<T>` instead of a `Result<Option<T>>`, it may make more sense to just have the consumer of the API call unwrap manually.

Let me know if there's anything I missed/overlooked here.
