### PR TITLE
Add fd to ProgramInfo

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -101,6 +101,7 @@ fn name_arr_to_string(a: &[c_char], default: &str) -> String {
 /// Information about a BPF program
 pub struct ProgramInfo {
     pub name: String,
+    pub fd: i32,
     pub ty: ProgramType,
     pub tag: [u8; 8],
     pub id: u32,
@@ -147,6 +148,7 @@ impl ProgramInfo {
 
         Some(ProgramInfo {
             name,
+            fd: _fd,
             ty,
             tag: s.tag,
             id: s.id,


### PR DESCRIPTION
A bpf program's fd can be useful to obtain relevant data such as memlock
(like how it's done in bpftool). This change allows users to obtain the fd of
a bpf program without making them resort to an unsafe call in libbpf-sys.

Signed-off-by: Milan <milan@mdaverde.com>

### Alternatives

Add fd to `Iterator::Item`. Instead of the iterator producing `ProgramInfo`, a 
tuple can be generated instead: `(fd, ProgramInfo)`.

Add ability to safely convert from `ProgramInfo` to `Program` (which has 
necessary `fd()`)

Leave the user to call `unsafe libbpf_sys::bpf_prog_get_fd_by_id()`

### Other considerations

We can also return `fd`s for other bpf object types (`MapInfo`, `BtfInfo`, `LinkInfo`)

