### PR TITLE
Expose libbpf-sys' static feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,11 +19,13 @@ jobs:
         components: rustfmt, clippy
         override: true
     - name: Install deps
-      run: sudo apt-get install -y clang-12 libelf-dev
+      run: sudo apt-get install -y clang-12 libelf-dev zlib1g-dev
     - name: Symlink clang
       run: sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-12 /bin/clang
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
+    - name: Build capable example with static libelf and libz
+      run: RUSTFLAGS='-L /usr/lib/x86_64-linux-gnu' cargo b --package capable --features=static
     - name: Run tests
       # Skip BTF tests which require sudo
       # Skip BTF dump float test for now, we can enable it when we have access to clang 13+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "0.8.0+v0.8.0"
+version = "0.8.1+v0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28195d30a1fc5355743db9921a188bb393bb9c67a37fcefa00106dcaf6e5fd80"
+checksum = "4c7e278968e49b5a174d1e47c6c8ef3e6922c439343644af1cb27a98928914a1"
 dependencies = [
  "cc",
  "pkg-config",

--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -15,3 +15,6 @@ clap = { version = "3.1", default-features = false, features = ["std", "derive"]
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
+
+[features]
+static = ["libbpf-rs/static"]

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.14"
-libbpf-sys = { version = "0.8.0" }
+libbpf-sys = { version = "0.8.1" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = "1.5"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -17,11 +17,12 @@ maintenance = { status = "actively-developed" }
 # When turned on, link against system-installed libbpf instead of building
 # and linking against vendored libbpf sources
 novendor = ["libbpf-sys/novendor"]
+static = ["libbpf-sys/static"]
 
 [dependencies]
 bitflags = "1.3"
 lazy_static = "1.4"
-libbpf-sys = { version = "0.8.0" }
+libbpf-sys = { version = "0.8.1" }
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.23"


### PR DESCRIPTION
To statically link elfutils and libz. Tested on [rbperf](https://github.com/javierhonduco/rbperf) compiled with `RUSTFLAGS="-L /usr/lib -L /usr/lib64" cargo b`

**With the feature disabled (the default)**

```
[javierhonduco@fedora rbperf]$ ldd target/debug/rbperf
        linux-vdso.so.1 (0x00007fffa8de3000)
        libelf.so.1 => /lib/libelf.so.1 (0x00007ff9a5727000)
        libz.so.1 => /lib64/libz.so.1 (0x00007ff9a570d000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007ff9a56ed000)
        libm.so.6 => /lib64/libm.so.6 (0x00007ff9a560f000)
        libc.so.6 => /lib64/libc.so.6 (0x00007ff9a540e000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff9a5fa2000)
```

**With the static feature**
```
[javierhonduco@fedora rbperf]$ ldd target/debug/rbperf
        linux-vdso.so.1 (0x00007ffc5ed6a000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007ff391800000)
        libm.so.6 => /lib64/libm.so.6 (0x00007ff391722000)
        libc.so.6 => /lib64/libc.so.6 (0x00007ff391521000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff392098000)
```