### PR TITLE
Add a Debug impl for all union types

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -488,7 +488,6 @@ impl<'a> Btf<'a> {
                     writeln!(def, "}}")?;
 
                     // if required write a Default implementation for this struct
-                    #[rustfmt::skip]
                     if gen_impl_default {
                         writeln!(def, r#"impl Default for {} {{"#, t.name)?;
                         writeln!(def, r#"    fn default() -> Self {{"#)?;
@@ -502,7 +501,10 @@ impl<'a> Btf<'a> {
                     } else if !t.is_struct {
                         // write a Debug implementation for a union
                         writeln!(def, r#"impl std::fmt::Debug for {} {{"#, t.name)?;
-                        writeln!(def, r#"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"#)?;
+                        writeln!(
+                            def,
+                            r#"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"#
+                        )?;
                         writeln!(def, r#"        write!(f, "unimplemented debug for union")"#)?;
                         writeln!(def, r#"    }}"#)?;
                         writeln!(def, r#"}}"#)?;

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -505,7 +505,7 @@ impl<'a> Btf<'a> {
                             def,
                             r#"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"#
                         )?;
-                        writeln!(def, r#"        write!(f, "unimplemented debug for union")"#)?;
+                        writeln!(def, r#"        write!(f, "(???)")"#)?;
                         writeln!(def, r#"    }}"#)?;
                         writeln!(def, r#"}}"#)?;
                     }

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -488,6 +488,7 @@ impl<'a> Btf<'a> {
                     writeln!(def, "}}")?;
 
                     // if required write a Default implementation for this struct
+                    #[rustfmt::skip]
                     if gen_impl_default {
                         writeln!(def, r#"impl Default for {} {{"#, t.name)?;
                         writeln!(def, r#"    fn default() -> Self {{"#)?;

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -465,8 +465,10 @@ impl<'a> Btf<'a> {
 
                     if !gen_impl_default && t.is_struct {
                         writeln!(def, r#"#[derive(Debug, Default, Copy, Clone)]"#)?;
-                    } else {
+                    } else if t.is_struct {
                         writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
+                    } else {
+                        writeln!(def, r#"#[derive(Copy, Clone)]"#)?;
                     }
 
                     let aggregate_type = if t.is_struct { "struct" } else { "union" };
@@ -494,6 +496,13 @@ impl<'a> Btf<'a> {
                             writeln!(def, r#"{},"#, impl_def)?;
                         }
                         writeln!(def, r#"        }}"#)?;
+                        writeln!(def, r#"    }}"#)?;
+                        writeln!(def, r#"}}"#)?;
+                    } else if !t.is_struct {
+                        // write a Debug implementation for a union
+                        writeln!(def, r#"impl std::fmt::Debug for {} {{"#, t.name)?;
+                        writeln!(def, r#"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"#)?;
+                        writeln!(def, r#"        write!(f, "unimplemented debug for union")"#)?;
                         writeln!(def, r#"    }}"#)?;
                         writeln!(def, r#"}}"#)?;
                     }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1293,7 +1293,7 @@ pub union Foo {
 }
 impl std::fmt::Debug for Foo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 "#;
@@ -1620,7 +1620,7 @@ pub union __anon_1 {
 }
 impl std::fmt::Debug for __anon_1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 #[derive(Copy, Clone)]
@@ -1631,7 +1631,7 @@ pub union __anon_2 {
 }
 impl std::fmt::Debug for __anon_2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 "#;
@@ -1754,7 +1754,7 @@ pub union __anon_2 {
 }
 impl std::fmt::Debug for __anon_2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 #[derive(Debug, Default, Copy, Clone)]
@@ -1772,7 +1772,7 @@ pub union __anon_4 {
 }
 impl std::fmt::Debug for __anon_4 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 "#;
@@ -1840,7 +1840,7 @@ pub union __anon_2 {
 }
 impl std::fmt::Debug for __anon_2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 #[derive(Debug, Default, Copy, Clone)]
@@ -1858,7 +1858,7 @@ pub union __anon_4 {
 }
 impl std::fmt::Debug for __anon_4 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unimplemented debug for union")
+        write!(f, "(???)")
     }
 }
 "#;

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -902,6 +902,15 @@ fn assert_definition(btf: &Btf, btf_item: u32, expected_output: &str) {
     let ao = actual_output.trim_end().trim_start();
     let eo = expected_output.trim_end().trim_start();
 
+    println!("---------------");
+    println!("expected output");
+    println!("---------------");
+    println!("{}", eo);
+    println!("-------------");
+    println!("actual output");
+    println!("-------------");
+    println!("{}", ao);
+
     assert_eq!(eo, ao);
 }
 
@@ -1275,12 +1284,17 @@ union Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union Foo {
     pub x: i32,
     pub y: u32,
     pub z: [i8; 128],
+}
+impl std::fmt::Debug for Foo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
 }
 "#;
 
@@ -1598,17 +1612,27 @@ pub struct Foo {
     pub baz: __anon_2,
     pub w: i32,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
-#[derive(Debug, Copy, Clone)]
+impl std::fmt::Debug for __anon_1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
+}
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_2 {
     pub w: u32,
     pub u: *mut u64,
+}
+impl std::fmt::Debug for __anon_2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
 }
 "#;
 
@@ -1722,11 +1746,16 @@ pub struct __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_2 {
     pub a: *mut i8,
     pub b: i32,
+}
+impl std::fmt::Debug for __anon_2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
@@ -1735,11 +1764,16 @@ pub struct __anon_3 {
     __pad_4: [u8; 4],
     pub u: *mut u64,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_4 {
     pub c: u8,
     pub d: [u64; 5],
+}
+impl std::fmt::Debug for __anon_4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
 }
 "#;
 
@@ -1798,11 +1832,16 @@ pub struct __anon_1 {
     pub y: [u8; 10],
     pub z: [u16; 16],
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_2 {
     pub a: *mut i8,
     pub b: i32,
+}
+impl std::fmt::Debug for __anon_2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
@@ -1811,12 +1850,18 @@ pub struct __anon_3 {
     __pad_4: [u8; 4],
     pub u: *mut u64,
 }
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub union __anon_4 {
     pub c: u8,
     pub d: [u64; 5],
-}"#;
+}
+impl std::fmt::Debug for __anon_4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unimplemented debug for union")
+    }
+}
+"#;
     let btf = build_btf_prog(prog_text);
 
     let struct_foo = find_type_in_btf!(btf, Struct, "Foo");


### PR DESCRIPTION
Fix for 
https://github.com/libbpf/libbpf-rs/issues/119

Rust cannot #[derive(Debug)] for unions.  Structures must have Debuggable unions in order to #[derive(Debug)] for them.

To solve issue #119 we must either remove all #[derive(Debug)] or impl Debug for unions.  This PR suggests doing the latter.