### PR TITLE
libbpf-rs/program.rs: Fix lifetime issue with CString pointers

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -235,13 +235,14 @@ impl Program {
         binary_path: T,
         func_offset: usize,
     ) -> Result<Link> {
-        let path = util::path_to_cstring(binary_path.as_ref())?.as_ptr();
+        let path = util::path_to_cstring(binary_path.as_ref())?;
+        let path_ptr = path.as_ptr();
         let ptr = unsafe {
             libbpf_sys::bpf_program__attach_uprobe(
                 self.ptr,
                 retprobe,
                 pid,
-                path,
+                path_ptr,
                 func_offset as libbpf_sys::size_t,
             )
         };
@@ -256,8 +257,10 @@ impl Program {
     /// Attach this program to a [kernel
     /// probe](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html).
     pub fn attach_kprobe<T: AsRef<str>>(&mut self, retprobe: bool, func_name: T) -> Result<Link> {
-        let func_name = util::str_to_cstring(func_name.as_ref())?.as_ptr();
-        let ptr = unsafe { libbpf_sys::bpf_program__attach_kprobe(self.ptr, retprobe, func_name) };
+        let func_name = util::str_to_cstring(func_name.as_ref())?;
+        let func_name_ptr = func_name.as_ptr();
+        let ptr =
+            unsafe { libbpf_sys::bpf_program__attach_kprobe(self.ptr, retprobe, func_name_ptr) };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {
             Err(Error::System(err as i32))
@@ -269,10 +272,13 @@ impl Program {
     /// Attach this program to a [kernel
     /// tracepoint](https://www.kernel.org/doc/html/latest/trace/tracepoints.html).
     pub fn attach_tracepoint<T: AsRef<str>>(&mut self, tp_category: T, tp_name: T) -> Result<Link> {
-        let tp_category = util::str_to_cstring(tp_category.as_ref())?.as_ptr();
-        let tp_name = util::str_to_cstring(tp_name.as_ref())?.as_ptr();
-        let ptr =
-            unsafe { libbpf_sys::bpf_program__attach_tracepoint(self.ptr, tp_category, tp_name) };
+        let tp_category = util::str_to_cstring(tp_category.as_ref())?;
+        let tp_category_ptr = tp_category.as_ptr();
+        let tp_name = util::str_to_cstring(tp_name.as_ref())?;
+        let tp_name_ptr = tp_name.as_ptr();
+        let ptr = unsafe {
+            libbpf_sys::bpf_program__attach_tracepoint(self.ptr, tp_category_ptr, tp_name_ptr)
+        };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {
             Err(Error::System(err as i32))
@@ -284,8 +290,9 @@ impl Program {
     /// Attach this program to a [raw kernel
     /// tracepoint](https://lwn.net/Articles/748352/).
     pub fn attach_raw_tracepoint<T: AsRef<str>>(&mut self, tp_name: T) -> Result<Link> {
-        let tp_name = util::str_to_cstring(tp_name.as_ref())?.as_ptr();
-        let ptr = unsafe { libbpf_sys::bpf_program__attach_raw_tracepoint(self.ptr, tp_name) };
+        let tp_name = util::str_to_cstring(tp_name.as_ref())?;
+        let tp_name_ptr = tp_name.as_ptr();
+        let ptr = unsafe { libbpf_sys::bpf_program__attach_raw_tracepoint(self.ptr, tp_name_ptr) };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {
             Err(Error::System(err as i32))


### PR DESCRIPTION
My original CStrings fix had a really bad lifetime issue that caused a use-after-free error.
The details are outlined here: https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr
Update affected functions to store the CString and raw pointer as separate bindings to prevent the early free.