### PR TITLE
Split CI into more independently running jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,11 +58,20 @@ jobs:
     - name: Run BTF tests
       run: cd libbpf-rs && cargo test --verbose -- test_object test_tc
     - if: ${{ matrix.rust != 'nightly' }}
-      name: Run rustfmt
-      run: cargo fmt --package libbpf-cargo libbpf-rs -- --check
-    - if: ${{ matrix.rust != 'nightly' }}
       name: Run clippy
       run: cargo clippy --tests -- -D warnings
+  rustfmt:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - run: cargo fmt --package libbpf-cargo libbpf-rs -- --check
   cargo-doc:
     name: Check documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,13 +50,24 @@ jobs:
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
-    - name: Build capable example with static libelf and libz
-      run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --package capable --features=static
     - name: Run tests
       # Skip BTF tests which require sudo
       run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc
     - name: Run BTF tests
       run: cd libbpf-rs && cargo test --verbose -- test_object test_tc
+  build-capable:
+    name: Build capable example with static libelf and libz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get install -y libelf-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --package capable --features=static
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,8 +63,18 @@ jobs:
     - if: ${{ matrix.rust != 'nightly' }}
       name: Run clippy
       run: cargo clippy --tests -- -D warnings
-    - if: ${{ matrix.rust != 'nightly' }}
-      name: Check documentation
-      env:
-        RUSTDOCFLAGS: '-D warnings'
-      run: cargo doc --no-deps
+  cargo-doc:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: '-D warnings'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get install -y libelf-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo doc --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,13 +45,13 @@ jobs:
         components: rustfmt
         override: true
     - name: Install deps
-      run: sudo apt-get install -y clang-14 libelf-dev zlib1g-dev
-    - name: Symlink clang
-      run: sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
+      run: |
+        sudo apt-get install -y clang-14 libelf-dev zlib1g-dev
+        sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
     - name: Build capable example with static libelf and libz
-      run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo b --package capable --features=static
+      run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --package capable --features=static
     - name: Run tests
       # Skip BTF tests which require sudo
       run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}
-        components: rustfmt, clippy
+        components: rustfmt
         override: true
     - name: Install deps
       run: sudo apt-get install -y clang-14 libelf-dev zlib1g-dev
@@ -57,9 +57,20 @@ jobs:
       run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc
     - name: Run BTF tests
       run: cd libbpf-rs && cargo test --verbose -- test_object test_tc
-    - if: ${{ matrix.rust != 'nightly' }}
-      name: Run clippy
-      run: cargo clippy --tests -- -D warnings
+  clippy:
+    name: Lint with clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get install -y libelf-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+      - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
Please see individual commits for descriptions, but as per my brief testing we:

> seem to be reducing total CI duration from somewhere between 7:20 minutes [0] and 9:30 minutes [1] down to about five minutes [2] while also reporting formatting and similar problems much earlier than beforehand.

[0] https://github.com/danielocfb/libbpf-rs/actions/runs/3913755036
[1] https://github.com/danielocfb/libbpf-rs/actions/runs/3906846913
[2] https://github.com/danielocfb/libbpf-rs/actions/runs/3915159222