### PR TITLE
Update checkout and toolchain actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
         # Please adjust README when bumping version.
         rust: [stable, 1.58.1]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v1.0.6
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}


### PR DESCRIPTION
GitHub is complaining about usage of old Node.js on every GitHub Actions run:
> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout,
> actions-rs/toolchain, actions/checkout

Update the actions in question to get rid of those warnings.

Signed-off-by: Daniel Müller <deso@posteo.net>