### PR TITLE
Add license information tc_port_whitelist example

### DIFF
--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tc_whitelist_ports"
 version = "0.1.0"
 authors = ["Michael Mullin <mimullin@blackberry.com>"]
+license = "LGPL-2.1 OR BSD-2-Clause"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
It's not good style for us to have example code lying around without a license, to the point that it renders the example code completely useless, because it is unlikely to be safely reusable. This change proposes to license tc_port_whitelist example under LGPL-2.1 OR BSD-2-Clause, similar to the main library.

Signed-off-by: Daniel Müller <deso@posteo.net>