### PR TITLE
Add license information bpf_query, runqslower, and tproxy examples

### DIFF
--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bpf_query"
 version = "0.1.0"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
+license = "LGPL-2.1 OR BSD-2-Clause"
 edition = "2021"
 
 [dependencies]

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -2,6 +2,7 @@
 name = "runqslower"
 version = "0.1.0"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
+license = "LGPL-2.1 OR BSD-2-Clause"
 edition = "2021"
 
 [dependencies]

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tproxy"
 version = "0.1.0"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
+license = "LGPL-2.1 OR BSD-2-Clause"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
It's not good style for us to have example code lying around without a license, to the point that it renders the example code completely useless, because it is unlikely to be safely reusable. This change proposes to license `bpf_query`, `runqslower`, and `tproxy` examples under `LGPL-2.1 OR BSD-2-Clause`, similar to the main library.

Signed-off-by: Daniel Müller <deso@posteo.net>