### PR TITLE
Implement Clippy recommendations on examples and libbpf-rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,5 @@ jobs:
       run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object
     - name: Run rustfmt
       run: cargo fmt --package libbpf-cargo libbpf-rs -- --check
+    - name: Run clippy
+      run: cargo clippy -- -D warnings

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -113,6 +113,7 @@ fn bump_memlock_rlimit() -> Result<()> {
 }
 
 fn print_banner(extra_fields: bool) {
+    #[allow(clippy::print_literal)]
     if extra_fields {
         println!(
             "{:9} {:6} {:6} {:6} {:16} {:4} {:20} {:6} {}",

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -147,14 +147,14 @@ impl Map {
     /// maps. The values are aligned to 8 bytes.
     fn percpu_aligned_value_size(&self) -> usize {
         let val_size = self.value_size() as usize;
-        return util::roundup(val_size, 8);
+        util::roundup(val_size, 8)
     }
 
     /// Returns the size of the buffer needed for a lookup/update of a per-cpu map.
     fn percpu_buffer_size(&self) -> Result<usize> {
         let aligned_val_size = self.percpu_aligned_value_size();
         let ncpu = util::num_possible_cpus()?;
-        return Ok(ncpu * aligned_val_size);
+        Ok(ncpu * aligned_val_size)
     }
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
@@ -226,9 +226,9 @@ impl Map {
             for chunk in raw_vals.chunks_exact(aligned_val_size) {
                 out.push(chunk[..val_size].to_vec());
             }
-            return Ok(Some(out));
+            Ok(Some(out))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 
@@ -363,12 +363,7 @@ impl Map {
     /// elements each.
     ///
     /// For per-cpu maps, [`Map::update_percpu()`] must be used.
-    pub fn update_percpu(
-        &mut self,
-        key: &[u8],
-        values: &Vec<Vec<u8>>,
-        flags: MapFlags,
-    ) -> Result<()> {
+    pub fn update_percpu(&mut self, key: &[u8], values: &[Vec<u8>], flags: MapFlags) -> Result<()> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::InvalidInput(format!(
                 "update() must be used for maps that are not per-cpu (type of the map is {})",
@@ -499,13 +494,13 @@ pub enum MapType {
 impl MapType {
     /// Returns if the map is of one of the per-cpu types.
     pub fn is_percpu(&self) -> bool {
-        match self {
+        matches!(
+            self,
             MapType::PercpuArray
-            | MapType::PercpuHash
-            | MapType::LruPercpuHash
-            | MapType::PercpuCgroupStorage => true,
-            _ => false,
-        }
+                | MapType::PercpuHash
+                | MapType::LruPercpuHash
+                | MapType::PercpuCgroupStorage
+        )
     }
 }
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -10,6 +10,7 @@ use crate::util;
 use crate::*;
 
 /// Builder for creating an [`OpenObject`]. Typically the entry point into libbpf-rs.
+#[derive(Default)]
 pub struct ObjectBuilder {
     name: String,
     relaxed_maps: bool,
@@ -113,15 +114,6 @@ impl ObjectBuilder {
         }
 
         OpenObject::new(obj)
-    }
-}
-
-impl Default for ObjectBuilder {
-    fn default() -> Self {
-        ObjectBuilder {
-            name: String::new(),
-            relaxed_maps: false,
-        }
     }
 }
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -171,7 +171,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
         };
 
         if let Some(ref n) = self.name {
-            s.name = str_to_cstring_and_pool(&n, &mut string_pool)?;
+            s.name = str_to_cstring_and_pool(n, &mut string_pool)?;
         }
 
         // libbpf_sys will use it as const despite the signature


### PR DESCRIPTION
This change enables a clean clippy check over the entire libbpf-rs project assuming clippy defaults (+branches_sharing_code linter).  IMHO clippy enhances the code quality of the project.