### PR TITLE
Add struct_ops attach support

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -476,6 +476,26 @@ impl Map {
             ptr: std::ptr::null_mut(),
         })
     }
+
+    /// Attach a struct ops map
+    pub fn attach_struct_ops(&mut self) -> Result<Link> {
+        if self.map_type() != MapType::StructOps {
+            return Err(Error::InvalidInput(format!(
+                "Invalid map type ({}) for attach_struct_ops()",
+                self.map_type(),
+            )));
+        }
+
+        let ret = unsafe {
+            let p = libbpf_sys::bpf_map__attach_struct_ops(self.ptr);
+            let rc = libbpf_sys::libbpf_get_error(p as *const c_void);
+            if rc != 0 {
+                return Err(Error::System(rc as i32));
+            }
+            p
+        };
+        Ok(Link::new(ret))
+    }
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
Libbpf has support for BPF STRUCT_OPS
https://lwn.net/Articles/809092/ which allows for bpf to implement
specific kernel's function pointers.

libbpf has bpf_map__attach_struct_ops() to attach these. This commit
adds the equivalent functionality to libbpf-rs without which
STRUCT_OPS cannot be used.