### PR TITLE
[libbpf-cargo] Add an impl Default for enums

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -445,6 +445,12 @@ impl<'a> Btf<'a> {
                     }
 
                     writeln!(def, "}}")?;
+
+                    writeln!(def, r#"impl Default for {name} {{"#, name = t.name)?;
+                    writeln!(def, r#"    fn default() -> Self {{"#)?;
+                    writeln!(def, r#"        {name}::{value}"#, name = t.name, value = t.values[0].name)?;
+                    writeln!(def, r#"    }}"#)?;
+                    writeln!(def, r#"}}"#)?;
                 }
                 BtfType::Datasec(t) => {
                     let mut sec_name = t.name.to_string();

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -446,11 +446,19 @@ impl<'a> Btf<'a> {
 
                     writeln!(def, "}}")?;
 
-                    writeln!(def, r#"impl Default for {name} {{"#, name = t.name)?;
-                    writeln!(def, r#"    fn default() -> Self {{"#)?;
-                    writeln!(def, r#"        {name}::{value}"#, name = t.name, value = t.values[0].name)?;
-                    writeln!(def, r#"    }}"#)?;
-                    writeln!(def, r#"}}"#)?;
+                    // write an impl Default for this enum
+                    if t.values.len() > 0 {
+                        writeln!(def, r#"impl Default for {name} {{"#, name = t.name)?;
+                        writeln!(def, r#"    fn default() -> Self {{"#)?;
+                        writeln!(
+                            def,
+                            r#"        {name}::{value}"#,
+                            name = t.name,
+                            value = t.values[0].name
+                        )?;
+                        writeln!(def, r#"    }}"#)?;
+                        writeln!(def, r#"}}"#)?;
+                    }
                 }
                 BtfType::Datasec(t) => {
                     let mut sec_name = t.name.to_string();

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1189,6 +1189,11 @@ pub enum Foo {
     One = 1,
     seven = 7,
 }
+impl Default for Foo {
+    fn default() -> Self {
+        Foo::Zero
+    }
+}
 "#;
     assert_eq!(
         foo_defn,
@@ -1974,6 +1979,11 @@ pub struct Foo {
 #[repr(u32)]
 pub enum __anon_1 {
     FOO = 1,
+}
+impl Default for __anon_1 {
+    fn default() -> Self {
+        __anon_1::FOO
+    }
 }
 "#;
     assert_eq!(


### PR DESCRIPTION
Compilation breaks when enums are used in structures.  Enums cannot be #[derive(Default)], so in order to conform to using Defaults with structures we must impl default for Enums.

Advanced Rust style enums (enums that act as unions, or hold different types) have not been considered as C-BPF will not use these advanced Rust style enums.

Alternate implementation to this is to force the programmer to impl Default themselves.  This gives a bad experience when using libbpf-cargo+libbpf-rs as compilation will break if using something like cargo libbpf make, and the impl Default must constantly be edited whenever the C-BPF enum is changed.

Default value used is the first value within the enum.