### PR TITLE
libbpf-cargo: Make generated object files deterministic by not using a temporary directory for include headers

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -931,7 +931,7 @@ fn gen_project(
     manifest_path: Option<&PathBuf>,
     rustfmt_path: Option<&PathBuf>,
 ) -> Result<()> {
-    let to_gen = metadata::get(debug, manifest_path)?;
+    let (_target_dir, to_gen) = metadata::get(debug, manifest_path)?;
     if debug && !to_gen.is_empty() {
         println!("Found bpf objs to gen skel:");
         for obj in &to_gen {

--- a/libbpf-cargo/src/metadata.rs
+++ b/libbpf-cargo/src/metadata.rs
@@ -138,7 +138,8 @@ fn get_package(
         .collect())
 }
 
-pub fn get(debug: bool, manifest_path: Option<&PathBuf>) -> Result<Vec<UnprocessedObj>> {
+/// Returns the `target_directory` and a list of objects to compile.
+pub fn get(debug: bool, manifest_path: Option<&PathBuf>) -> Result<(PathBuf, Vec<UnprocessedObj>)> {
     let mut cmd = MetadataCommand::new();
 
     if let Some(path) = manifest_path {
@@ -166,5 +167,5 @@ pub fn get(debug: bool, manifest_path: Option<&PathBuf>) -> Result<Vec<Unprocess
         }
     }
 
-    Ok(v)
+    Ok((metadata.target_directory, v))
 }


### PR DESCRIPTION
Clang includes the name of the directory where includes are stored in the `.debug_line` section of
the headers when debug info is enabled. Since the directory was randomly created on each new run,
that meant the object file varied randomly each time it was created.

This changes the directory name to be consistently in a subdirectory of `target/` instead.

Fixes https://github.com/libbpf/libbpf-rs/issues/163. Closes https://github.com/libbpf/libbpf-rs/pull/169.

Signed-off-by: Joshua Nelson <jnelson@cloudflare.com>