### PR TITLE
libbpf-rs: Add wrapper for ringbuffer__epoll_fd

### DIFF
--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -146,6 +146,13 @@ impl<'a> RingBuffer<'a> {
 
         util::parse_ret(ret)
     }
+
+    /// Get an fd that can be used to sleep until data is available
+    pub fn epoll_fd(&self) -> i32 {
+        assert!(!self.ptr.is_null());
+
+        unsafe { libbpf_sys::ring_buffer__epoll_fd(self.ptr) }
+    }
 }
 
 impl<'a> Drop for RingBuffer<'a> {


### PR DESCRIPTION
As part of the initiative to reach feature-parity with libbpf-1.0, this
commit adds a wrapper for the ringbuffer__epoll_fd API.