### PR TITLE
libbpf-cargo:  fix cargo clippy warnings in test

### DIFF
--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1033,7 +1033,7 @@ fn build_btf_prog(prog_text: &str) -> Btf {
         .open(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path())
         .expect("failed to open object file");
     let mmap = unsafe { Mmap::map(&obj) }.expect("Failed to mmap object file");
-    let btf = Btf::new("prog", &*mmap)
+    let btf = Btf::new("prog", &mmap)
         .expect("Failed to initialize Btf")
         .expect("Did not find .BTF section");
 


### PR DESCRIPTION
The clippy will show error when checking:

error: deref which would be done by auto-deref
    --> libbpf-cargo/src/test.rs:1036:32
     |
1036 |     let btf = Btf::new("prog", &*mmap)
     |                                ^^^^^^ help: try this: `&mmap`
     |
     = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`

see the CI in #285. 