### PR TITLE
libbpf-cargo: __unnamed_ is unnecessary as a field prefix

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -14,7 +14,6 @@ use crate::btf::c_types::*;
 use crate::btf::*;
 
 const ANON_PREFIX: &str = "__anon_";
-const UNNAMED_PREFIX: &str = "__unnamed_";
 
 pub struct Btf<'a> {
     types: Vec<BtfType<'a>>,
@@ -479,7 +478,7 @@ impl<'a> Btf<'a> {
                         let field_name = if !member.name.is_empty() {
                             member.name.to_string()
                         } else {
-                            format!("{}{}", UNNAMED_PREFIX, field_ty_str)
+                            field_ty_str.clone()
                         };
 
                         agg_content.push(format!(r#"    pub {}: {},"#, field_name, field_ty_str));

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -2080,9 +2080,9 @@ struct bpf_sock_tuple_5_15 tup;
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct bpf_sock_tuple_5_15 {
-    pub __unnamed___anon_1: __anon_1,
+    pub __anon_1: __anon_1,
     __pad_36: [u8; 4],
-    pub __unnamed___anon_4: __anon_4,
+    pub __anon_4: __anon_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
Rust can have a field name be the same as the type.  __unnamed_ is
not necessary for unnamed unions, and harms readability

Signed-off-by: Michael Mullin <mimullin@blackberry.com>