### PR TITLE
libbpf-cargo: btf: Support bool type

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -197,10 +197,13 @@ impl<'a> Btf<'a> {
                     _ => bail!("Invalid integer width"),
                 };
 
-                if t.encoding == btf::BtfIntEncoding::Signed {
-                    format!("i{}", width)
-                } else {
-                    format!("u{}", width)
+                match t.encoding {
+                    btf::BtfIntEncoding::Signed => format!("i{}", width),
+                    btf::BtfIntEncoding::Bool => {
+                        assert!(t.bits as usize == (std::mem::size_of::<bool>() * 8));
+                        format!("bool")
+                    }
+                    btf::BtfIntEncoding::Char | btf::BtfIntEncoding::None => format!("u{}", width),
                 }
             }
             BtfType::Ptr(t) => {

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1844,3 +1844,39 @@ impl Default for __anon_1 {
 
     assert_definition(&btf, struct_foo, expected_output);
 }
+
+#[test]
+fn test_btf_dump_definition_int_encodings() {
+    let prog_text = r#"
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct Foo {
+    s32 a;
+    u16 b;
+    s16 c;
+    bool d;
+    char e;
+};
+struct Foo foo;
+"#;
+
+    let expected_output = r#"
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct Foo {
+    pub a: i32,
+    pub b: u16,
+    pub c: i16,
+    pub d: bool,
+    pub e: i8,
+}
+"#;
+
+    let btf = build_btf_prog(prog_text);
+
+    // Find the struct
+    let struct_foo = find_type_in_btf!(btf, Struct, "Foo");
+
+    assert_definition(&btf, struct_foo, expected_output);
+}


### PR DESCRIPTION
Before, forgot to check int encoding for bools. Rust bools appear to be
1 byte wide just like C bool.

This fixes #129.