### PR TITLE
perf_buffer: Add epoll_fd, consume, consume_buffer, ... wrappers

### DIFF
--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -157,9 +157,35 @@ pub struct PerfBuffer<'b> {
 }
 
 impl<'b> PerfBuffer<'b> {
+    pub fn epoll_fd(&self) -> i32 {
+        unsafe { libbpf_sys::perf_buffer__epoll_fd(self.ptr) }
+    }
+
     pub fn poll(&self, timeout: Duration) -> Result<()> {
         let ret = unsafe { libbpf_sys::perf_buffer__poll(self.ptr, timeout.as_millis() as i32) };
         util::parse_ret(ret)
+    }
+
+    pub fn consume(&self) -> Result<()> {
+        let ret = unsafe { libbpf_sys::perf_buffer__consume(self.ptr) };
+        util::parse_ret(ret)
+    }
+
+    pub fn consume_buffer(&self, buf_idx: usize) -> Result<()> {
+        let ret = unsafe {
+            libbpf_sys::perf_buffer__consume_buffer(self.ptr, buf_idx as libbpf_sys::size_t)
+        };
+        util::parse_ret(ret)
+    }
+
+    pub fn buffer_cnt(&self) -> usize {
+        unsafe { libbpf_sys::perf_buffer__buffer_cnt(self.ptr) as usize }
+    }
+
+    pub fn buffer_fd(&self, buf_idx: usize) -> Result<i32> {
+        let ret =
+            unsafe { libbpf_sys::perf_buffer__buffer_fd(self.ptr, buf_idx as libbpf_sys::size_t) };
+        util::parse_ret_i32(ret)
     }
 }
 

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -48,6 +48,15 @@ pub fn parse_ret(ret: i32) -> Result<()> {
     }
 }
 
+pub fn parse_ret_i32(ret: i32) -> Result<i32> {
+    if ret < 0 {
+        // Error code is returned negative, flip to positive to match errno
+        Err(Error::System(-ret))
+    } else {
+        Ok(ret)
+    }
+}
+
 pub fn parse_ret_usize(ret: i32) -> Result<usize> {
     if ret < 0 {
         // Error code is returned negative, flip to positive to match errno


### PR DESCRIPTION
This patch adds epoll_fd, consume, consume_buffer, buffer_cnt, and
buffer_fd support for perf buffers.

This is part of a larger effort to reach feature-parity with libbpf.

Signed-off-by: Joanne Koong <joannekoong@gmail.com>