### PR TITLE
CI: add cargo audit check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,20 @@
+name: Audit
+
+on:
+  pull_request:
+    # Runs when Cargo files are updated in a PR.
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    # Runs every Sunday at midnight.
+    - cron: 0 0 * * 0
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Rust](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
+![Audit](https://github.com/libbpf/libbpf-rs/workflows/Audit/badge.svg?branch=master)
 
 WARNING: The API is not stable and is subject to breakage. Any breakage will
 include a minor version bump pre-1.0 and a major version bump post-1.0.


### PR DESCRIPTION
Addresses: https://github.com/libbpf/libbpf-rs/issues/187

This PR adds the `cargo audit` check to a GitHub actions workflow. It runs the check:
- Every time the Cargo.lock or Cargo.toml files are updated in a PR.
- Every Sunday at midnight.

Signed-off-by: Dan Bond <danbond@protonmail.com>