### PR TITLE
libbpf-cargo: Add open_opts method for SkelBuilder.

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -716,6 +716,22 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
                     skel_config
                 }})
             }}
+
+            pub fn open_opts(self, open_opts: libbpf_sys::bpf_object_open_opts) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
+                let mut skel_config = build_skel_config()?;
+
+                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), &open_opts) }};
+                if ret != 0 {{
+                    return Err(libbpf_rs::Error::System(-ret));
+                }}
+
+                let obj = unsafe {{ libbpf_rs::OpenObject::from_ptr(skel_config.object_ptr())? }};
+
+                Ok(Open{name}Skel {{
+                    obj,
+                    skel_config
+                }})
+            }}
         }}
         "#,
         name = obj_name

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -36,8 +36,7 @@ impl ObjectBuilder {
         self
     }
 
-    /// Used for skeleton -- an end user may not consider this API stable
-    #[doc(hidden)]
+    /// Get an instance of libbpf_sys::bpf_object_open_opts.
     pub fn opts(&mut self, name: *const c_char) -> libbpf_sys::bpf_object_open_opts {
         libbpf_sys::bpf_object_open_opts {
             sz: mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,


### PR DESCRIPTION
SkelBuilder only has the open method, and we can't easily pass in parameters like btf_custom_path.

Therefore, this commit adds the open_opts method for SkelBuilder. Developers can obtain an instance of libbpf_sys::bpf_object_open_opts through obj_builder.opts(std::ptr::null()), and then set the btf_custom_path parameter.

Signed-off-by: Shuyi Cheng <chengshuyi@linux.alibaba.com>