### PR TITLE
util: Add parse_ret helper functions

### DIFF
--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -1,4 +1,3 @@
-use nix::errno;
 use std::path::Path;
 
 use crate::*;
@@ -28,11 +27,7 @@ impl Link {
     /// Replace the underlying prog with `prog`.
     pub fn update_prog(&mut self, prog: Program) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__update_program(self.ptr, prog.ptr) };
-        if ret != 0 {
-            Err(Error::System(errno::errno()))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// Release "ownership" of underlying BPF resource (typically, a BPF program
@@ -55,24 +50,14 @@ impl Link {
         let path_ptr = path_c.as_ptr();
 
         let ret = unsafe { libbpf_sys::bpf_link__pin(self.ptr, path_ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// from bpffs
     pub fn unpin(&mut self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__unpin(self.ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// Returns the file descriptor of the link.

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -38,23 +38,12 @@ impl OpenMap {
             )
         };
 
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            return Err(Error::System(-ret));
-        }
-
-        Ok(())
+        util::parse_ret(ret)
     }
 
     pub fn set_max_entries(&mut self, count: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_max_entries(self.ptr, count) };
-
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            return Err(Error::System(-ret));
-        }
-
-        Ok(())
+        util::parse_ret(ret)
     }
 
     pub fn set_inner_map_fd(&mut self, inner: &Map) {
@@ -64,12 +53,7 @@ impl OpenMap {
     /// Reuse an fd for a BPF map
     pub fn reuse_fd(&self, fd: i32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__reuse_fd(self.ptr, fd) };
-
-        if ret != 0 {
-            return Err(Error::System(-ret));
-        }
-
-        Ok(())
+        util::parse_ret(ret)
     }
 
     /// Reuse an already-pinned map for `self`.
@@ -170,12 +154,7 @@ impl Map {
         let path_ptr = path_c.as_ptr();
 
         let ret = unsafe { libbpf_sys::bpf_map__pin(self.ptr, path_ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
@@ -185,12 +164,7 @@ impl Map {
         let path_ptr = path_c.as_ptr();
 
         let ret = unsafe { libbpf_sys::bpf_map__unpin(self.ptr, path_ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// Returns map value as `Vec` of `u8`.
@@ -289,12 +263,7 @@ impl Map {
         let ret = unsafe {
             libbpf_sys::bpf_map_delete_elem(self.fd as i32, key.as_ptr() as *const c_void)
         };
-
-        if ret == 0 {
-            Ok(())
-        } else {
-            Err(Error::System(errno::errno()))
-        }
+        util::parse_ret(ret)
     }
 
     /// Same as [`Map::lookup()`] except this also deletes the key from the map.
@@ -429,11 +398,7 @@ impl Map {
             )
         };
 
-        if ret == 0 {
-            Ok(())
-        } else {
-            Err(Error::System(errno::errno()))
-        }
+        util::parse_ret(ret)
     }
 
     /// Returns an iterator over keys in this map

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -159,11 +159,7 @@ pub struct PerfBuffer<'b> {
 impl<'b> PerfBuffer<'b> {
     pub fn poll(&self, timeout: Duration) -> Result<()> {
         let ret = unsafe { libbpf_sys::perf_buffer__poll(self.ptr, timeout.as_millis() as i32) };
-        if ret < 0 {
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 }
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 use std::path::Path;
 
-use nix::errno;
 use num_enum::TryFromPrimitive;
 use strum_macros::Display;
 
@@ -191,12 +190,7 @@ impl Program {
         let path_ptr = path_c.as_ptr();
 
         let ret = unsafe { libbpf_sys::bpf_program__pin(self.ptr, path_ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
@@ -206,12 +200,7 @@ impl Program {
         let path_ptr = path_c.as_ptr();
 
         let ret = unsafe { libbpf_sys::bpf_program__unpin(self.ptr, path_ptr) };
-        if ret != 0 {
-            // Error code is returned negative, flip to positive to match errno
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// Auto-attach based on prog section
@@ -349,11 +338,7 @@ impl Program {
     pub fn attach_sockmap(&self, map_fd: i32) -> Result<()> {
         let err =
             unsafe { libbpf_sys::bpf_prog_attach(self.fd(), map_fd, self.attach_type() as u32, 0) };
-        if err != 0 {
-            Err(Error::System(errno::errno()))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(err)
     }
 
     /// Attach this program to [XDP](https://lwn.net/Articles/825998/)

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -133,11 +133,7 @@ impl RingBuffer {
 
         let ret = unsafe { libbpf_sys::ring_buffer__poll(self.ptr, timeout.as_millis() as i32) };
 
-        if ret < 0 {
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 
     /// Greedily consume from all open ring buffers, calling the registered
@@ -148,11 +144,7 @@ impl RingBuffer {
 
         let ret = unsafe { libbpf_sys::ring_buffer__consume(self.ptr) };
 
-        if ret < 0 {
-            Err(Error::System(-ret))
-        } else {
-            Ok(())
-        }
+        util::parse_ret(ret)
     }
 }
 

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -36,6 +36,19 @@ pub fn roundup(num: usize, r: usize) -> usize {
 /// Get the number of CPUs in the system, e.g., to interact with per-cpu maps.
 pub fn num_possible_cpus() -> Result<usize> {
     let ret = unsafe { libbpf_sys::libbpf_num_possible_cpus() };
+    parse_ret_usize(ret)
+}
+
+pub fn parse_ret(ret: i32) -> Result<()> {
+    if ret < 0 {
+        // Error code is returned negative, flip to positive to match errno
+        Err(Error::System(-ret))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn parse_ret_usize(ret: i32) -> Result<usize> {
     if ret < 0 {
         // Error code is returned negative, flip to positive to match errno
         Err(Error::System(-ret))


### PR DESCRIPTION
This patch adds helper functions for parsing the return code into its
corresponding Result.

Signed-off-by: Joanne Koong <joannekoong@gmail.com>