### PR TITLE
libbpf-cargo: enable split building and generation in SkeletonBuilder

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -1,5 +1,4 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::{fs::create_dir_all, path::Path};
 
 use libbpf_cargo::SkeletonBuilder;
 
@@ -16,6 +15,9 @@ fn main() {
     // all up.
     create_dir_all("./src/bpf/.output").unwrap();
     let skel = Path::new("./src/bpf/.output/capable.skel.rs");
-    SkeletonBuilder::new(SRC).generate(&skel).unwrap();
+    SkeletonBuilder::new()
+        .source(SRC)
+        .build_and_generate(&skel)
+        .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,5 +1,4 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::{fs::create_dir_all, path::Path};
 
 use libbpf_cargo::SkeletonBuilder;
 
@@ -16,6 +15,9 @@ fn main() {
     // all up.
     create_dir_all("./src/bpf/.output").unwrap();
     let skel = Path::new("./src/bpf/.output/runqslower.skel.rs");
-    SkeletonBuilder::new(SRC).generate(&skel).unwrap();
+    SkeletonBuilder::new()
+        .source(SRC)
+        .build_and_generate(&skel)
+        .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -1,5 +1,4 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::{fs::create_dir_all, path::Path};
 
 use libbpf_cargo::SkeletonBuilder;
 
@@ -16,6 +15,9 @@ fn main() {
     // all up.
     create_dir_all("./src/bpf/.output").unwrap();
     let skel = Path::new("./src/bpf/.output/tc.skel.rs");
-    SkeletonBuilder::new(SRC).generate(&skel).unwrap();
+    SkeletonBuilder::new()
+        .source(SRC)
+        .build_and_generate(&skel)
+        .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1,15 +1,16 @@
-use std::convert::TryInto;
-use std::fs::{create_dir, read, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    convert::TryInto,
+    fs::{create_dir, read, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use goblin::Object;
 use memmap2::Mmap;
 use tempfile::{tempdir, NamedTempFile, TempDir};
 
-use crate::btf;
-use crate::{btf::Btf, build::build, make::make, SkeletonBuilder};
+use crate::{btf, btf::Btf, build::build, make::make, SkeletonBuilder};
 
 static VMLINUX: &'static str = include_str!("../test_data/vmlinux.h");
 
@@ -701,9 +702,10 @@ fn test_skeleton_builder_basic() {
 
     // Generate skeleton file
     let skel = NamedTempFile::new().unwrap();
-    SkeletonBuilder::new(proj_dir.join("src/bpf/prog.bpf.c"))
+    SkeletonBuilder::new()
+        .source(proj_dir.join("src/bpf/prog.bpf.c"))
         .debug(true)
-        .generate(skel.path())
+        .build_and_generate(skel.path())
         .unwrap();
 
     let mut cargo = OpenOptions::new()
@@ -805,18 +807,20 @@ fn test_skeleton_builder_clang_opts() {
     let skel = NamedTempFile::new().unwrap();
 
     // Should fail b/c `PURPOSE` not defined
-    SkeletonBuilder::new(proj_dir.join("src/bpf/prog.bpf.c"))
+    SkeletonBuilder::new()
+        .source(proj_dir.join("src/bpf/prog.bpf.c"))
         .debug(true)
         .clang("clang")
-        .generate(skel.path())
+        .build_and_generate(skel.path())
         .unwrap_err();
 
     // Should succeed b/c we defined the macro
-    SkeletonBuilder::new(proj_dir.join("src/bpf/prog.bpf.c"))
+    SkeletonBuilder::new()
+        .source(proj_dir.join("src/bpf/prog.bpf.c"))
         .debug(true)
         .clang("clang")
         .clang_args("-DPURPOSE=you_pass_the_butter")
-        .generate(skel.path())
+        .build_and_generate(skel.path())
         .unwrap();
 }
 


### PR DESCRIPTION
It might be desirable for an end-user to run SkeletonBuilder directly on an object file
rather than compiling with clang. This could be useful for a few reasons, such as
establishing greater control over the build process or working with vendored object files.

As such, this commit refactors SkeletonBuilder slightly, breaking generate() up into
build() and generate() respectively. A new function is added called build_and_generate()
which encompasses the old behaviour. To make this work, we also remove the source argument
from SkeletonBuilder::new() and instead shift over to SkeletonBuilder::source() and
SkeletonBuilder::obj() to specify a source and object file respectively.

In cases where SkeletonBuilder::obj is missing, we fall back to creating a temporary
directory as before.

Note that this is technically a breaking change for users of the SkeletonBuilder API
(generally in a build.rs file for example). I've updated the examples as necessary to reflect this.

Signed-off-by: William Findlay <will@isovalent.com>