### PR TITLE
Fix libbpf-rs path detection in tests

### DIFF
--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -96,16 +96,14 @@ fn validate_bpf_o(path: &Path) {
 }
 
 /// Returns the path to the local libbpf-rs
-///
-/// Warning: hacky! But necessary to run tests. We assume that the current working directory is
-/// libbpf-cargo project root. Hopefully this is a cargo-provided invariant. I tried using the
-/// file!() macro but it returns a relative path and seems even hackier to make work.
 fn get_libbpf_rs_path() -> PathBuf {
-    let cwd = std::env::current_dir().expect("failed to get cwd");
+    // The `CARGO_MANIFEST_DIR` environment variable points to the
+    // libbpf-cargo directory, at build time.
+    let libcargo_dir = env!("CARGO_MANIFEST_DIR");
 
-    Path::new(&cwd)
+    Path::new(&libcargo_dir)
         .parent()
-        .expect("failed to get parent of cwd")
+        .expect("failed to get parent of libbpf-cargo directory")
         .join("libbpf-rs")
         .canonicalize()
         .expect("failed to canonicalize libbpf-rs")


### PR DESCRIPTION
The libbpf-rs path detection in tests is broken. It's only working when run from the libbpf-cargo/ sub-directory, otherwise (including when run from the project root!) we get non-descriptive failures at runtime:

  > ---- test::test_skeleton_datasec stdout ----
  > Metadata for package=proj
  >         null
  > Found bpf progs to compile:
  >         UnprocessedObj { package: "proj", path: "/tmp/.tmpnoGGx9/proj/src/bpf/prog.bpf.c", out: "/tmp/.tmpnoGGx9/proj/target/bpf", name: "prog" }
  > Building /tmp/.tmpnoGGx9/proj/src/bpf/prog.bpf.c
  > Metadata for package=proj
  >         null
  > Found bpf objs to gen skel:
  >         UnprocessedObj { package: "proj", path: "/tmp/.tmpnoGGx9/proj/src/bpf/prog.bpf.c", out: "/tmp/.tmpnoGGx9/proj/target/bpf", name: "prog" }
  > thread 'test::test_skeleton_datasec' panicked at 'assertion failed: status.success()', libbpf-cargo/src/test.rs:661:5

Fix this problem by storing the path to libbpf-cargo at build time. Given that the path is absolute (at least in my testing), the binary can now also be freely moved around (even relative to the source code).

Signed-off-by: Daniel Müller <deso@posteo.net>