### PR TITLE
Update minimum supported Rust version from 1.56 to 1.58

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # Please adjust README when bumping version.
-        rust: [stable, 1.56.0]
+        rust: [stable, 1.58.1]
     steps:
     - uses: actions/checkout@v2
     - name: Install Rust

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.56+-blue.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.58.1+-blue.svg)](https://blog.rust-lang.org/2022/01/20/Rust-1.58.1.html)
 
 WARNING: The API is not stable and is subject to breakage. Any breakage will
 include a minor version bump pre-1.0 and a major version bump post-1.0.


### PR DESCRIPTION
Version 1.58 is the minimum version that supports using captured identifiers in format strings, which is used within the libbpf-rs codebase.

This patch upgrades the minimum Rust version from 1.56 to 1.58.