### PR TITLE
map: Implement more open map setters

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -42,6 +42,21 @@ impl OpenMap {
         util::parse_ret(ret)
     }
 
+    pub fn set_type(&mut self, ty: MapType) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_map__set_type(self.ptr, ty as u32) };
+        util::parse_ret(ret)
+    }
+
+    pub fn set_key_size(&mut self, size: u32) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_map__set_key_size(self.ptr, size) };
+        util::parse_ret(ret)
+    }
+
+    pub fn set_value_size(&mut self, size: u32) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_map__set_value_size(self.ptr, size) };
+        util::parse_ret(ret)
+    }
+
     pub fn set_max_entries(&mut self, count: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_max_entries(self.ptr, count) };
         util::parse_ret(ret)


### PR DESCRIPTION
This PR exposes libbpf's `set_type`, `set_key_size`, and `
set_value_size`.

The reason why this can be useful is, for example, while migrating an
application that uses perf buffers to ring buffers, while maintaining
backwards compatibility for systems that don't have BPF ring buffers
yet.

In this program, only one map called events is created, and before
loading the program and creating the maps, we modify its type, as well
as other parameters.

```rust
let mut maps = open_skel.maps_mut();
let events = maps.events();

if options.use_ringbuf {
    events.set_type(MapType::RingBuf).unwrap();
    events.set_key_size(0).unwrap();
    events.set_value_size(0).unwrap();
    events.set_max_entries(1024).unwrap();
} else {
    events.set_type(MapType::PerfEventArray).unwrap();
    events.set_key_size(4).unwrap();
    events.set_value_size(4).unwrap();
    events.set_max_entries(0).unwrap();
}
```

On the BPF-side a similar pattern is followed where depending on whether
buffer is used, we send the event with the `bpf_ringbuf_output` or
`bpf_perf_event_output` helper

Thanks,

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>
