### PR TITLE
libbpf-rs, libbpf-cargo: Support novendor feature

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -23,6 +23,11 @@ path = "src/main.rs"
 [lib]
 path = "src/lib.rs"
 
+[features]
+# When turned on, link against system-installed libbpf instead of building
+# and linking against vendored libbpf sources
+novendor = ["libbpf-sys/novendor"]
+
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.12"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -13,6 +13,11 @@ keywords = ["bpf", "ebpf", "libbpf"]
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+# When turned on, link against system-installed libbpf instead of building
+# and linking against vendored libbpf sources
+novendor = ["libbpf-sys/novendor"]
+
 [dependencies]
 thiserror = "1.0"
 bitflags = "1.2"


### PR DESCRIPTION
Re-export libbpf-sys's novendor feature. When used turned on, libbpf-rs
and libbpf-cargo will avoid vendoring libbpf and instead use system
installed libbpf.