### PR TITLE
Add necessary padding to overall struct type size

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -880,6 +880,18 @@ impl Btf {
                         agg_content.push(format!(r#"    pub {}: {},"#, field_name, field_ty_str));
                     }
 
+                    if t.is_struct {
+                        let struct_size = t.size as usize;
+                        let padding =
+                            self.required_padding(offset, struct_size, type_id, packed)?;
+                        if padding != 0 {
+                            agg_content.push(format!(r#"    __pad_{offset}: [u8; {padding}],"#,));
+                            impl_default.push(format!(
+                                r#"            __pad_{offset}: [u8::default(); {padding}]"#,
+                            ));
+                        }
+                    }
+
                     if !gen_impl_default && t.is_struct {
                         writeln!(def, r#"#[derive(Debug, Default, Copy, Clone)]"#)?;
                     } else if t.is_struct {

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1111,6 +1111,34 @@ pub struct Foo {
 }
 
 #[test]
+fn test_btf_dump_align() {
+    let prog_text = r#"
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct Foo {
+    int x;
+} __attribute__((aligned(16)));
+
+struct Foo foo = {1};
+"#;
+
+    let expected_output = r#"
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct Foo {
+    pub x: i32,
+    __pad_4: [u8; 12],
+}
+"#;
+
+    let btf = build_btf_prog(prog_text);
+    let struct_foo = find_type_in_btf!(btf, Struct, "Foo");
+
+    assert_definition(&btf, struct_foo, expected_output);
+}
+
+#[test]
 fn test_btf_dump_basic_long_array() {
     let prog_text = r#"
 #include "vmlinux.h"
@@ -1767,6 +1795,7 @@ pub struct Foo {
     __pad_36: [u8; 4],
     pub baz: __anon_2,
     pub w: i32,
+    __pad_52: [u8; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -1844,6 +1873,7 @@ pub struct Foo {
     pub bar: __anon_1,
     pub baz: __anon_2,
     pub w: i32,
+    __pad_68: [u8; 4],
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
When a C struct is defined with greater-than-natural alignment (by tagging it with the respective attribute), our emitted Rust types end up being incorrect and not necessarily matching kernel types. The problem is that while we support adding padding between members as necessary, we do not make sure to pad to the BTF defined type size (which is how alignment is conveyed via BTF).
Let's ensure we pad up to this size, to ensure better (well, hopefully perfect...) match up between generated types and kernel definitions.

Fixes: #270

Signed-off-by: Daniel Müller <deso@posteo.net>