### PR TITLE
libbpf-rs: Add set_autoload/set_attach_target to OpenProgram

### DIFF
--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -360,12 +360,6 @@ impl Object {
             let section = unsafe { libbpf_sys::bpf_program__section_name(next_ptr) };
             let section = util::c_ptr_to_string(section)?;
 
-            // Get the program fd
-            let fd = unsafe { libbpf_sys::bpf_program__fd(next_ptr) };
-            if fd < 0 {
-                return Err(Error::System(-fd));
-            }
-
             // Add the program to the hashmap
             obj.progs
                 .insert(name.clone(), Program::new(next_ptr, name, section));

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -111,8 +111,7 @@ extern "C" fn outer_print_cb(
 pub fn set_print(
     mut callback: Option<(PrintLevel, PrintCallback)>,
 ) -> Option<(PrintLevel, PrintCallback)> {
-    let real_cb: libbpf_sys::libbpf_print_fn_t;
-    real_cb = callback.as_ref().and(Some(outer_print_cb));
+    let real_cb: libbpf_sys::libbpf_print_fn_t = callback.as_ref().and(Some(outer_print_cb));
     std::mem::swap(&mut callback, &mut *PRINT_CB.lock().unwrap());
     unsafe { libbpf_sys::libbpf_set_print(real_cb) };
     callback

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -41,6 +41,11 @@ impl OpenProgram {
     pub fn section(&self) -> &str {
         &self.section
     }
+
+    pub fn set_autoload(&mut self, autoload: bool) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_program__set_autoload(self.ptr, autoload) };
+        util::parse_ret(ret)
+    }
 }
 
 /// Type of a [`Program`]. Maps to `enum bpf_prog_type` in kernel uapi.


### PR DESCRIPTION
Add bpf_program__set_autoload / bpf_program__set_attach_target equivalent API to libbpf-rs.

Closes #175 and #176.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>