### PR TITLE
Minor updates for libbpf-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "0.7.1+v0.7.0"
+version = "0.8.0+v0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f827f39ef9181560ee49c82bbdc8e8441c56404f62dc6eef1384113fd4c268"
+checksum = "28195d30a1fc5355743db9921a188bb393bb9c67a37fcefa00106dcaf6e5fd80"
 dependencies = [
  "cc",
  "pkg-config",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.14"
-libbpf-sys = { version = "0.7.1" }
+libbpf-sys = { version = "0.8.0" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = "1.5"

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -23,6 +23,7 @@ pub enum BtfKind {
     Datasec = 15,
     Float = 16,
     DeclTag = 17,
+    TypeTag = 18,
 }
 
 #[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
@@ -176,6 +177,12 @@ pub struct BtfDeclTag<'a> {
     pub component_idx: i32,
 }
 
+#[derive(Debug)]
+pub struct BtfTypeTag<'a> {
+    pub name: &'a str,
+    pub type_id: u32,
+}
+
 pub enum BtfType<'a> {
     Void,
     Int(BtfInt<'a>),
@@ -195,6 +202,7 @@ pub enum BtfType<'a> {
     Datasec(BtfDatasec<'a>),
     Float(BtfFloat<'a>),
     DeclTag(BtfDeclTag<'a>),
+    TypeTag(BtfTypeTag<'a>),
 }
 
 impl<'a> BtfType<'a> {
@@ -218,6 +226,7 @@ impl<'a> BtfType<'a> {
             BtfType::Datasec(_) => BtfKind::Datasec,
             BtfType::Float(_) => BtfKind::Float,
             BtfType::DeclTag(_) => BtfKind::DeclTag,
+            BtfType::TypeTag(_) => BtfKind::TypeTag,
         }
     }
 }
@@ -243,6 +252,7 @@ impl<'a> fmt::Display for BtfType<'a> {
             BtfType::Datasec(_) => write!(f, "datasec"),
             BtfType::Float(_) => write!(f, "float"),
             BtfType::DeclTag(_) => write!(f, "decltag"),
+            BtfType::TypeTag(_) => write!(f, "typetag"),
         }
     }
 }

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -21,7 +21,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 bitflags = "1.3"
 lazy_static = "1.4"
-libbpf-sys = { version = "0.7.1" }
+libbpf-sys = { version = "0.8.0" }
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.23"

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -207,7 +207,7 @@ impl Program {
     }
 
     pub fn prog_type(&self) -> ProgramType {
-        match ProgramType::try_from(unsafe { libbpf_sys::bpf_program__get_type(self.ptr) }) {
+        match ProgramType::try_from(unsafe { libbpf_sys::bpf_program__type(self.ptr) }) {
             Ok(ty) => ty,
             Err(_) => ProgramType::Unknown,
         }
@@ -225,7 +225,7 @@ impl Program {
 
     pub fn attach_type(&self) -> ProgramAttachType {
         match ProgramAttachType::try_from(unsafe {
-            libbpf_sys::bpf_program__get_expected_attach_type(self.ptr)
+            libbpf_sys::bpf_program__expected_attach_type(self.ptr)
         }) {
             Ok(ty) => ty,
             Err(_) => ProgramAttachType::Unknown,


### PR DESCRIPTION
* Update libbpf-sys to v0.8.0
* Replace deprecated libbpf APIs
* Add Btf::get_kind for libbpf-cargo
* Add support for BTF_KIND_TYPE_TAG