### PR TITLE
libbpf-cargo: Strip DWARF information from generated object files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,13 +44,14 @@ jobs:
         override: true
     - name: Install deps
       run: |
-        sudo apt-get install -y clang-14 libelf-dev zlib1g-dev
+        sudo apt-get install -y clang-14 libelf-dev zlib1g-dev linux-headers-$(uname -r)
+        sudo ln -s /usr/include/asm-generic /usr/include/asm
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
     - name: Build
       run: cargo build --verbose --workspace --exclude runqslower
     - name: Run tests
       # Skip BTF tests which require sudo
-      run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc
+      run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc --include-ignored
     - name: Run BTF tests
       run: cd libbpf-rs && cargo test --verbose -- test_object test_tc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "goblin",
+ "libbpf-rs",
  "libbpf-sys",
  "memmap2",
  "num_enum",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,6 +33,7 @@ novendor = ["libbpf-sys/novendor"]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
 libbpf-sys = { version = "1.0.3" }
+libbpf-rs = { path = "../libbpf-rs" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -166,16 +166,16 @@ fn compile(debug: bool, objs: &[UnprocessedObj], clang: &Path, target_dir: &Path
     };
 
     for obj in objs {
-        let dest_name = if let Some(f) = obj.path.file_stem() {
-            let mut stem = f.to_os_string();
-            stem.push(".o");
-            stem
-        } else {
-            bail!(
+        let stem = obj.path.file_stem().with_context(|| {
+            format!(
                 "Could not calculate destination name for obj={}",
                 obj.path.display()
-            );
-        };
+            )
+        })?;
+
+        let mut dest_name = stem.to_os_string();
+        dest_name.push(".o");
+
         let mut dest_path = obj.out.to_path_buf();
         dest_path.push(&dest_name);
         fs::create_dir_all(&obj.out)?;

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -147,9 +147,7 @@ fn capitalize_first_letter(s: &str) -> String {
 
 fn get_raw_map_name(map: *const libbpf_sys::bpf_map) -> Result<String> {
     let name_ptr = unsafe { libbpf_sys::bpf_map__name(map) };
-    if name_ptr.is_null() {
-        bail!("Map name unknown");
-    }
+    ensure!(!name_ptr.is_null(), "Map name unknown");
 
     Ok(unsafe { CStr::from_ptr(name_ptr) }.to_str()?.to_string())
 }
@@ -182,10 +180,7 @@ fn get_map_name(map: *const libbpf_sys::bpf_map) -> Result<Option<String>> {
 
 fn get_prog_name(prog: *const libbpf_sys::bpf_program) -> Result<String> {
     let name_ptr = unsafe { libbpf_sys::bpf_program__name(prog) };
-
-    if name_ptr.is_null() {
-        bail!("Prog name unknown");
-    }
+    ensure!(!name_ptr.is_null(), "Prog name unknown");
 
     Ok(unsafe { CStr::from_ptr(name_ptr) }.to_str()?.to_string())
 }
@@ -615,9 +610,7 @@ fn open_bpf_object(name: &str, data: &[u8]) -> Result<BpfObj> {
             &obj_opts,
         )
     };
-    if object.is_null() {
-        bail!("Failed to bpf_object__open_mem()");
-    }
+    ensure!(!object.is_null(), "Failed to bpf_object__open_mem()");
 
     Ok(BpfObj(ptr::NonNull::new(object).unwrap()))
 }
@@ -857,9 +850,7 @@ fn gen_skel(
     out: OutputDest,
     rustfmt_path: Option<&PathBuf>,
 ) -> Result<()> {
-    if name.is_empty() {
-        bail!("Object file has no name");
-    }
+    ensure!(!name.is_empty(), "Object file has no name");
 
     let skel = gen_skel_contents(debug, name, obj)?;
     let skel = try_rustfmt(&skel, rustfmt_path)?;
@@ -946,9 +937,10 @@ pub fn gen_single(
 
     let name = match filename.to_str() {
         Some(n) => {
-            if !n.ends_with(".o") {
-                bail!("Object file does not have `.o` suffix: {}", n);
-            }
+            ensure!(
+                n.ends_with(".o"),
+                "Object file does not have `.o` suffix: {n}"
+            );
 
             n.split('.').next().unwrap()
         }


### PR DESCRIPTION
Clang generated BPF object files may contain DWARF information that
references paths to temporary directories, for example. That ends up
rendering our generated skeleton unstable, as it potentially changes
between invocations [0]. That can be unfortunate if the skeleton is
meant to be checked into version control.
Andrii suggested [1] stripping said DWARF information by linking the
object file, which strips it as a side effect. This change does so.

[0] https://github.com/libbpf/libbpf-rs/issues/163
[1] https://github.com/libbpf/libbpf-rs/pull/169#issuecomment-1006074629

Closes: https://github.com/libbpf/libbpf-rs/issues/177
Signed-off-by: Daniel Müller <deso@posteo.net>