### PR TITLE
libbpf-rs: Turn on tests for BTF

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,10 @@ jobs:
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
     - name: Run tests
-      # Skip tests that require BTF built into kernel
+      # Skip BTF tests which require sudo 
       run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object
+    - name: Run BTF tests
+      run: cd libbpf-rs && cargo test --verbose -- test_object
     - name: Run rustfmt
       run: cargo fmt --package libbpf-cargo libbpf-rs -- --check
     - name: Run clippy


### PR DESCRIPTION
Ubuntu 20.04 has recently added BTF into it's kernel
BTF tests can now be run

Signed-off-by: Michael Mullin <mimullin@blackberry.com>