### PR TITLE
Bump strum_macros to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.18.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "1.2"
 libbpf-sys = { version = "0.4.0-1" }
 nix = "0.17"
 num_enum = "0.5"
-strum_macros = "0.18"
+strum_macros = "0.21"
 vsprintf = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Hi,

I'd like to update strum_macros to 0.21, as we strive to keep package in sync to the latest version during Fedora Rust packaging.