### PR TITLE
Use proper iterator on libbpf-cargo build

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -51,7 +51,7 @@ fn extract_libbpf_headers_to_disk() -> Result<TempDir> {
     let tempdir = TempDir::new()?;
     let dir = tempdir.path().join("bpf");
     fs::create_dir_all(&dir)?;
-    for (filename, contents) in libbpf_sys::API_HEADERS {
+    for (filename, contents) in libbpf_sys::API_HEADERS.iter() {
         let path = dir.as_path().join(filename);
         let mut file = OpenOptions::new().write(true).create(true).open(path)?;
         file.write_all(contents.as_bytes())?;


### PR DESCRIPTION
I couldn't get all the tests to pass, but I think this should fix some issues:

Truncated `cargo test`:
```
running 20 tests
test test_object_build_from_memory ... ok
test test_object_name ... ok
test test_object_ringbuf ... ok
test test_object_ringbuf_closure ... ok
test test_object_maps_iter ... ok
test test_object_programs_iter_mut ... ok
test test_object_map_mutation ... ok
test test_object_map_empty_lookup ... ok
test test_object_map_lookup_flags ... ok
test test_object_map_pin ... FAILED
test test_object_link_pin ... FAILED
test test_object_build_and_load ... ok
test test_object_map_key_iter_empty ... ok
test test_object_map_key_iter ... ok
test test_object_programs ... ok
test test_object_maps ... ok
test test_object_map_key_value_size ... ok
test test_object_reuse_pined_map ... FAILED
test test_object_program_pin ... FAILED
test test_object_task_iter ... ok
```

vs latest `cargo test`:

```
cargo test
   Compiling libbpf-cargo v0.7.2 (/home/daniel/git/libbpf-rs/libbpf-cargo)
   Compiling query v0.1.0 (/home/daniel/git/libbpf-rs/examples/query)
   Compiling libbpf-rs v0.11.1 (/home/daniel/git/libbpf-rs/libbpf-rs)
error[E0277]: `[(&str, &str); 10]` is not an iterator
  --> libbpf-cargo/src/build.rs:54:33
   |
54 |     for (filename, contents) in libbpf_sys::API_HEADERS {
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over i
t
   |
   = help: the trait `Iterator` is not implemented for `[(&str, &str); 10]`
   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
   = note: required because of the requirements on the impl of `IntoIterator` for `[(&str, &str); 10]`
   = note: required by `into_iter`

error[E0277]: `[(&str, &str); 10]` is not an iterator
  --> libbpf-cargo/src/build.rs:54:33
   |
54 |     for (filename, contents) in libbpf_sys::API_HEADERS {
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over i
t
   |
   = help: the trait `Iterator` is not implemented for `[(&str, &str); 10]`
   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
   = note: required because of the requirements on the impl of `IntoIterator` for `[(&str, &str); 10]`
   = note: required by `into_iter`

error: aborting due to previous error

```

Tested on:
```
Linux 5.13.0-rc6-x86_64
/usr/lib64/libbpf.so.0.3.0
```

Seems libbpf 0.4.0 also gives the same results:

```
     Running tests/test.rs (target/debug/deps/test-30fb5b13c8dfbf5a)

running 20 tests
test test_object_name ... ok
test test_object_build_from_memory ... ok
test test_object_ringbuf ... ok
test test_object_ringbuf_closure ... ok
test test_object_map_mutation ... ok
test test_object_programs_iter_mut ... ok
test test_object_maps ... ok
test test_object_map_lookup_flags ... ok
test test_object_build_and_load ... ok
test test_object_maps_iter ... ok
test test_object_link_pin ... FAILED
test test_object_programs ... ok
test test_object_map_pin ... FAILED
test test_object_map_empty_lookup ... ok
test test_object_map_key_value_size ... ok
test test_object_map_key_iter_empty ... ok
test test_object_map_key_iter ... ok
test test_object_reuse_pined_map ... FAILED
test test_object_program_pin ... FAILED
test test_object_task_iter ... ok
```
KCONFIG:
```
CONFIG_BPF=y
CONFIG_HAVE_EBPF_JIT=y
CONFIG_ARCH_WANT_DEFAULT_BPF_JIT=y
# BPF subsystem
CONFIG_BPF_SYSCALL=y
# CONFIG_BPF_JIT is not set
# CONFIG_BPF_UNPRIV_DEFAULT_OFF is not set
CONFIG_BPF_PRELOAD=y
CONFIG_BPF_PRELOAD_UMD=y
# end of BPF subsystem
CONFIG_CGROUP_BPF=y
CONFIG_IPV6_SEG6_BPF=y
CONFIG_NETFILTER_XT_MATCH_BPF=y
CONFIG_BPFILTER=y
CONFIG_BPFILTER_UMH=y
CONFIG_NET_CLS_BPF=y
CONFIG_NET_ACT_BPF=y
CONFIG_BPF_STREAM_PARSER=y
CONFIG_LWTUNNEL_BPF=y
CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
CONFIG_BPF_EVENTS=y
CONFIG_BPF_KPROBE_OVERRIDE=y
# CONFIG_TEST_BPF is not set
```