### PR TITLE
libbpf-cargo: Skip the output of datasec static variables

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -604,6 +604,11 @@ impl<'a> Btf<'a> {
                     for datasec_var in &t.vars {
                         let var = match self.type_by_id(datasec_var.type_id)? {
                             BtfType::Var(v) => {
+                                if v.linkage == BtfVarLinkage::Static {
+                                    // do not output Static Var
+                                    continue;
+                                }
+
                                 if let Some(next_ty_id) = next_type(v.type_id)? {
                                     dependent_types.push(next_ty_id);
                                 }


### PR DESCRIPTION
In libbpf 6.0+ bpf_printk is using a static const for the ____fmt
variable under certain conditions. This is causing an error when
generating rust code for the rodata.  libbpf-rs should skip generation
of fields for static variables.

Solution: Skip generation of static variables while parsing datasec

Signed-off-by: Michael Mullin <mimullin@blackberry.com>