### PR TITLE
libbpf-rs: Add derive(Debug) to query-related structs and enums

### DIFF
--- a/libbpf-rs/src/iter.rs
+++ b/libbpf-rs/src/iter.rs
@@ -9,6 +9,7 @@ use crate::*;
 /// This implements [`std::io::Read`] for reading bytes from the iterator.
 /// Methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
+#[derive(Debug)]
 pub struct Iter {
     fd: i32,
 }

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -66,6 +66,8 @@
 //!
 //! [See example here](https://github.com/libbpf/libbpf-rs/tree/master/examples/runqslower).
 
+#![warn(missing_debug_implementations)]
+
 mod error;
 mod iter;
 mod link;

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -6,6 +6,7 @@ use crate::*;
 ///
 /// This struct is used to model ownership. The underlying program will be detached
 /// when this object is dropped if nothing else is holding a reference count.
+#[allow(missing_debug_implementations)]
 pub struct Link {
     ptr: *mut libbpf_sys::bpf_link,
 }

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -573,7 +573,7 @@ bitflags! {
 // If you add a new per-cpu map, also update `is_percpu`.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Display)]
+#[derive(Clone, TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Display, Debug)]
 pub enum MapType {
     Unspec = 0,
     Hash,

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -17,6 +17,7 @@ use crate::*;
 ///
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
+#[allow(missing_debug_implementations)]
 pub struct OpenMap {
     ptr: *mut libbpf_sys::bpf_map,
 }
@@ -123,6 +124,7 @@ impl OpenMap {
 ///
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
+#[allow(missing_debug_implementations)]
 pub struct Map {
     fd: i32,
     name: String,
@@ -625,6 +627,7 @@ impl MapType {
     }
 }
 
+#[allow(missing_debug_implementations)]
 pub struct MapKeyIter<'a> {
     map: &'a Map,
     prev: Option<Vec<u8>>,

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, ffi::CStr, mem, os::raw::c_char, path::Path, ptr
 use crate::{util, *};
 
 /// Builder for creating an [`OpenObject`]. Typically the entry point into libbpf-rs.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ObjectBuilder {
     name: String,
     relaxed_maps: bool,
@@ -117,6 +117,7 @@ impl ObjectBuilder {
 /// Represents an opened (but not yet loaded) BPF object file.
 ///
 /// Use this object to access [`OpenMap`]s and [`OpenProgram`]s.
+#[allow(missing_debug_implementations)]
 pub struct OpenObject {
     ptr: *mut libbpf_sys::bpf_object,
     maps: HashMap<String, OpenMap>,
@@ -290,6 +291,7 @@ impl Drop for OpenObject {
 ///
 /// Note that this is an explanation of the motivation -- Rust's lifetime system should already be
 /// enforcing this invariant.
+#[allow(missing_debug_implementations)]
 pub struct Object {
     ptr: *mut libbpf_sys::bpf_object,
     maps: HashMap<String, Map>,

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -18,12 +18,14 @@ impl<T> SampleCb for T where T: FnMut(i32, &[u8]) {}
 pub trait LostCb: FnMut(i32, u64) {}
 impl<T> LostCb for T where T: FnMut(i32, u64) {}
 
+#[allow(missing_debug_implementations)]
 struct CbStruct<'b> {
     sample_cb: Option<Box<dyn SampleCb + 'b>>,
     lost_cb: Option<Box<dyn LostCb + 'b>>,
 }
 
 /// Builds [`PerfBuffer`] instances.
+#[allow(missing_debug_implementations)]
 pub struct PerfBufferBuilder<'a, 'b> {
     map: &'a Map,
     pages: usize,
@@ -150,6 +152,7 @@ impl<'a, 'b> PerfBufferBuilder<'a, 'b> {
 
 /// Represents a special kind of [`Map`]. Typically used to transfer data between
 /// [`Program`]s and userspace.
+#[allow(missing_debug_implementations)]
 pub struct PerfBuffer<'b> {
     ptr: *mut libbpf_sys::perf_buffer,
     // Hold onto the box so it'll get dropped when PerfBuffer is dropped

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -90,7 +90,7 @@ impl OpenProgram {
 /// Type of a [`Program`]. Maps to `enum bpf_prog_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, TryFromPrimitive, Display)]
+#[derive(Clone, TryFromPrimitive, Display, Debug)]
 pub enum ProgramType {
     Unspec = 0,
     SocketFilter,
@@ -131,7 +131,7 @@ pub enum ProgramType {
 /// Attach type of a [`Program`]. Maps to `enum bpf_attach_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, TryFromPrimitive, Display)]
+#[derive(Clone, TryFromPrimitive, Display, Debug)]
 pub enum ProgramAttachType {
     CgroupInetIngress,
     CgroupInetEgress,

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -10,6 +10,7 @@ use crate::*;
 /// Represents a parsed but not yet loaded BPF program.
 ///
 /// This object exposes operations that need to happen before the program is loaded.
+#[allow(missing_debug_implementations)]
 pub struct OpenProgram {
     ptr: *mut libbpf_sys::bpf_program,
     section: String,
@@ -186,6 +187,7 @@ pub enum ProgramAttachType {
 ///
 /// If you attempt to attach a `Program` with the wrong attach method, the `attach_*`
 /// method will fail with the appropriate error.
+#[allow(missing_debug_implementations)]
 pub struct Program {
     pub(crate) ptr: *mut libbpf_sys::bpf_program,
     name: String,

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -26,7 +26,7 @@ macro_rules! gen_info_impl {
     ($(#[$attr:meta])*
      $name:ident, $info_ty:ty, $uapi_info_ty:ty, $next_id:expr, $fd_by_id:expr) => {
         $(#[$attr])*
-        #[derive(Default)]
+        #[derive(Default, Debug)]
         pub struct $name {
             cur_id: u32,
         }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -99,6 +99,7 @@ fn name_arr_to_string(a: &[c_char], default: &str) -> String {
 }
 
 /// Information about a BPF program
+#[derive(Debug)]
 pub struct ProgramInfo {
     pub name: String,
     pub ty: ProgramType,
@@ -194,6 +195,7 @@ gen_info_impl!(
 );
 
 /// Information about a BPF map
+#[derive(Debug)]
 pub struct MapInfo {
     pub name: String,
     pub ty: MapType,
@@ -248,6 +250,7 @@ gen_info_impl!(
 );
 
 /// Information about BPF type format
+#[derive(Debug)]
 pub struct BtfInfo {
     pub btf: u64,
     pub btf_size: u32,
@@ -273,24 +276,29 @@ gen_info_impl!(
     libbpf_sys::bpf_btf_get_fd_by_id
 );
 
+#[derive(Debug)]
 pub struct RawTracepointLinkInfo {
     pub name: String,
 }
 
+#[derive(Debug)]
 pub struct TracingLinkInfo {
     pub attach_type: ProgramAttachType,
 }
 
+#[derive(Debug)]
 pub struct CgroupLinkInfo {
     pub cgroup_id: u64,
     pub attach_type: ProgramAttachType,
 }
 
+#[derive(Debug)]
 pub struct NetNsLinkInfo {
     pub ino: u32,
     pub attach_type: ProgramAttachType,
 }
 
+#[derive(Debug)]
 pub enum LinkTypeInfo {
     RawTracepoint(RawTracepointLinkInfo),
     Tracing(TracingLinkInfo),
@@ -301,6 +309,7 @@ pub enum LinkTypeInfo {
 }
 
 /// Information about a BPF link
+#[derive(Debug)]
 pub struct LinkInfo {
     pub info: LinkTypeInfo,
     pub id: u32,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 use crate::*;
 
 type Cb<'a> = Box<dyn FnMut(&[u8]) -> i32 + 'a>;
+
+#[allow(missing_debug_implementations)]
 struct RingBufferCallback<'a> {
     cb: Cb<'a>,
 }
@@ -27,6 +29,7 @@ impl<'a> RingBufferCallback<'a> {
 /// [`Program`]s and userspace.  As of Linux 5.8, the `ringbuf` map is now
 /// preferred over the `perf buffer`.
 #[derive(Default)]
+#[allow(missing_debug_implementations)]
 pub struct RingBufferBuilder<'a> {
     fd_callbacks: Vec<(i32, RingBufferCallback<'a>)>,
 }
@@ -119,6 +122,7 @@ impl<'a> RingBufferBuilder<'a> {
 /// `ringbuf`s are a special kind of [`Map`], used to transfer data between
 /// [`Program`]s and userspace.  As of Linux 5.8, the `ringbuf` map is now
 /// preferred over the `perf buffer`.
+#[allow(missing_debug_implementations)]
 pub struct RingBuffer<'a> {
     ptr: *mut libbpf_sys::ring_buffer,
     #[allow(clippy::vec_box)]

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -14,18 +14,21 @@ use libbpf_sys::{
 use crate::util;
 use crate::*;
 
+#[allow(missing_debug_implementations)]
 struct MapSkelConfig {
     name: String,
     p: Box<*mut bpf_map>,
     mmaped: Option<Box<*mut c_void>>,
 }
 
+#[allow(missing_debug_implementations)]
 struct ProgSkelConfig {
     name: String,
     p: Box<*mut bpf_program>,
     link: Box<*mut bpf_link>,
 }
 
+#[allow(missing_debug_implementations)]
 pub struct ObjectSkeletonConfigBuilder<'a> {
     data: &'a [u8],
     p: Box<*mut bpf_object>,
@@ -203,6 +206,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 /// * free any allocated memory on drop
 ///
 /// This struct can be moved around at will. Upon drop, all allocated resources will be freed
+#[allow(missing_debug_implementations)]
 pub struct ObjectSkeletonConfig<'a> {
     inner: bpf_object_skeleton,
     obj: Box<*mut bpf_object>,


### PR DESCRIPTION
This is a simple quality-of-life improvement to make it a bit easier to use and discover the library.

```
fn main() {
    for prog in libbpf_rs::query::ProgInfoIter::default() {
        println!("{:#?}", prog);
    }
    for prog in libbpf_rs::query::LinkInfoIter::default() {
        println!("{:#?}", prog);
    }
    for prog in libbpf_rs::query::MapInfoIter::default() {
        println!("{:#?}", prog);
    }
}
```