### PR TITLE
libbpf-cargo/btf: Add BTF_KIND_FLOAT and BTF_KIND_DECL_TAG

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -368,7 +368,12 @@ impl<'a> Btf<'a> {
                     BtfType::Const(t) => id = t.type_id,
                     BtfType::Restrict(t) => id = t.type_id,
                     BtfType::Typedef(t) => id = t.type_id,
-                    _ => return Ok(None),
+                    BtfType::Void
+                    | BtfType::Int(_)
+                    | BtfType::Fwd(_)
+                    | BtfType::Func(_)
+                    | BtfType::FuncProto(_)
+                    | BtfType::Var(_) => return Ok(None),
                 }
             }
         };
@@ -376,7 +381,18 @@ impl<'a> Btf<'a> {
         let is_terminal = |id| -> Result<bool> {
             match self.type_by_id(id)?.kind() {
                 BtfKind::Struct | BtfKind::Union | BtfKind::Enum | BtfKind::Datasec => Ok(false),
-                _ => Ok(true),
+                BtfKind::Void
+                | BtfKind::Int
+                | BtfKind::Ptr
+                | BtfKind::Array
+                | BtfKind::Fwd
+                | BtfKind::Typedef
+                | BtfKind::Volatile
+                | BtfKind::Const
+                | BtfKind::Restrict
+                | BtfKind::Func
+                | BtfKind::FuncProto
+                | BtfKind::Var => Ok(true),
             }
         };
 
@@ -669,7 +685,18 @@ impl<'a> Btf<'a> {
                 BtfType::Const(t) => type_id = t.type_id,
                 BtfType::Restrict(t) => type_id = t.type_id,
                 BtfType::Typedef(t) => type_id = t.type_id,
-                _ => return Ok(type_id),
+                BtfType::Void
+                | BtfType::Int(_)
+                | BtfType::Ptr(_)
+                | BtfType::Array(_)
+                | BtfType::Struct(_)
+                | BtfType::Union(_)
+                | BtfType::Enum(_)
+                | BtfType::Fwd(_)
+                | BtfType::Func(_)
+                | BtfType::FuncProto(_)
+                | BtfType::Var(_)
+                | BtfType::Datasec(_) => return Ok(type_id),
             };
         }
     }

--- a/libbpf-cargo/src/btf/c_types.rs
+++ b/libbpf-cargo/src/btf/c_types.rs
@@ -62,3 +62,9 @@ pub struct btf_datasec_var {
     pub offset: u32,
     pub size: u32,
 }
+
+#[repr(C)]
+#[derive(Debug, Clone, DerivePread, Pwrite, IOread, SizeWith)]
+pub struct btf_decl_tag {
+    pub component_idx: i32,
+}

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -21,6 +21,8 @@ pub enum BtfKind {
     FuncProto = 13,
     Var = 14,
     Datasec = 15,
+    Float = 16,
+    DeclTag = 17,
 }
 
 #[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
@@ -161,6 +163,19 @@ pub struct BtfDatasec<'a> {
     pub vars: Vec<BtfDatasecVar>,
 }
 
+#[derive(Debug)]
+pub struct BtfFloat<'a> {
+    pub name: &'a str,
+    pub size: u32,
+}
+
+#[derive(Debug)]
+pub struct BtfDeclTag<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+    pub component_idx: i32,
+}
+
 pub enum BtfType<'a> {
     Void,
     Int(BtfInt<'a>),
@@ -178,6 +193,8 @@ pub enum BtfType<'a> {
     FuncProto(BtfFuncProto<'a>),
     Var(BtfVar<'a>),
     Datasec(BtfDatasec<'a>),
+    Float(BtfFloat<'a>),
+    DeclTag(BtfDeclTag<'a>),
 }
 
 impl<'a> BtfType<'a> {
@@ -199,6 +216,8 @@ impl<'a> BtfType<'a> {
             BtfType::Enum(_) => BtfKind::Enum,
             BtfType::FuncProto(_) => BtfKind::FuncProto,
             BtfType::Datasec(_) => BtfKind::Datasec,
+            BtfType::Float(_) => BtfKind::Float,
+            BtfType::DeclTag(_) => BtfKind::DeclTag,
         }
     }
 }
@@ -222,6 +241,8 @@ impl<'a> fmt::Display for BtfType<'a> {
             BtfType::Enum(_) => write!(f, "enum"),
             BtfType::FuncProto(_) => write!(f, "funcproto"),
             BtfType::Datasec(_) => write!(f, "datasec"),
+            BtfType::Float(_) => write!(f, "float"),
+            BtfType::DeclTag(_) => write!(f, "decltag"),
         }
     }
 }


### PR DESCRIPTION
Add support for BTF_KIND_FLOAT and BTF_KIND_DECL_TAG.

Closes #172.