### PR TITLE
Add license information to capable example

### DIFF
--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "capable"
 version = "0.1.0"
 authors = ["Devasia Thomas <https://www.linkedin.com/in/devasiathomas>"]
+license = "LGPL-2.1 OR BSD-2-Clause"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
It's not good style for us to have example code lying around without a license, to the point that it renders the example code completely useless, because it is unlikely to be safely reusable. This change proposes to license capable example under LGPL-2.1 OR BSD-2-Clause, similar to the main library.

Signed-off-by: Daniel Müller <deso@posteo.net>