### PR TITLE
Fix cargo clippy warnings

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -603,7 +603,7 @@ impl<'a> Btf<'a> {
                         }
                     }
 
-                    writeln!(def, r#"#[derive(Debug, Copy, Clone, PartialEq)]"#)?;
+                    writeln!(def, r#"#[derive(Debug, Copy, Clone, PartialEq, Eq)]"#)?;
                     writeln!(
                         def,
                         r#"#[repr({signed}{repr_size})]"#,

--- a/libbpf-cargo/src/btf/types.rs
+++ b/libbpf-cargo/src/btf/types.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use num_enum::TryFromPrimitive;
 
-#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq, Eq)]
 #[repr(u32)]
 pub enum BtfKind {
     Void = 0,
@@ -26,7 +26,7 @@ pub enum BtfKind {
     TypeTag = 18,
 }
 
-#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum BtfIntEncoding {
     None = 0,
@@ -84,7 +84,7 @@ pub struct BtfEnum<'a> {
     pub values: Vec<BtfEnumValue<'a>>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BtfFwdKind {
     Struct,
     Union,
@@ -135,7 +135,7 @@ pub struct BtfFuncProto<'a> {
     pub params: Vec<BtfFuncParam<'a>>,
 }
 
-#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, PartialEq, Eq)]
 #[repr(u32)]
 pub enum BtfVarLinkage {
     Static = 0,

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -689,7 +689,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     // Open bpf_object so we can iterate over maps and progs
     let file = File::open(obj_file_path)?;
     let mmap = unsafe { Mmap::map(&file)? };
-    let object = open_bpf_object(&libbpf_obj_name, &*mmap)?;
+    let object = open_bpf_object(&libbpf_obj_name, &mmap)?;
 
     gen_skel_c_skel_constructor(&mut skel, object, &libbpf_obj_name)?;
 
@@ -743,7 +743,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     gen_skel_map_defs(&mut skel, object, &obj_name, true, true)?;
     gen_skel_prog_defs(&mut skel, object, &obj_name, true, false)?;
     gen_skel_prog_defs(&mut skel, object, &obj_name, true, true)?;
-    gen_skel_datasec_defs(&mut skel, raw_obj_name, &*mmap)?;
+    gen_skel_datasec_defs(&mut skel, raw_obj_name, &mmap)?;
 
     write!(
         skel,
@@ -819,7 +819,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     writeln!(skel, "}}")?;
 
     // Coerce to &[u8] just to be safe, as we'll be using debug formatting
-    let bytes: &[u8] = &*mmap;
+    let bytes: &[u8] = &mmap;
     write!(
         skel,
         r#"

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1397,7 +1397,7 @@ enum Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u32)]
 pub enum Foo {
     Zero = 0,
@@ -1992,7 +1992,7 @@ struct Foo foo;
 pub struct Foo {
     pub test: __anon_1,
 }
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u32)]
 pub enum __anon_1 {
     FOO = 1,

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -573,7 +573,7 @@ bitflags! {
 // If you add a new per-cpu map, also update `is_percpu`.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, TryFromPrimitive, IntoPrimitive, PartialEq, Display)]
+#[derive(Clone, TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Display)]
 pub enum MapType {
     Unspec = 0,
     Hash,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 
 use crate::*;
 
+type Cb<'a> = Box<dyn FnMut(&[u8]) -> i32 + 'a>;
 struct RingBufferCallback<'a> {
-    cb: Box<dyn FnMut(&[u8]) -> i32 + 'a>,
+    cb: Cb<'a>,
 }
 
 impl<'a> RingBufferCallback<'a> {


### PR DESCRIPTION
These include warnings such as:

warning: you are deriving `PartialEq` and can implement `Eq`
   --> libbpf-rs/src/map.rs:576:50
    |
576 | #[derive(Clone, TryFromPrimitive, IntoPrimitive, PartialEq,
Display)]
    |                                                  ^^^^^^^^^ help:
consider deriving `Eq` as well: `PartialEq, Eq`
    |
    = note: `#[warn(clippy::derive_partial_eq_without_eq)]` on by
default
    = help: for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

warning: very complex type used. Consider factoring parts into `type`
definitions
  --> libbpf-rs/src/ringbuf.rs:11:9
   |
11 |     cb: Box<dyn FnMut(&[u8]) -> i32 + 'a>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(clippy::type_complexity)]` on by default
   = help: for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity

warning: deref which would be done by auto-deref
   --> libbpf-cargo/src/gen.rs:692:53
    |
692 |     let object = open_bpf_object(&libbpf_obj_name, &*mmap)?;
    |                                                     ^^^^^ help:
try this: `mmap`
    |
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default
    = help: for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref