### PR TITLE
Run CI on push events

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,6 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -655,7 +655,7 @@ fn test_object_map_create_and_pin() {
 
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
-        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as u32,
+        map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
         btf_fd: 0,
         btf_key_type_id: 0,
         btf_value_type_id: 0,
@@ -707,7 +707,7 @@ fn test_object_map_create_without_name() {
 
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
-        map_flags: libbpf_sys::BPF_F_NO_PREALLOC as u32,
+        map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
         btf_fd: 0,
         btf_key_type_id: 0,
         btf_value_type_id: 0,


### PR DESCRIPTION
CI should really run on all pushes, or it is super cumbersome to test change quickly. Adjust the workflow accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>