### PR TITLE
Revert Changes to compile against libbpf-sys 1.1.0, update to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.0.3+v1.0.1"
+version = "1.1.1+v1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376d23644bd8f7ec2ebf1b07f9d8e6a46989bae201c6ee378b0cd486fafc0624"
+checksum = "9f0bfc74513824996a8f689cae8b40445c9a54bc9f57a31d9778b281b9970868"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.1.0+v1.1.0"
+version = "1.0.3+v1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88258828dee5eef841bc7ffa1547bff112cb15870e4287be4e367d37cd4f75d"
+checksum = "376d23644bd8f7ec2ebf1b07f9d8e6a46989bae201c6ee378b0cd486fafc0624"
 dependencies = [
  "cc",
  "pkg-config",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -32,7 +32,7 @@ novendor = ["libbpf-sys/novendor"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.14"
-libbpf-sys = { version = "1.1.0" }
+libbpf-sys = { version = "1.0.3" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -5,7 +5,7 @@ use std::ffi::{c_void, CStr, CString};
 use std::fmt::Write;
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_ulong};
 use std::ptr;
 use std::slice;
 
@@ -375,14 +375,14 @@ impl Btf {
     pub fn new(name: &str, object_file: &[u8]) -> Result<Option<Self>> {
         let cname = CString::new(name)?;
         let obj_opts = libbpf_sys::bpf_object_open_opts {
-            sz: std::mem::size_of::<libbpf_sys::bpf_object_open_opts>(),
+            sz: std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
             object_name: cname.as_ptr(),
             ..Default::default()
         };
         let bpf_obj = unsafe {
             libbpf_sys::bpf_object__open_mem(
                 object_file.as_ptr() as *const c_void,
-                object_file.len(),
+                object_file.len() as c_ulong,
                 &obj_opts,
             )
         };

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -23,7 +23,7 @@ static = ["libbpf-sys/static"]
 [dependencies]
 bitflags = "1.3"
 lazy_static = "1.4"
-libbpf-sys = { version = "1.1.0" }
+libbpf-sys = { version = "1.0.3" }
 nix = { version = "0.24", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.23"

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -57,7 +57,7 @@ impl OpenMap {
             libbpf_sys::bpf_map__set_initial_value(
                 self.ptr,
                 data.as_ptr() as *const std::ffi::c_void,
-                data.len(),
+                data.len() as libbpf_sys::size_t,
             )
         };
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -39,7 +39,7 @@ impl ObjectBuilder {
     /// Get an instance of libbpf_sys::bpf_object_open_opts.
     pub fn opts(&mut self, name: *const c_char) -> libbpf_sys::bpf_object_open_opts {
         libbpf_sys::bpf_object_open_opts {
-            sz: mem::size_of::<libbpf_sys::bpf_object_open_opts>(),
+            sz: mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
             object_name: name,
             relaxed_maps: self.relaxed_maps,
             pin_root_path: ptr::null(),
@@ -97,7 +97,11 @@ impl ObjectBuilder {
         let opts = self.opts(name_ptr);
 
         let obj = unsafe {
-            libbpf_sys::bpf_object__open_mem(mem.as_ptr() as *const c_void, mem.len(), &opts)
+            libbpf_sys::bpf_object__open_mem(
+                mem.as_ptr() as *const c_void,
+                mem.len() as libbpf_sys::size_t,
+                &opts,
+            )
         };
         let err = unsafe { libbpf_sys::libbpf_get_error(obj as *const _) };
         if err != 0 {

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -113,7 +113,7 @@ impl<'a, 'b> PerfBufferBuilder<'a, 'b> {
         let ptr = unsafe {
             libbpf_sys::perf_buffer__new(
                 self.map.fd(),
-                self.pages,
+                self.pages as libbpf_sys::size_t,
                 c_sample_cb,
                 c_lost_cb,
                 callback_struct_ptr as *mut _,
@@ -175,16 +175,19 @@ impl<'b> PerfBuffer<'b> {
     }
 
     pub fn consume_buffer(&self, buf_idx: usize) -> Result<()> {
-        let ret = unsafe { libbpf_sys::perf_buffer__consume_buffer(self.ptr, buf_idx) };
+        let ret = unsafe {
+            libbpf_sys::perf_buffer__consume_buffer(self.ptr, buf_idx as libbpf_sys::size_t)
+        };
         util::parse_ret(ret)
     }
 
     pub fn buffer_cnt(&self) -> usize {
-        unsafe { libbpf_sys::perf_buffer__buffer_cnt(self.ptr) }
+        unsafe { libbpf_sys::perf_buffer__buffer_cnt(self.ptr) as usize }
     }
 
     pub fn buffer_fd(&self, buf_idx: usize) -> Result<i32> {
-        let ret = unsafe { libbpf_sys::perf_buffer__buffer_fd(self.ptr, buf_idx) };
+        let ret =
+            unsafe { libbpf_sys::perf_buffer__buffer_fd(self.ptr, buf_idx as libbpf_sys::size_t) };
         util::parse_ret_i32(ret)
     }
 }

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -105,7 +105,7 @@ impl OpenProgram {
     /// So [`OpenProgram::insn_cnt`] and [`Program::insn_cnt`] may return different values.
     ///
     pub fn insn_cnt(&self) -> usize {
-        unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr) }
+        unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr) as usize }
     }
 
     /// Gives read-only access to BPF program's underlying BPF instructions.
@@ -374,7 +374,13 @@ impl Program {
         let path = util::path_to_cstring(binary_path.as_ref())?;
         let path_ptr = path.as_ptr();
         let ptr = unsafe {
-            libbpf_sys::bpf_program__attach_uprobe(self.ptr, retprobe, pid, path_ptr, func_offset)
+            libbpf_sys::bpf_program__attach_uprobe(
+                self.ptr,
+                retprobe,
+                pid,
+                path_ptr,
+                func_offset as libbpf_sys::size_t,
+            )
         };
         let err = unsafe { libbpf_sys::libbpf_get_error(ptr as *const _) };
         if err != 0 {
@@ -520,7 +526,7 @@ impl Program {
     ///
     /// Please see note in [`OpenProgram::insn_cnt`].
     pub fn insn_cnt(&self) -> usize {
-        unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr) }
+        unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr) as usize }
     }
 
     /// Gives read-only access to BPF program's underlying BPF instructions.

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_void;
 use std::boxed::Box;
+use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
 use std::time::Duration;
@@ -109,11 +110,11 @@ impl<'a> RingBufferBuilder<'a> {
         Ok(RingBuffer { ptr, _cbs: cbs })
     }
 
-    unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: usize) -> i32 {
+    unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: c_ulong) -> i32 {
         let callback_struct = ctx as *mut RingBufferCallback;
         let callback = (*callback_struct).cb.as_mut();
 
-        callback(slice::from_raw_parts(data as *const u8, size))
+        callback(slice::from_raw_parts(data as *const u8, size as usize))
     }
 }
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -3,7 +3,7 @@ use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::boxed::Box;
 use std::ffi::CString;
 use std::mem::size_of;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_ulong};
 use std::ptr;
 
 use libbpf_sys::{
@@ -169,7 +169,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
         let mut string_pool = Vec::new();
 
         let mut s = libbpf_sys::bpf_object_skeleton {
-            sz: size_of::<bpf_object_skeleton>(),
+            sz: size_of::<bpf_object_skeleton>() as c_ulong,
             ..Default::default()
         };
 
@@ -179,7 +179,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 
         // libbpf_sys will use it as const despite the signature
         s.data = self.data.as_ptr() as *mut c_void;
-        s.data_sz = self.data.len();
+        s.data_sz = self.data.len() as c_ulong;
 
         s.obj = &mut *self.p;
 

--- a/libbpf-rs/src/tc.rs
+++ b/libbpf-rs/src/tc.rs
@@ -58,8 +58,8 @@ impl TcHook {
             opts: libbpf_sys::bpf_tc_opts::default(),
         };
 
-        tc_hook.hook.sz = std::mem::size_of::<libbpf_sys::bpf_tc_hook>();
-        tc_hook.opts.sz = std::mem::size_of::<libbpf_sys::bpf_tc_opts>();
+        tc_hook.hook.sz = std::mem::size_of::<libbpf_sys::bpf_tc_hook>() as libbpf_sys::size_t;
+        tc_hook.opts.sz = std::mem::size_of::<libbpf_sys::bpf_tc_opts>() as libbpf_sys::size_t;
         tc_hook.opts.prog_fd = fd;
 
         tc_hook

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -658,7 +658,7 @@ fn test_object_map_create_and_pin() {
     bump_rlimit_mlock();
 
     let opts = libbpf_sys::bpf_map_create_opts {
-        sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>(),
+        sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
         map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
         btf_fd: 0,
         btf_key_type_id: 0,
@@ -710,7 +710,7 @@ fn test_object_map_create_without_name() {
     bump_rlimit_mlock();
 
     let opts = libbpf_sys::bpf_map_create_opts {
-        sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>(),
+        sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
         map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
         btf_fd: 0,
         btf_key_type_id: 0,


### PR DESCRIPTION
Changes which fixed libbpf-sys compile breakage for 1.1.0 now cause breaks against 1.1.1.

These two commits fix those issues.