### PR TITLE
build: Download latest version of Rust before building

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: rustfmt, clippy
+        override: true
     - name: Install deps
       run: sudo apt-get install -y clang-10 libelf-dev
     - name: Symlink clang


### PR DESCRIPTION
Without this action, we otherwise default to using the
ubuntu-latest version of Rust.

Signed-off-by: Joanne Koong <joannekoong@gmail.com>