### PR TITLE
Created reuse_fd function to allow BPF maps to be shared without pinning

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -61,6 +61,19 @@ impl OpenMap {
         unsafe { libbpf_sys::bpf_map__set_inner_map_fd(self.ptr, inner.fd()) };
     }
 
+    /**
+     * Reuse an fd for a BPF map
+     */
+    pub fn reuse_fd(&self, fd: i32) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_map__reuse_fd(self.ptr, fd) };
+
+        if ret != 0 {
+            return Err(Error::System(-ret));
+        }
+
+        Ok(())
+    }
+
     /// Reuse an already-pinned map for `self`.
     pub fn reuse_pinned_map<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let cstring = util::path_to_cstring(path)?;
@@ -70,18 +83,14 @@ impl OpenMap {
             return Err(Error::System(errno::errno()));
         }
 
-        let ret = unsafe { libbpf_sys::bpf_map__reuse_fd(self.ptr, fd) };
+        let reuse_result = self.reuse_fd(fd);
 
         // Always close `fd` regardless of if `bpf_map__reuse_fd` succeeded or failed
         //
         // Ignore errors b/c can't really recover from failure
         let _ = unistd::close(fd);
 
-        if ret != 0 {
-            return Err(Error::System(-ret));
-        }
-
-        Ok(())
+        reuse_result
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Yadunandan Pillai <ytpillai@pm.me>

Solves #171 