### PR TITLE
libbpf-rs: Fix attach_struct_ops

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -486,7 +486,13 @@ impl Map {
             )));
         }
 
-        let ret = unsafe {
+        if self.ptr.is_null() {
+            return Err(Error::InvalidInput(
+                "Cannot attach a user-created struct_ops map".to_string(),
+            ));
+        }
+
+        let ptr = unsafe {
             let p = libbpf_sys::bpf_map__attach_struct_ops(self.ptr);
             let rc = libbpf_sys::libbpf_get_error(p as *const c_void);
             if rc != 0 {
@@ -494,7 +500,7 @@ impl Map {
             }
             p
         };
-        Ok(Link::new(ret))
+        Ok(Link::new(ptr))
     }
 }
 


### PR DESCRIPTION
PR 222 added attach_struct_ops but there were some requests for
changes from @insearchoflosttime after the PR was pulled. This commit
addresses the feedback.

Signed-off-by: Dan Schatzberg <schatzberg.dan@gmail.com>