### PR TITLE
Stop using assert_eq! in assert_definition() helper function

### DIFF
--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1060,7 +1060,7 @@ fn assert_definition(btf: &Btf, btf_item: u32, expected_output: &str) {
     println!("-------------");
     println!("{}", ao);
 
-    assert_eq!(eo, ao);
+    assert!(eo == ao);
 }
 
 #[test]


### PR DESCRIPTION
We have the assert_definition() helper for comparing actual output to expected output, panicking if the two don't match. The function takes care of printing the actual and expected output in nicely formatted form to stdout before performing the equality check (and, thus, irrespective of its outcome).
Currently, if the equality comparison done via assert_eq! macro fails we end up printing the expected and actual output *again*, but this time without formatting it properly (no interpretation of newline characters, for example).
Stop using assert_eq! in favor of assert!, which will only indicate the check that caused a panic (on assertion failure), but does not print actual and expected output, resulting in less confusing data on test failure.

Signed-off-by: Daniel Müller <deso@posteo.net>