### PR TITLE
libbpf-cargo: add fn open_with_btf_custom_path for SkelBuilder

### DIFF
--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -716,6 +716,24 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
                     skel_config
                 }})
             }}
+
+            pub fn open_with_btf_custom_path(mut self, btf_custom_path: &str) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
+                let mut skel_config = build_skel_config()?;
+                let mut open_opts = self.obj_builder.opts(std::ptr::null());
+                let btf_custom_path_ptr = btf_custom_path.as_ptr() as *const i8;
+                open_opts.btf_custom_path = btf_custom_path_ptr;
+                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), &open_opts) }};
+                if ret != 0 {{
+                    return Err(libbpf_rs::Error::System(-ret));
+                }}
+
+                let obj = unsafe {{ libbpf_rs::OpenObject::from_ptr(skel_config.object_ptr())? }};
+
+                Ok(Open{name}Skel {{
+                    obj,
+                    skel_config
+                }})
+            }}
         }}
         "#,
         name = obj_name


### PR DESCRIPTION
add fn open_with_btf_custom_path for SkelBuilder

Temporarily resolved the problem that custom BTF files cannot be sent parameters.
#231 