### PR TITLE
libbpf-cargo: update regex to 0.16.0 to mitigate DoS vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -34,7 +34,7 @@ cargo_metadata = "0.14"
 libbpf-sys = { version = "0.8.1" }
 memmap2 = "0.5"
 num_enum = "0.5"
-regex = "1.5"
+regex = "1.6.0"
 scroll = "0.11"
 scroll_derive = "0.11"
 semver = "1.0"


### PR DESCRIPTION
As described in
https://github.com/libbpf/libbpf-rs/security/dependabot/1, there are DoS
vulnerabilities associated with regex version 1.5

This commit updates the regex version to 1.6.0

Signed-off-by: Joanne Koong <joannekoong@gmail.com>