### PR TITLE
libbpf-rs: Omit get_ prefix for getters

### DIFF
--- a/libbpf-rs/src/iter.rs
+++ b/libbpf-rs/src/iter.rs
@@ -15,7 +15,7 @@ pub struct Iter {
 
 impl Iter {
     pub fn new(link: &Link) -> Result<Self> {
-        let link_fd = link.get_fd();
+        let link_fd = link.fd();
         let fd = unsafe { libbpf_sys::bpf_iter_create(link_fd) };
         if fd < 0 {
             return Err(Error::System(errno::errno()));

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -61,7 +61,13 @@ impl Link {
     }
 
     /// Returns the file descriptor of the link.
+    #[deprecated(since = "0.17.0", note = "please use `fd` instead")]
     pub fn get_fd(&self) -> i32 {
+        unsafe { libbpf_sys::bpf_link__fd(self.ptr) }
+    }
+
+    /// Returns the file descriptor of the link.
+    pub fn fd(&self) -> i32 {
         unsafe { libbpf_sys::bpf_link__fd(self.ptr) }
     }
 }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -33,7 +33,7 @@ macro_rules! gen_info_impl {
 
         impl $name {
             // Returns Some(next_valid_fd), None on none left
-            fn get_next_valid_fd(&mut self) -> Option<i32> {
+            fn next_valid_fd(&mut self) -> Option<i32> {
                 loop {
                     if unsafe { $next_id(self.cur_id, &mut self.cur_id) } != 0 {
                         return None;
@@ -57,7 +57,7 @@ macro_rules! gen_info_impl {
             type Item = $info_ty;
 
             fn next(&mut self) -> Option<Self::Item> {
-                let fd = match self.get_next_valid_fd() {
+                let fd = match self.next_valid_fd() {
                     Some(fd) => fd,
                     None => return None,
                 };


### PR DESCRIPTION
Let's follow the Rust ([0]) and libbpf ([1]) naming conventions,
omit the get_ prefix for getters.

  [0]: https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#gettersetter-apis
  [1]: https://github.com/libbpf/libbpf/wiki/Libbpf:-the-road-to-v1.0

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>