### PR TITLE
Allow having package.metadata sections that aren't for libbpf

### DIFF
--- a/libbpf-cargo/src/metadata.rs
+++ b/libbpf-cargo/src/metadata.rs
@@ -15,8 +15,9 @@ struct LibbpfPackageMetadata {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "lowercase")]
-enum PackageMetadata {
-    Libbpf(LibbpfPackageMetadata),
+struct PackageMetadata {
+    #[serde(default)]
+    libbpf: LibbpfPackageMetadata,
 }
 
 #[derive(Debug, Clone)]
@@ -42,8 +43,8 @@ fn get_package(
     }
 
     let package_metadata = if package.metadata != Value::Null {
-        let PackageMetadata::Libbpf(lpm) = serde_json::from_value(package.metadata.clone())?;
-        lpm
+        let PackageMetadata { libbpf } = serde_json::from_value(package.metadata.clone())?;
+        libbpf
     } else {
         LibbpfPackageMetadata::default()
     };


### PR DESCRIPTION
This allows having sections of the following form in Cargo.toml:
```
[package.metadata.deb]
    # ...
```

Previously, they would give a hard error:

```
$ cargo libbpf make
Compiling BPF objects
Error: Failed to compile BPF objects

Caused by:
    Failed to process package=bpf-graceful-restart, error=unknown variant `deb`, expected `libbpf`
```

Serde by default requires all enum variants to be known ahead of time;
this works by changing the deserialized type to a struct instead.

Signed-off-by: Joshua Nelson <jnelson@cloudflare.com>

Fixes https://github.com/libbpf/libbpf-rs/issues/164.