### PR TITLE
Lookup all values for per-cpu maps 

### DIFF
--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -27,3 +27,8 @@ pub fn c_ptr_to_string(p: *const c_char) -> Result<String> {
         .map_err(|e| Error::Internal(e.to_string()))?
         .to_owned())
 }
+
+/// Round up a number to the next multiple of `r`
+pub fn roundup(num: usize, r: usize) -> usize {
+    ((num + (r - 1)) / r) * r
+}


### PR DESCRIPTION
A successful lookup of a key in a per-cpu map does not return just one value but one value per CPU. These values written to the buffer aligned to 8 bytes. 

Currently, the `Vec` returned by `lookup` would just contain the first value. In addition, libbpf would write to memory areas outside the allocated buffer. This may cause crashes.

This PR makes `lookup` return a `Vec` with all values and proper alignment when called on per-cpu maps. 