### PR TITLE
Enforce minimum Rust version from Cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Please adjust README when bumping version.
+        # Please adjust README and rust-version field in Cargo.toml files when
+        # bumping version.
         rust: [stable, 1.59.0, nightly]
     steps:
     - name: "Set environmental variables"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 version = "0.13.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 edition = "2021"
+rust-version = "1.59"
 license = "LGPL-2.1 OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,6 +7,7 @@ readme = "../README.md"
 version = "0.19.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 edition = "2021"
+rust-version = "1.59"
 license = "LGPL-2.1 OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 


### PR DESCRIPTION
Compilation problems caused by unsupported Rust features due to an old toolchain can be confusing. They also make it non-obvious what the minimum Rust version to upgrade to is.
Starting with Rust 1.56, Cargo honors the rust-version field [0] that causes it to fail compilation with a meaningful error message if the toolchain is not recent enough.
Set it for libbpf-rs and libbpf-cargo to have nicer errors reported to users in case of old toolchain usage.

[0] https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

Signed-off-by: Daniel Müller <deso@posteo.net>