### PR TITLE
Enabled Dependabot for automatically updating locked versions of dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    versioning-strategy: "lockfile-only"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Now that we have decoupled our minimum supported Rust version checks from `Cargo.lock` [0], we can easily keep dependency versions up-to-date. Doing so will make sure that we always release with the most recent dependencies, which may include bug and security fixes. It will also help with enabling cargo audit/deny [2], depending on what we audit.

This change enables Dependabot for doing so. It will scan for updated packages and open pull requests. I've tried it out on my fork [1] and it worked fine.

[0] https://github.com/libbpf/libbpf-rs/pull/318
[1] https://github.com/danielocfb/libbpf-rs/pull/2 [2] https://github.com/libbpf/libbpf-rs/issues/187

Signed-off-by: Daniel Müller <deso@posteo.net>