### PR TITLE
libbpf-cargo: Fix compilation on non-x86_64 archs

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use std::ffi::{c_void, CStr, CString};
 use std::fmt::Write;
 use std::mem::size_of;
+use std::os::raw::{c_char, c_ulong};
 use std::slice;
 
 use anyhow::{bail, ensure, Result};
@@ -33,7 +34,7 @@ impl<'a> Btf<'a> {
         let bpf_obj = unsafe {
             libbpf_sys::bpf_object__open_mem(
                 object_file.as_ptr() as *const c_void,
-                object_file.len() as u64,
+                object_file.len() as c_ulong,
                 &obj_opts,
             )
         };
@@ -859,7 +860,8 @@ impl<'a> Btf<'a> {
     }
 
     fn get_btf_str(&self, offset: usize) -> Result<&'a str> {
-        let c_str = unsafe { CStr::from_ptr(&self.string_table[offset] as *const u8 as *const i8) };
+        let c_str =
+            unsafe { CStr::from_ptr(&self.string_table[offset] as *const u8 as *const c_char) };
         Ok(c_str.to_str()?)
     }
 }

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -4,6 +4,7 @@ use std::ffi::{c_void, CStr, CString};
 use std::fmt::Write as fmt_write;
 use std::fs::File;
 use std::io::Write;
+use std::os::raw::c_ulong;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::ptr;
@@ -586,7 +587,7 @@ fn open_bpf_object(name: &str, data: &[u8]) -> Result<*mut libbpf_sys::bpf_objec
     let object = unsafe {
         libbpf_sys::bpf_object__open_mem(
             data.as_ptr() as *const c_void,
-            data.len() as u64,
+            data.len() as c_ulong,
             &obj_opts,
         )
     };


### PR DESCRIPTION
libbpf-cargo was making assumptions about the width of c_ulong and signedness of c_char in some places. This was causing compilation to fail on some other archs. Fixes #108 