### PR TITLE
libbpf-cargo: allow user to set _TARGET_ARCH flag though clang_args.

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -111,26 +111,36 @@ fn check_clang(debug: bool, clang: &Path, skip_version_checks: bool) -> Result<(
 ///
 /// for each prog.
 fn compile_one(debug: bool, source: &Path, out: &Path, clang: &Path, options: &str) -> Result<()> {
-    let arch = match std::env::consts::ARCH {
-        "x86_64" => "x86",
-        "aarch64" => "arm64",
-        _ => std::env::consts::ARCH,
-    };
-
     if debug {
         println!("Building {}", source.display());
     }
 
     let mut cmd = Command::new(clang.as_os_str());
+    let mut arch_set = false;
+
+    // When doing cross-compile, user may set -D__TARGET_ARCH_<arch> in clang_args.
     if !options.is_empty() {
         cmd.args(options.split_whitespace());
+
+        if options.contains("-D__TARGET_ARCH_") {
+            arch_set = true;
+        }
     }
+
+    if !arch_set {
+        let arch = match std::env::consts::ARCH {
+            "x86_64" => "x86",
+            "aarch64" => "arm64",
+            _ => std::env::consts::ARCH,
+        };
+        cmd.arg(format!("-D__TARGET_ARCH_{}", arch));
+    }
+
     cmd.arg("-g")
         .arg("-O2")
         .arg("-target")
         .arg("bpf")
         .arg("-c")
-        .arg(format!("-D__TARGET_ARCH_{}", arch))
         .arg(source.as_os_str())
         .arg("-o")
         .arg(out);


### PR DESCRIPTION
When doing cross-compile such as compiling bpf programs for arm64 on a
x86_64 PC like following:

	cargo build --target aarch64-unknown-linux-gnu --release

_TARGET_ARCH should be the target one (arm64) instead of the one of the
build host (x86).

In this case, cross-compile user may set _TARGET_ARCH him/herself though
clang_args. This commit skip setting _TARGET_ARCH when found it in
clang_args.