### PR TITLE
libbpf-cargo: Implement cargo clippy recommendations

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -201,7 +201,7 @@ impl<'a> Btf<'a> {
                     btf::BtfIntEncoding::Signed => format!("i{}", width),
                     btf::BtfIntEncoding::Bool => {
                         assert!(t.bits as usize == (std::mem::size_of::<bool>() * 8));
-                        format!("bool")
+                        "bool".to_string()
                     }
                     btf::BtfIntEncoding::Char | btf::BtfIntEncoding::None => format!("u{}", width),
                 }


### PR DESCRIPTION
libbpf-cargo does not have a clean pass of 'cargo clippy'.

Solution: Implement changes recommended by running cargo clippy over
libbpf-cargo source files

Signed-off-by: Michael Mullin <mimullin@blackberry.com>

NOTE: libbpf-rs has many more clippy recomendations.  I am not comfortable working on that until the unit tests are working as per PR: https://github.com/libbpf/libbpf-rs/pull/158