### PR TITLE
libbpf-cargo: Switch memmap dependency to memmap2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "cargo_metadata",
  "goblin",
  "libbpf-sys",
- "memmap",
+ "memmap2",
  "num_enum",
  "regex",
  "scroll",
@@ -249,13 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "20ff203f7bdc401350b1dbaa0355135777d25f41c0bbc601851bbd6cf61e8ff5"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -27,7 +27,6 @@ path = "src/lib.rs"
 anyhow = "1.0"
 cargo_metadata = "0.12"
 libbpf-sys = { version = "0.4.0-1" }
-memmap = "0.7"
 num_enum = "0.5"
 regex = "1.4"
 scroll = "0.10"
@@ -38,6 +37,7 @@ structopt = "0.3"
 semver = "0.9"
 tempfile = "3.1"
 thiserror = "1.0"
+memmap2 = "0.3.0"
 
 [dev-dependencies]
 goblin = "0.2"

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -10,7 +10,7 @@ use std::process::{Command, Stdio};
 use std::ptr;
 
 use anyhow::{bail, ensure, Context, Result};
-use memmap::Mmap;
+use memmap2::Mmap;
 
 use crate::btf;
 use crate::metadata;

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use goblin::Object;
-use memmap::Mmap;
+use memmap2::Mmap;
 use tempfile::{tempdir, NamedTempFile, TempDir};
 
 use crate::btf;


### PR DESCRIPTION
According to [this security advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077), the `memmap` crate is no longer maintained and should be replaced with the `memmap2` fork. This causes `cargo audit` to fail on any project that depends on `libbpf-cargo`. This PR simply replaces `memmap` with `memmap2`.

As an aside, I would like to propose adding `cargo audit` and `cargo clippy` to the CI workflow to reduce the risk of vulnerable dependencies and enforce good code hygiene. Any thoughts? I can file a separate PR for this if you're interested.