### PR TITLE
libbpf-cargo: fix bpf code build on aarch64

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -111,10 +111,10 @@ fn check_clang(debug: bool, clang: &Path, skip_version_checks: bool) -> Result<(
 ///
 /// for each prog.
 fn compile_one(debug: bool, source: &Path, out: &Path, clang: &Path, options: &str) -> Result<()> {
-    let arch = if std::env::consts::ARCH == "x86_64" {
-        "x86"
-    } else {
-        std::env::consts::ARCH
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x86",
+        "aarch64" => "arm64",
+        _ => std::env::consts::ARCH,
     };
 
     if debug {


### PR DESCRIPTION
set __TARGET_ARCH_arm64.