### PR TITLE
Update to libbpf-sys v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "0.8.1+v0.8.0"
+version = "1.0.0+v1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e278968e49b5a174d1e47c6c8ef3e6922c439343644af1cb27a98928914a1"
+checksum = "1ac3b57422fd2678ecbcff6961dcb7caa4d5004191a7deac071a40082d5772b6"
 dependencies = [
  "cc",
  "pkg-config",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.14"
-libbpf-sys = { version = "0.8.1" }
+libbpf-sys = { version = "1.0.0" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = "1.6.0"

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -157,8 +157,7 @@ fn get_prog_name(prog: *const libbpf_sys::bpf_program) -> Result<String> {
 }
 
 fn map_is_mmapable(map: *const libbpf_sys::bpf_map) -> bool {
-    let def = unsafe { libbpf_sys::bpf_map__def(map) };
-    (unsafe { (*def).map_flags } & libbpf_sys::BPF_F_MMAPABLE) > 0
+    (unsafe { libbpf_sys::bpf_map__map_flags(map) } & libbpf_sys::BPF_F_MMAPABLE) > 0
 }
 
 fn map_is_datasec(map: *const libbpf_sys::bpf_map) -> bool {
@@ -170,10 +169,9 @@ fn map_is_datasec(map: *const libbpf_sys::bpf_map) -> bool {
 
 fn map_is_readonly(map: *const libbpf_sys::bpf_map) -> bool {
     assert!(map_is_mmapable(map));
-    let def = unsafe { libbpf_sys::bpf_map__def(map) };
 
     // BPF_F_RDONLY_PROG means readonly from prog side
-    (unsafe { (*def).map_flags } & libbpf_sys::BPF_F_RDONLY_PROG) > 0
+    (unsafe { libbpf_sys::bpf_map__map_flags(map) } & libbpf_sys::BPF_F_RDONLY_PROG) > 0
 }
 
 fn gen_skel_c_skel_constructor(

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -22,7 +22,7 @@ static = ["libbpf-sys/static"]
 [dependencies]
 bitflags = "1.3"
 lazy_static = "1.4"
-libbpf-sys = { version = "0.8.1" }
+libbpf-sys = { version = "1.0.0" }
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.23"

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -42,17 +42,13 @@ impl ObjectBuilder {
             sz: mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
             object_name: name,
             relaxed_maps: self.relaxed_maps,
-            relaxed_core_relocs: false,
             pin_root_path: ptr::null(),
-            attach_prog_fd: 0,
             kconfig: ptr::null(),
             btf_custom_path: ptr::null(),
-            __bindgen_padding_0: <[u8; 6]>::default(),
-            __bindgen_padding_1: <[u8; 4]>::default(),
             kernel_log_buf: ptr::null_mut(),
             kernel_log_size: 0,
             kernel_log_level: 0,
-            __bindgen_padding_2: <[u8; 4]>::default(),
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
v1!

libbpf-sys release tag: [v1.0.0](https://github.com/libbpf/libbpf-sys/releases/tag/1.0.0%2Bv1.0.0)

Outside of updating the dependency, other changes:

* libbpf-rs: Remove use of deprecated bpf_object_open_opts fields [0]

* libbpf-cargo: Remove use of deprecated bpf_map__def call [1]

[0] https://github.com/libbpf/libbpf/commit/d8454ba8ad83514a5afc6e3d05bddb61f299d5f4#diff-ecec02d2345e3666818b41e879a7e9242acbd0575f20f796b2d8b7fe0cf2841bL127
[1] https://github.com/libbpf/libbpf/commit/d8454ba8ad83514a5afc6e3d05bddb61f299d5f4#diff-ac82747bd450e8e5e0805a99d6c24afa9fcbfcddffbce5aa3288b2edabe17419L9776

Signed-off-by: Milan Landaverde <milan@mdaverde.com>