### PR TITLE
Replace deprecated libbpf functions

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -46,7 +46,7 @@ macro_rules! gen_bpf_object_iter {
             type Item = *mut $iter_ty;
 
             fn next(&mut self) -> Option<Self::Item> {
-                self.last = unsafe { $next_fn(self.last, self.obj) };
+                self.last = unsafe { $next_fn(self.obj, self.last) };
 
                 if self.last.is_null() {
                     None
@@ -58,11 +58,15 @@ macro_rules! gen_bpf_object_iter {
     };
 }
 
-gen_bpf_object_iter!(MapIter, libbpf_sys::bpf_map, libbpf_sys::bpf_map__next);
+gen_bpf_object_iter!(
+    MapIter,
+    libbpf_sys::bpf_map,
+    libbpf_sys::bpf_object__next_map
+);
 gen_bpf_object_iter!(
     ProgIter,
     libbpf_sys::bpf_program,
-    libbpf_sys::bpf_program__next
+    libbpf_sys::bpf_object__next_program
 );
 
 /// Run `rustfmt` over `s` and return result

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -138,7 +138,7 @@ impl OpenObject {
         let mut map: *mut libbpf_sys::bpf_map = std::ptr::null_mut();
         loop {
             // Get the pointer to the next BPF map
-            let next_ptr = unsafe { libbpf_sys::bpf_map__next(map, obj.ptr) };
+            let next_ptr = unsafe { libbpf_sys::bpf_object__next_map(obj.ptr, map) };
             if next_ptr.is_null() {
                 break;
             }
@@ -158,7 +158,7 @@ impl OpenObject {
         let mut prog: *mut libbpf_sys::bpf_program = std::ptr::null_mut();
         loop {
             // Get the pointer to the next BPF program
-            let next_ptr = unsafe { libbpf_sys::bpf_program__next(prog, obj.ptr) };
+            let next_ptr = unsafe { libbpf_sys::bpf_object__next_program(obj.ptr, prog) };
             if next_ptr.is_null() {
                 break;
             }
@@ -311,7 +311,7 @@ impl Object {
         let mut map: *mut libbpf_sys::bpf_map = std::ptr::null_mut();
         loop {
             // Get the pointer to the next BPF map
-            let next_ptr = unsafe { libbpf_sys::bpf_map__next(map, obj.ptr) };
+            let next_ptr = unsafe { libbpf_sys::bpf_object__next_map(obj.ptr, map) };
             if next_ptr.is_null() {
                 break;
             }
@@ -345,7 +345,7 @@ impl Object {
         let mut prog: *mut libbpf_sys::bpf_program = std::ptr::null_mut();
         loop {
             // Get the pointer to the next BPF program
-            let next_ptr = unsafe { libbpf_sys::bpf_program__next(prog, obj.ptr) };
+            let next_ptr = unsafe { libbpf_sys::bpf_object__next_program(obj.ptr, prog) };
             if next_ptr.is_null() {
                 break;
             }


### PR DESCRIPTION
`bpf_map__next` and `bpf_program__next` are deprecated in libbpf in favor of
`bpf_object__next_map` and `bpf_object__next_program`.

This patch replaces our uses of `bpf_map__next` and `bpf_program__next` with
the updated APIs.

Signed-off-by: Joanne Koong <joannekoong@gmail.com>