### PR TITLE
runqslower: Place generated skeleton in .output directory

### DIFF
--- a/examples/runqslower/.gitignore
+++ b/examples/runqslower/.gitignore
@@ -1,1 +1,1 @@
-src/bpf/mod.rs
+src/bpf/.output

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,3 +1,4 @@
+use std::fs::create_dir_all;
 use std::path::Path;
 
 use libbpf_cargo::SkeletonBuilder;
@@ -13,7 +14,8 @@ fn main() {
     //
     // However, there is hope! When the above feature stabilizes we can clean this
     // all up.
-    let skel = Path::new("./src/bpf/mod.rs");
+    create_dir_all("./src/bpf/.output").unwrap();
+    let skel = Path::new("./src/bpf/.output/runqslower.skel.rs");
     SkeletonBuilder::new(SRC).generate(&skel).unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -8,8 +8,9 @@ use libbpf_rs::PerfBufferBuilder;
 use plain::Plain;
 use structopt::StructOpt;
 
-mod bpf;
-use bpf::*;
+#[path = "bpf/.output/runqslower.skel.rs"]
+mod runqslower;
+use runqslower::*;
 
 /// Trace high run queue latency
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
In line with how libbpf-bootstrap and libbpf-tools does it.