### PR TITLE
libbpf-rs: Add BPF linker support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -108,9 +109,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -241,17 +242,21 @@ name = "libbpf-rs"
 version = "0.19.1"
 dependencies = [
  "bitflags",
+ "cc",
  "lazy_static",
  "libbpf-sys",
  "libc",
  "log",
  "nix 0.24.2",
  "num_enum",
+ "pkg-config",
  "plain",
  "probe",
  "scopeguard",
  "serial_test",
  "strum_macros",
+ "syn 0.15.44",
+ "tempfile",
  "thiserror",
  "vsprintf",
 ]
@@ -349,9 +354,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -430,9 +435,9 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -486,9 +491,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -498,8 +503,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "version_check",
 ]
 
@@ -508,6 +513,15 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -520,11 +534,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.47",
 ]
 
 [[package]]
@@ -642,9 +665,9 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -653,9 +676,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -682,9 +705,9 @@ version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -715,9 +738,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -739,10 +762,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "rustversion",
- "syn",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -751,8 +785,8 @@ version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "unicode-ident",
 ]
 
@@ -804,9 +838,9 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -859,6 +893,12 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "version_check"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -37,6 +37,7 @@ plain = "0.2.3"
 probe = "0.3"
 scopeguard = "1.1"
 serial_test = "0.5"
+tempfile = "3.3"
 
 # A set of unused dependencies that we require to force correct minimum versions
 # of transitive dependencies, for cases where our dependencies have incorrect

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -75,6 +75,7 @@
 mod error;
 mod iter;
 mod link;
+mod linker;
 mod map;
 mod object;
 mod perf_buffer;
@@ -93,6 +94,7 @@ pub use libbpf_sys;
 pub use crate::error::{Error, Result};
 pub use crate::iter::Iter;
 pub use crate::link::Link;
+pub use crate::linker::Linker;
 pub use crate::map::{Map, MapFlags, MapType, OpenMap};
 pub use crate::object::{Object, ObjectBuilder, OpenObject};
 pub use crate::perf_buffer::{PerfBuffer, PerfBufferBuilder};

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+use std::ptr::null_mut;
+
+use crate::util::path_to_cstring;
+use crate::Error;
+use crate::Result;
+
+/// A type used for linking multiple BPF object files into a single one.
+///
+/// Please refer to
+/// <https://lwn.net/ml/bpf/20210310040431.916483-6-andrii@kernel.org/> for
+/// additional details.
+#[derive(Debug)]
+pub struct Linker {
+    /// The `libbpf` linker object.
+    linker: *mut libbpf_sys::bpf_linker,
+}
+
+impl Linker {
+    /// Instantiate a `Linker` object.
+    pub fn new<P>(output: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let output = path_to_cstring(output)?;
+        let opts = null_mut();
+        // SAFETY: `output` is a valid pointer and `opts` is accepted as NULL.
+        let linker = unsafe { libbpf_sys::bpf_linker__new(output.as_ptr(), opts) };
+        // SAFETY: `libbpf_get_error` is always safe to call.
+        let err = unsafe { libbpf_sys::libbpf_get_error(linker as *const _) };
+        if err != 0 {
+            return Err(Error::System(err as i32));
+        }
+
+        let slf = Self { linker };
+        Ok(slf)
+    }
+
+    /// Add a file to the set of files to link.
+    pub fn add<P>(&mut self, file: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let file = path_to_cstring(file)?;
+        let opts = null_mut();
+        // SAFETY: `linker` and `file` are a valid pointers.
+        let err = unsafe { libbpf_sys::bpf_linker__add_file(self.linker, file.as_ptr(), opts) };
+        if err != 0 {
+            Err(Error::System(err))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Link all BPF object files [`add`](Self::add)ed to this object into a single one.
+    pub fn link(&self) -> Result<()> {
+        // SAFETY: `linker` is a valid pointer.
+        let err = unsafe { libbpf_sys::bpf_linker__finalize(self.linker) };
+        if err != 0 {
+            return Err(Error::System(err));
+        }
+        Ok(())
+    }
+}
+
+// SAFETY: `bpf_linker` can be sent to a different thread.
+unsafe impl Send for Linker {}
+
+impl Drop for Linker {
+    fn drop(&mut self) {
+        // SAFETY: `linker` is a valid pointer returned by `bpf_linker__new`.
+        unsafe { libbpf_sys::bpf_linker__free(self.linker) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Check that `Linker` is `Send`.
+    #[test]
+    fn linker_is_send() {
+        fn test<T>()
+        where
+            T: Send,
+        {
+        }
+
+        test::<Linker>();
+    }
+}


### PR DESCRIPTION
A while back libbpf got support for linking multiple BPF object files statically into a single one [0]. This functionality is useful in and off itself and should be exposed as such by this library, but it is also a suitable building block for ensuring deterministic skeleton creation [1] [2] [3].
As such, this change hooks it up. We mirror the libbpf APIs very closely, just packaging them up in a nicer Rust interface.

[0] https://lwn.net/ml/bpf/20210310040431.916483-6-andrii@kernel.org/ [1] https://github.com/libbpf/libbpf-rs/issues/177 [2] https://github.com/libbpf/libbpf-rs/issues/163 [3] https://github.com/libbpf/libbpf-rs/pull/169

Signed-off-by: Daniel Müller <deso@posteo.net>