### PR TITLE
Ignore clippy lint warning for derive default

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -988,6 +988,9 @@ impl Btf {
 
                     // write an impl Default for this enum
                     if !t.values.is_empty() {
+                        // TODO: remove #[allow(clippy::derivable_impls)]
+                        //       once minimum rust at 1.62+
+                        writeln!(def, r#"#[allow(clippy::derivable_impls)]"#)?;
                         writeln!(def, r#"impl Default for {name} {{"#, name = t.name)?;
                         writeln!(def, r#"    fn default() -> Self {{"#)?;
                         writeln!(

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1480,6 +1480,7 @@ pub enum Foo {
     One = 1,
     seven = 7,
 }
+#[allow(clippy::derivable_impls)]
 impl Default for Foo {
     fn default() -> Self {
         Foo::Zero
@@ -2075,6 +2076,7 @@ pub struct Foo {
 pub enum __anon_1 {
     FOO = 1,
 }
+#[allow(clippy::derivable_impls)]
 impl Default for __anon_1 {
     fn default() -> Self {
         __anon_1::FOO


### PR DESCRIPTION
Rust version 1.62 made it possible to use #[derive(Default)] (see: https://github.com/rust-lang/rust/pull/94457)

As of rust version 1.68, the default clippy configuration will print a warning for manually impl Derive on enums. As such, users of libbpf-cargo will begin to experience clippy warnings when they migrate to version 1.68.

libbpf-cargo's minimum rust version is 1.58, thus the recommended method to remove the clippy warnings, is not yet an option for the project.

Add a #[allow(clippy::derivable_impls)], to suppress the clippy warning on all generated skeletons.
Add a TODO to remove this once the project moves to a minimum rust version of 1.62

Signed-off-by: Michael Mullin <mimullin@blackberry.com>