### PR TITLE
libbpf-rs: Implement `Send` for `PerfBuffer` and `RingBuffer`

### DIFF
--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -220,10 +220,30 @@ impl<'b> PerfBuffer<'b> {
     }
 }
 
-impl<'b> Drop for PerfBuffer<'b> {
+// SAFETY: `perf_buffer` objects can safely be polled from any thread.
+unsafe impl Send for PerfBuffer<'_> {}
+
+impl Drop for PerfBuffer<'_> {
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::perf_buffer__free(self.ptr);
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Check that `PerfBuffer` is `Send`.
+    #[test]
+    fn perfbuffer_is_send() {
+        fn test<T>()
+        where
+            T: Send,
+        {
+        }
+
+        test::<PerfBuffer>();
     }
 }


### PR DESCRIPTION
As per https://github.com/libbpf/libbpf-rs/issues/224#issuecomment-1119996446 ring buffers and perf buffers can be polled from any thread. Hence, it is safe for us to implement `Send` for the corresponding Rust types, `RingBuffer` and `PerfBuffer`.

Closes: #224
Signed-off-by: Daniel Müller <deso@posteo.net>