### PR TITLE
Update time crate dependency to 0.3.15

### DIFF
--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -10,7 +10,7 @@ libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 phf = { version = "0.10", features = ["macros"] }
 plain = "0.2"
-time = { version = "0.3", features = ["formatting", "local-offset", "macros"]}
+time = { version = "=0.3.15", features = ["formatting", "local-offset", "macros"]}
 clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
-time = { version = "0.3", features = ["formatting", "local-offset", "macros"]}
+time = { version = "=0.3.15", features = ["formatting", "local-offset", "macros"]}
 clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]


### PR DESCRIPTION
In libbpf-rs, the minimum supported Rust version is 1.59. libbpf-rs triggers builds in CI for version 1.59.

The latest compatible candidate version of the time crate in 1.59 is 0.3.15.

Without this change, the time crate may be upgraded to versions beyond 0.3.15, which will trigger a build failure for version 1.59.