### PR TITLE
Prevent Rust Warnings

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -665,7 +665,9 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
 
            #![allow(dead_code)]
            #![allow(non_snake_case)]
+           #![allow(non_camel_case_types)]
            #![allow(clippy::transmute_ptr_to_ref)]
+           #![allow(clippy::upper_case_acronyms)]
 
            use libbpf_rs::libbpf_sys;
         "#


### PR DESCRIPTION
Prevent warnings in generated skeletons due to upper_case_acronyms or non_camel_case_types.

EG. The following enum will cause both warnings when compiling a generated skeleton (upper case is limited to clippy)
```
enum file_event_t {
    CREATE,
    CLOSE,
    DELETE,
    LINK,
};
```