### PR TITLE
Problems with internal maps (.rodata) and old kernels

### DIFF
--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -266,12 +266,10 @@ impl OpenObject {
             return Err(Error::System(-ret));
         }
 
-        let obj = Object::new(self.ptr)?;
-
+        let ptr = self.ptr;
         // Prevent object from being closed once `self` is dropped
         self.ptr = ptr::null_mut();
-
-        Ok(obj)
+        Object::new(ptr)
     }
 }
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -327,7 +327,9 @@ impl Object {
 
             // Get the map fd
             let fd = unsafe { libbpf_sys::bpf_map__fd(next_ptr) };
-            if fd < 0 {
+            // Old kernels can have uninitialized internal maps:
+            // https://github.com/libbpf/libbpf/blob/5c31bcf220f66e70f39fd141f5b0c55c6ab65e8e/src/libbpf.c#L5009-L5022
+            if fd < 0 && !unsafe { libbpf_sys::bpf_map__is_internal(next_ptr) } {
                 return Err(Error::System(-fd));
             }
 


### PR DESCRIPTION
Found some problems with >= libbpf-sys 0.6.0 and old kernels (in my case it was CentOS/RHEL 7). The problems were with internal maps (.rodata) generated (but not really used) by a relatively new compiler. 

What I found:
1. double free in the error path that actually resulted in segfault
2. after getting rid of the segfault there remains an error with loading such programs