### PR TITLE
Stop alignment truncation

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -702,18 +702,9 @@ impl Btf {
         let align = if packed {
             1
         } else {
-            // Assume 32-bit alignment in case we're generating code for 32-bit
-            // arch. Worst case is on a 64-bit arch the compiler will generate
-            // extra padding. The final layout will still be identical to what is
-            // described by BTF.
             let a = self.align_of(type_id)? as usize;
             ensure!(a != 0, "Failed to get alignment of type_id: {}", type_id);
-
-            if a > 4 {
-                4
-            } else {
-                a
-            }
+            a
         };
 
         // If we aren't aligning to the natural offset, padding needs to be inserted

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1199,7 +1199,6 @@ pub struct Foo {
     pub ip: *mut i32,
     pub ipp: *mut *mut i32,
     pub bar: Bar,
-    __pad_18: [u8; 6],
     pub pb: *mut Bar,
     pub v: u64,
     pub cv: i64,
@@ -1253,7 +1252,6 @@ pub struct Foo {
     pub ip: *mut i32,
     pub ipp: *mut *mut i32,
     pub bar: Bar,
-    __pad_84: [u8; 4],
     pub pb: *mut Bar,
     pub v: u64,
     pub cv: i64,
@@ -1764,7 +1762,6 @@ struct Foo foo;
 pub struct Foo {
     pub x: i32,
     pub bar: __anon_1,
-    __pad_36: [u8; 4],
     pub baz: __anon_2,
     pub w: i32,
 }
@@ -1855,7 +1852,6 @@ pub struct __anon_1 {
 #[repr(C)]
 pub struct __anon_2 {
     pub w: u32,
-    __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 "#;
@@ -1907,7 +1903,6 @@ pub struct Foo {
     pub zerg: __anon_2,
     pub baz: __anon_3,
     pub w: i32,
-    __pad_76: [u8; 4],
     pub flarg: __anon_4,
 }
 #[derive(Debug, Default, Copy, Clone)]
@@ -1938,7 +1933,6 @@ impl Default for __anon_2 {
 #[repr(C)]
 pub struct __anon_3 {
     pub w: u32,
-    __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 #[derive(Copy, Clone)]
@@ -2083,7 +2077,6 @@ struct bpf_sock_tuple_5_15 tup;
 #[repr(C)]
 pub struct bpf_sock_tuple_5_15 {
     pub __anon_1: __anon_1,
-    __pad_36: [u8; 4],
     pub __anon_4: __anon_4,
 }
 #[derive(Copy, Clone)]


### PR DESCRIPTION
The Rust code generation logic contains some alignment truncation logic -- limiting reported alignment to four on all systems -- whose purpose is unclear and the associated comment describes what is being done but not why. History of that logic is a single commit [0] importing the world.
The logic causes a bunch of padding to be added to Rust definitions that is not present when dumping the same BTF object in C (using bpftool, for example), making it unnecessary hard to compare emitted definitions.
Remove it. I was unable to find similar code in the Linux BTF and C code generation logic and have verified that bpftool does not emit padding for any of the types affected in tests [1].

[0] https://github.com/libbpf/libbpf-rs/commit/1f0be0fb192e61ee21b77325df5d6e2c1df78dd0 [1] https://gist.github.com/danielocfb/89e8bd7f28b5283ac94891984ff1742a

Signed-off-by: Daniel Müller <deso@posteo.net>