### PR TITLE
Provide Debug impl for remaining public types

### DIFF
--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use crate::*;
@@ -6,7 +7,7 @@ use crate::*;
 ///
 /// This struct is used to model ownership. The underlying program will be detached
 /// when this object is dropped if nothing else is holding a reference count.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct Link {
     ptr: *mut libbpf_sys::bpf_link,
 }
@@ -48,7 +49,7 @@ impl Link {
     /// Release "ownership" of underlying BPF resource (typically, a BPF program
     /// attached to some BPF hook, e.g., tracepoint, kprobe, etc). Disconnected
     /// links, when destructed through bpf_link__destroy() call won't attempt to
-    /// detach/unregisted that BPF resource. This is useful in situations where,
+    /// detach/unregistered that BPF resource. This is useful in situations where,
     /// say, attached BPF program has to outlive userspace program that attached it
     /// in the system. Depending on type of BPF program, though, there might be
     /// additional steps (like pinning BPF program in BPF FS) necessary to ensure

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1,6 +1,7 @@
 use core::ffi::c_void;
 use std::convert::TryFrom;
 use std::ffi::CStr;
+use std::fmt::Debug;
 use std::path::Path;
 use std::ptr;
 use std::ptr::null;
@@ -18,7 +19,7 @@ use crate::*;
 ///
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct OpenMap {
     ptr: *mut libbpf_sys::bpf_map,
 }
@@ -145,7 +146,7 @@ impl OpenMap {
 ///
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct Map {
     fd: i32,
     name: String,
@@ -668,7 +669,7 @@ impl MapType {
     }
 }
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct MapKeyIter<'a> {
     map: &'a Map,
     prev: Option<Vec<u8>>,

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -115,7 +115,7 @@ impl ObjectBuilder {
 /// Represents an opened (but not yet loaded) BPF object file.
 ///
 /// Use this object to access [`OpenMap`]s and [`OpenProgram`]s.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct OpenObject {
     ptr: *mut libbpf_sys::bpf_object,
     maps: HashMap<String, OpenMap>,
@@ -290,7 +290,7 @@ impl Drop for OpenObject {
 ///
 /// Note that this is an explanation of the motivation -- Rust's lifetime system should already be
 /// enforcing this invariant.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct Object {
     ptr: *mut libbpf_sys::bpf_object,
     maps: HashMap<String, Map>,

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// Represents a parsed but not yet loaded BPF program.
 ///
 /// This object exposes operations that need to happen before the program is loaded.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct OpenProgram {
     ptr: *mut libbpf_sys::bpf_program,
     section: String,
@@ -258,7 +258,7 @@ pub enum ProgramAttachType {
 ///
 /// If you attempt to attach a `Program` with the wrong attach method, the `attach_*`
 /// method will fail with the appropriate error.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct Program {
     pub(crate) ptr: *mut libbpf_sys::bpf_program,
     name: String,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -1,5 +1,9 @@
 use core::ffi::c_void;
 use std::boxed::Box;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::ops::Deref as _;
 use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
@@ -9,7 +13,6 @@ use crate::*;
 
 type Cb<'a> = Box<dyn FnMut(&[u8]) -> i32 + 'a>;
 
-#[allow(missing_debug_implementations)]
 struct RingBufferCallback<'a> {
     cb: Cb<'a>,
 }
@@ -23,13 +26,21 @@ impl<'a> RingBufferCallback<'a> {
     }
 }
 
+impl Debug for RingBufferCallback<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let Self { cb } = self;
+        f.debug_struct("RingBufferCallback")
+            .field("cb", &(cb.deref() as *const _))
+            .finish()
+    }
+}
+
 /// Builds [`RingBuffer`] instances.
 ///
 /// `ringbuf`s are a special kind of [`Map`], used to transfer data between
 /// [`Program`]s and userspace.  As of Linux 5.8, the `ringbuf` map is now
 /// preferred over the `perf buffer`.
-#[derive(Default)]
-#[allow(missing_debug_implementations)]
+#[derive(Debug, Default)]
 pub struct RingBufferBuilder<'a> {
     fd_callbacks: Vec<(i32, RingBufferCallback<'a>)>,
 }
@@ -123,7 +134,7 @@ impl<'a> RingBufferBuilder<'a> {
 /// `ringbuf`s are a special kind of [`Map`], used to transfer data between
 /// [`Program`]s and userspace.  As of Linux 5.8, the `ringbuf` map is now
 /// preferred over the `perf buffer`.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct RingBuffer<'a> {
     ptr: *mut libbpf_sys::ring_buffer,
     #[allow(clippy::vec_box)]

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -14,21 +14,21 @@ use libbpf_sys::{
 use crate::util;
 use crate::*;
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 struct MapSkelConfig {
     name: String,
     p: Box<*mut bpf_map>,
     mmaped: Option<Box<*mut c_void>>,
 }
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 struct ProgSkelConfig {
     name: String,
     p: Box<*mut bpf_program>,
     link: Box<*mut bpf_link>,
 }
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct ObjectSkeletonConfigBuilder<'a> {
     data: &'a [u8],
     p: Box<*mut bpf_object>,
@@ -206,7 +206,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 /// * free any allocated memory on drop
 ///
 /// This struct can be moved around at will. Upon drop, all allocated resources will be freed
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct ObjectSkeletonConfig<'a> {
     inner: bpf_object_skeleton,
     obj: Box<*mut bpf_object>,


### PR DESCRIPTION
It is generally considered good practice to implement Debug on all public types of a crate [[0]][0] [[1]][1], in order to facilitate easier debugging by users.
Let's do just that for our remaining types that don't do it yet.

[0] https://rust-lang.github.io/api-guidelines/debuggability.html [1] https://rust-lang.github.io/api-guidelines/checklist.html

Closes: #260
Signed-off-by: Daniel Müller <deso@posteo.net>