### PR TITLE
libbpf-rs: update libbpf-sys dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ name = "bpf_query"
 version = "0.1.0"
 dependencies = [
  "libbpf-rs",
- "nix",
+ "nix 0.23.1",
  "structopt",
 ]
 
@@ -230,7 +230,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "log",
- "nix",
+ "nix 0.23.1",
  "num_enum",
  "plain",
  "scopeguard",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "0.6.1-2"
+version = "0.7.1+v0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df746ec055dfd68b3d0e8ea8dd12882157529132652d0df2e001305ba4803f0c"
+checksum = "58f827f39ef9181560ee49c82bbdc8e8441c56404f62dc6eef1384113fd4c268"
 dependencies = [
  "cc",
  "pkg-config",
@@ -296,6 +296,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -755,6 +768,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tc_whitelist_ports"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libbpf-cargo",
+ "libbpf-rs",
+ "libc",
+ "nix 0.22.3",
+ "plain",
+ "structopt",
 ]
 
 [[package]]

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.14"
-libbpf-sys = { version = "0.6.1-2" }
+libbpf-sys = { version = "0.7.1" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = "1.5"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -21,7 +21,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 bitflags = "1.3"
 lazy_static = "1.4"
-libbpf-sys = { version = "0.6.1-2" }
+libbpf-sys = { version = "0.7.1" }
 nix = "0.23"
 num_enum = "0.5"
 strum_macros = "0.23"

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -1,13 +1,7 @@
 use core::ffi::c_void;
-use std::collections::HashMap;
-use std::ffi::CStr;
-use std::mem;
-use std::os::raw::c_char;
-use std::path::Path;
-use std::ptr;
+use std::{collections::HashMap, ffi::CStr, mem, os::raw::c_char, path::Path, ptr};
 
-use crate::util;
-use crate::*;
+use crate::{util, *};
 
 /// Builder for creating an [`OpenObject`]. Typically the entry point into libbpf-rs.
 #[derive(Default)]
@@ -56,6 +50,10 @@ impl ObjectBuilder {
             btf_custom_path: ptr::null(),
             __bindgen_padding_0: <[u8; 6]>::default(),
             __bindgen_padding_1: <[u8; 4]>::default(),
+            kernel_log_buf: ptr::null_mut(),
+            kernel_log_size: 0,
+            kernel_log_level: 0,
+            __bindgen_padding_2: <[u8; 4]>::default(),
         }
     }
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,9 +1,11 @@
-use std::collections::HashSet;
-use std::fs;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::sync::mpsc::channel;
-use std::time::Duration;
+use std::{
+    collections::HashSet,
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    sync::mpsc::channel,
+    time::Duration,
+};
 
 use nix::errno;
 use plain::Plain;
@@ -654,7 +656,7 @@ fn test_object_map_create_and_pin() {
 
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
-        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as i32,
+        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as u32,
         btf_fd: 0,
         btf_key_type_id: 0,
         btf_value_type_id: 0,
@@ -706,7 +708,7 @@ fn test_object_map_create_without_name() {
 
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
-        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as i32,
+        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as u32,
         btf_fd: 0,
         btf_key_type_id: 0,
         btf_value_type_id: 0,


### PR DESCRIPTION
libbpf-sys 0.7.1 includes a newer libbpf version that has many useful features including the new
BPF_KPROBE_SYSCALL macro. Let's update so that users that are using a vendored libbpf can
take advantage of these features.