### PR TITLE
libbpf-cargo: use clap derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,30 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -53,9 +33,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "bpf_query"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "libbpf-rs",
  "nix",
- "structopt",
 ]
 
 [[package]]
@@ -72,12 +52,12 @@ name = "capable"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
  "phf",
  "plain",
- "structopt",
  "time",
 ]
 
@@ -117,17 +97,38 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -162,6 +163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,12 +178,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "libc",
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -206,6 +220,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "clap",
  "goblin",
  "libbpf-sys",
  "memmap2",
@@ -216,7 +231,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "structopt",
  "tempfile",
  "thiserror",
 ]
@@ -339,6 +353,12 @@ checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "parking_lot"
@@ -565,11 +585,11 @@ name = "runqslower"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
  "plain",
- "structopt",
  "time",
 ]
 
@@ -703,42 +723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -761,12 +751,12 @@ name = "tc_whitelist_ports"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
  "nix",
  "plain",
- "structopt",
 ]
 
 [[package]]
@@ -785,12 +775,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -846,22 +833,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
-structopt = "0.3"
+clap = { version = "3.1", default-features = false, features = ["std", "derive"] }

--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -1,11 +1,11 @@
 use std::process::exit;
 
+use clap::Parser;
 use libbpf_rs::query;
 use nix::unistd::Uid;
-use structopt::StructOpt;
 
 /// Query the system about BPF-related information
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     /// Display information about progs
     Prog,
@@ -21,10 +21,7 @@ fn prog() {
     for prog in query::ProgInfoIter::default() {
         println!(
             "name={:<16} type={:<15} run_count={:<2} runtime_ns={}",
-            prog.name,
-            prog.ty,
-            prog.run_cnt,
-            prog.run_time_ns
+            prog.name, prog.ty, prog.run_cnt, prog.run_time_ns
         );
     }
 }
@@ -65,7 +62,7 @@ fn main() {
         exit(1);
     }
 
-    let opts = Command::from_args();
+    let opts = Command::parse();
 
     match opts {
         Command::Prog => prog(),

--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -10,8 +10,8 @@ libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 phf = { version = "0.10", features = ["macros"] }
 plain = "0.2"
-structopt = "0.3"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"]}
+clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -7,10 +7,10 @@ use core::time::Duration;
 use std::str::FromStr;
 
 use anyhow::{bail, Result};
+use clap::Parser;
 use libbpf_rs::PerfBufferBuilder;
 use phf::phf_map;
 use plain::Plain;
-use structopt::StructOpt;
 use time::macros::format_description;
 use time::OffsetDateTime;
 
@@ -78,23 +78,23 @@ impl FromStr for uniqueness {
 }
 
 /// Trace capabilities
-#[derive(Debug, Copy, Clone, StructOpt)]
-#[structopt(name = "examples", about = "Usage instructions")]
+#[derive(Debug, Copy, Clone, Parser)]
+#[clap(name = "examples", about = "Usage instructions")]
 struct Command {
     /// verbose: include non-audit checks
-    #[structopt(short, long)]
+    #[clap(short, long)]
     verbose: bool,
     /// only trace <pid>
-    #[structopt(short, long, default_value = "0")]
+    #[clap(short, long, default_value = "0")]
     pid: u32,
     /// extra fields: Show TID and INSETID columns
-    #[structopt(short = "x", long = "extra")]
+    #[clap(short = 'x', long = "extra")]
     extra_fields: bool,
     /// don't repeat same info for the same <pid> or <cgroup>
-    #[structopt(long = "unique", default_value = "off")]
+    #[clap(long = "unique", default_value = "off")]
     unique_type: uniqueness,
     /// debug output for libbpf-rs
-    #[structopt(long)]
+    #[clap(long)]
     debug: bool,
 }
 
@@ -170,7 +170,7 @@ fn handle_lost_events(cpu: i32, count: u64) {
 }
 
 fn main() -> Result<()> {
-    let opts = Command::from_args();
+    let opts = Command::parse();
 
     let mut skel_builder = CapableSkelBuilder::default();
     if opts.debug {

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
-structopt = "0.3"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"]}
+clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -3,9 +3,9 @@
 use core::time::Duration;
 
 use anyhow::{bail, Result};
+use clap::Parser;
 use libbpf_rs::PerfBufferBuilder;
 use plain::Plain;
-use structopt::StructOpt;
 use time::macros::format_description;
 use time::OffsetDateTime;
 
@@ -14,19 +14,19 @@ mod runqslower;
 use runqslower::*;
 
 /// Trace high run queue latency
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Command {
     /// Trace latency higher than this value
-    #[structopt(default_value = "10000")]
+    #[clap(default_value = "10000")]
     latency: u64,
     /// Process PID to trace
-    #[structopt(default_value = "0")]
+    #[clap(default_value = "0")]
     pid: i32,
     /// Thread TID to trace
-    #[structopt(default_value = "0")]
+    #[clap(default_value = "0")]
     tid: i32,
     /// Verbose debug output
-    #[structopt(short, long)]
+    #[clap(short, long)]
     verbose: bool,
 }
 
@@ -73,7 +73,7 @@ fn handle_lost_events(cpu: i32, count: u64) {
 }
 
 fn main() -> Result<()> {
-    let opts = Command::from_args();
+    let opts = Command::parse();
 
     let mut skel_builder = RunqslowerSkelBuilder::default();
     if opts.verbose {

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
-structopt = "0.3"
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
+clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -1,37 +1,37 @@
 use anyhow::{bail, Result};
+use clap::Parser;
 use libbpf_rs::{
     MapFlags, TcHookBuilder, TC_CUSTOM, TC_EGRESS, TC_H_CLSACT, TC_H_MIN_INGRESS, TC_INGRESS,
 };
-use structopt::StructOpt;
 
 #[path = "bpf/.output/tc.skel.rs"]
 mod tc;
 use tc::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Command {
     /// list of ports to whitelist
-    #[structopt(short = "p", long = "ports")]
+    #[clap(short, long)]
     ports: Vec<u16>,
 
     /// attach a hook
-    #[structopt(short = "a", long = "attach")]
+    #[clap(short, long)]
     attach: bool,
 
     /// detach existing hook
-    #[structopt(short = "d", long = "detach")]
+    #[clap(short, long)]
     detach: bool,
 
     /// destroy all hooks on clsact
-    #[structopt(short = "D", long = "destroy")]
+    #[clap(short = 'D', long = "destroy")]
     destroy: bool,
 
     /// query existing hook
-    #[structopt(short = "q", long = "query")]
+    #[clap(short, long)]
     query: bool,
 
     /// interface to attach to
-    #[structopt(short = "i", long = "interface")]
+    #[clap(short = 'i', long = "interface")]
     iface: String,
 }
 
@@ -48,7 +48,7 @@ fn bump_memlock_rlimit() -> Result<()> {
     Ok(())
 }
 fn main() -> Result<()> {
-    let opts = Command::from_args();
+    let opts = Command::parse();
 
     bump_memlock_rlimit()?;
 

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -40,9 +40,9 @@ scroll_derive = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3"
 tempfile = "3.3"
 thiserror = "1.0"
+clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [dev-dependencies]
 goblin = "0.4"

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::{AppSettings, Parser, Subcommand};
 
 mod btf;
 #[doc(hidden)]
@@ -11,9 +11,12 @@ mod make;
 mod metadata;
 
 #[doc(hidden)]
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
+#[clap(version, about)]
+#[clap(propagate_version = true)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Opt {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     wrapper: Wrapper,
 }
 
@@ -28,42 +31,41 @@ struct Opt {
 //
 // so we must have a dummy subcommand here to eat the arg.
 #[doc(hidden)]
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum Wrapper {
+    #[clap(subcommand)]
     Libbpf(Command),
 }
 
-#[doc(hidden)]
-#[derive(Debug, StructOpt)]
-#[structopt(verbatim_doc_comment)]
-///
 /// cargo-libbpf is a cargo subcommand that helps develop and build eBPF (BPF) programs.
+#[doc(hidden)]
+#[derive(Debug, Subcommand)]
 enum Command {
     /// Build bpf programs
     Build {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         debug: bool,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to clang binary
         clang_path: Option<PathBuf>,
-        #[structopt(long)]
+        #[clap(long)]
         /// Skip clang version checks
         skip_clang_version_checks: bool,
     },
     /// Generate skeleton files
     Gen {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         debug: bool,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to rustfmt binary
         rustfmt_path: Option<PathBuf>,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Generate skeleton for the specified object file and print results to stdout
         ///
         /// When specified, skeletons for the rest of the project will not be generated
@@ -71,25 +73,25 @@ enum Command {
     },
     /// Build project
     Make {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         debug: bool,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to clang binary
         clang_path: Option<PathBuf>,
-        #[structopt(long)]
+        #[clap(long)]
         /// Skip clang version checks
         skip_clang_version_checks: bool,
-        #[structopt(short, long)]
+        #[clap(short, long)]
         /// Quiet output
         quiet: bool,
         /// Arguments to pass to `cargo build`
         ///
         /// Example: cargo libbpf build -- --package mypackage
         cargo_build_args: Vec<String>,
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         /// Path to rustfmt binary
         rustfmt_path: Option<PathBuf>,
     },
@@ -97,7 +99,7 @@ enum Command {
 
 #[doc(hidden)]
 fn main() -> Result<()> {
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
 
     match opts.wrapper {
         Wrapper::Libbpf(cmd) => match cmd {


### PR DESCRIPTION
As stated in the [docs](https://github.com/TeXitoi/structopt/blob/master/README.md#maintenance): structopt is now in maintenance mode.

This PR migrates to use the new [clap derive](https://github.com/clap-rs/clap/tree/master/clap_derive) functionality that has an almost identical interface.
I have updated and compiled all of the examples to ensure they are still working as expected.

Signed-off-by: Dan Bond <danbond@protonmail.com>