### PR TITLE
libbpf-rs: Few changes to recent patches

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -11,5 +11,5 @@ fn main() {
         .source(SRC)
         .build_and_generate(&out)
         .unwrap();
-    println!("cargo:rerun-if-changed={}", SRC);
+    println!("cargo:rerun-if-changed={SRC}");
 }

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -167,7 +167,7 @@ fn _handle_event(opts: Command, event: capable_bss_types::event) {
 }
 
 fn handle_lost_events(cpu: i32, count: u64) {
-    eprintln!("Lost {} events on CPU {}", count, cpu);
+    eprintln!("Lost {count} events on CPU {cpu}");
 }
 
 fn main() -> Result<()> {

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -11,5 +11,5 @@ fn main() {
         .source(SRC)
         .build_and_generate(&out)
         .unwrap();
-    println!("cargo:rerun-if-changed={}", SRC);
+    println!("cargo:rerun-if-changed={SRC}");
 }

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -71,7 +71,7 @@ fn handle_event(_cpu: i32, data: &[u8]) {
 }
 
 fn handle_lost_events(cpu: i32, count: u64) {
-    eprintln!("Lost {} events on CPU {}", count, cpu);
+    eprintln!("Lost {count} events on CPU {cpu}");
 }
 
 fn main() -> Result<()> {

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -11,5 +11,5 @@ fn main() {
         .source(SRC)
         .build_and_generate(&out)
         .unwrap();
-    println!("cargo:rerun-if-changed={}", SRC);
+    println!("cargo:rerun-if-changed={SRC}");
 }

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -80,28 +80,28 @@ fn main() -> Result<()> {
 
     if opts.query {
         match custom.query() {
-            Err(e) => println!("failed to find custom hook: {}", e),
-            Ok(prog_id) => println!("found custom hook prog_id: {}", prog_id),
+            Err(e) => println!("failed to find custom hook: {e}"),
+            Ok(prog_id) => println!("found custom hook prog_id: {prog_id}"),
         }
         match egress.query() {
-            Err(e) => println!("failed to find custom hook: {}", e),
-            Ok(prog_id) => println!("found custom hook prog_id: {}", prog_id),
+            Err(e) => println!("failed to find custom hook: {e}"),
+            Ok(prog_id) => println!("found custom hook prog_id: {prog_id}"),
         }
         match ingress.query() {
-            Err(e) => println!("failed to find custom hook: {}", e),
-            Ok(prog_id) => println!("found custom hook prog_id: {}", prog_id),
+            Err(e) => println!("failed to find custom hook: {e}"),
+            Ok(prog_id) => println!("found custom hook prog_id: {prog_id}"),
         }
     }
 
     if opts.detach {
         if let Err(e) = ingress.detach() {
-            println!("failed to detach ingress hook {}", e);
+            println!("failed to detach ingress hook {e}");
         }
         if let Err(e) = egress.detach() {
-            println!("failed to detach egress hook {}", e);
+            println!("failed to detach egress hook {e}");
         }
         if let Err(e) = custom.detach() {
-            println!("failed to detach custom hook {}", e);
+            println!("failed to detach custom hook {e}");
         }
     }
 
@@ -110,27 +110,27 @@ fn main() -> Result<()> {
             let key = (i as u32).to_ne_bytes();
             let val = port.to_ne_bytes();
             if let Err(e) = skel.maps_mut().ports().update(&key, &val, MapFlags::ANY) {
-                bail!("Example limited to 10 ports: {}", e);
+                bail!("Example limited to 10 ports: {e}");
             }
         }
         ingress.create()?;
 
         if let Err(e) = egress.attach() {
-            println!("failed to attach egress hook {}", e);
+            println!("failed to attach egress hook {e}");
         }
 
         if let Err(e) = ingress.attach() {
-            println!("failed to attach ingress hook {}", e);
+            println!("failed to attach ingress hook {e}");
         }
 
         if let Err(e) = custom.attach() {
-            println!("failed to attach custom hook {}", e);
+            println!("failed to attach custom hook {e}");
         }
     }
 
     if opts.destroy {
         if let Err(e) = destroy_all.destroy() {
-            println!("failed to destroy all {}", e);
+            println!("failed to destroy all {e}");
         }
     }
 

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -12,5 +12,5 @@ fn main() {
         .clang_args("-Wno-compare-distinct-pointer-types")
         .build_and_generate(&out)
         .unwrap();
-    println!("cargo:rerun-if-changed={}", SRC);
+    println!("cargo:rerun-if-changed={SRC}");
 }

--- a/examples/tproxy/src/bin/proxy.rs
+++ b/examples/tproxy/src/bin/proxy.rs
@@ -29,8 +29,8 @@ fn handle_client(client: TcpStream) -> Result<()> {
     let peer_addr = client.peer_addr().context("Failed to get peer addr")?;
 
     println!("New connection:");
-    println!("\tlocal: {}", local_addr);
-    println!("\tpeer: {}", peer_addr);
+    println!("\tlocal: {local_addr}");
+    println!("\tpeer: {peer_addr}");
     println!();
 
     Ok(())

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -86,10 +86,10 @@ fn main() -> Result<()> {
     }
 
     if let Err(e) = ingress.detach() {
-        eprintln!("Failed to detach prog: {}", e);
+        eprintln!("Failed to detach prog: {e}");
     }
     if let Err(e) = ingress.destroy() {
-        eprintln!("Failed to destroy TC hook: {}", e);
+        eprintln!("Failed to destroy TC hook: {e}");
     }
 
     Ok(())

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -552,12 +552,12 @@ impl Btf {
                 };
 
                 match t.encoding {
-                    btf::BtfIntEncoding::Signed => format!("i{}", width),
+                    btf::BtfIntEncoding::Signed => format!("i{width}"),
                     btf::BtfIntEncoding::Bool => {
                         assert!(t.bits as usize == (std::mem::size_of::<bool>() * 8));
                         "bool".to_string()
                     }
-                    btf::BtfIntEncoding::Char | btf::BtfIntEncoding::None => format!("u{}", width),
+                    btf::BtfIntEncoding::Char | btf::BtfIntEncoding::None => format!("u{width}"),
                 }
             }
             BtfType::Float(t) => {
@@ -570,12 +570,12 @@ impl Btf {
                     _ => bail!("Invalid float width"),
                 };
 
-                format!("f{}", width)
+                format!("f{width}")
             }
             BtfType::Ptr(t) => {
                 let pointee_ty = self.type_declaration(t.pointee_type)?;
 
-                format!("*mut {}", pointee_ty)
+                format!("*mut {pointee_ty}")
             }
             BtfType::Array(t) => {
                 let val_ty = self.type_declaration(t.val_type_id)?;
@@ -832,16 +832,11 @@ impl Btf {
                             )?;
 
                             if padding != 0 {
-                                agg_content.push(format!(
-                                    r#"    __pad_{offset}: [u8; {padding}],"#,
-                                    offset = offset,
-                                    padding = padding,
-                                ));
+                                agg_content
+                                    .push(format!(r#"    __pad_{offset}: [u8; {padding}],"#,));
 
                                 impl_default.push(format!(
                                     r#"            __pad_{offset}: [u8::default(); {padding}]"#,
-                                    offset = offset,
-                                    padding = padding,
                                 ));
                             }
 
@@ -877,7 +872,7 @@ impl Btf {
                             field_ty_str.clone()
                         };
 
-                        agg_content.push(format!(r#"    pub {}: {},"#, field_name, field_ty_str));
+                        agg_content.push(format!(r#"    pub {field_name}: {field_ty_str},"#));
                     }
 
                     if t.is_struct {
@@ -903,7 +898,7 @@ impl Btf {
                     let aggregate_type = if t.is_struct { "struct" } else { "union" };
                     let packed_repr = if packed { ", packed" } else { "" };
 
-                    writeln!(def, r#"#[repr(C{})]"#, packed_repr)?;
+                    writeln!(def, r#"#[repr(C{packed_repr})]"#)?;
                     writeln!(
                         def,
                         r#"pub {agg_type} {name} {{"#,
@@ -912,7 +907,7 @@ impl Btf {
                     )?;
 
                     for field in agg_content {
-                        writeln!(def, "{}", field)?;
+                        writeln!(def, "{field}")?;
                     }
                     writeln!(def, "}}")?;
 
@@ -922,7 +917,7 @@ impl Btf {
                         writeln!(def, r#"    fn default() -> Self {{"#)?;
                         writeln!(def, r#"        {} {{"#, t.name)?;
                         for impl_def in impl_default {
-                            writeln!(def, r#"{},"#, impl_def)?;
+                            writeln!(def, r#"{impl_def},"#)?;
                         }
                         writeln!(def, r#"        }}"#)?;
                         writeln!(def, r#"    }}"#)?;
@@ -967,13 +962,8 @@ impl Btf {
                     }
 
                     writeln!(def, r#"#[derive(Debug, Copy, Clone, PartialEq, Eq)]"#)?;
-                    writeln!(
-                        def,
-                        r#"#[repr({signed}{repr_size})]"#,
-                        signed = signed,
-                        repr_size = repr_size,
-                    )?;
-                    writeln!(def, r#"pub enum {name} {{"#, name = t.name,)?;
+                    writeln!(def, r#"#[repr({signed}{repr_size})]"#)?;
+                    writeln!(def, r#"pub enum {name} {{"#, name = t.name)?;
 
                     for value in &t.values {
                         writeln!(
@@ -1012,7 +1002,7 @@ impl Btf {
 
                     writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
                     writeln!(def, r#"#[repr(C)]"#)?;
-                    writeln!(def, r#"pub struct {} {{"#, sec_name,)?;
+                    writeln!(def, r#"pub struct {sec_name} {{"#)?;
 
                     let mut offset: u32 = 0;
                     for datasec_var in &t.vars {
@@ -1039,7 +1029,7 @@ impl Btf {
                             false,
                         )?;
                         if padding != 0 {
-                            writeln!(def, r#"    __pad_{}: [u8; {}],"#, offset, padding,)?;
+                            writeln!(def, r#"    __pad_{offset}: [u8; {padding}],"#)?;
                         }
 
                         // Set `offset` to end of current var

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -146,7 +146,7 @@ fn compile_one(debug: bool, source: &Path, out: &Path, clang: &Path, options: &s
             "aarch64" => "arm64",
             _ => std::env::consts::ARCH,
         };
-        cmd.arg(format!("-D__TARGET_ARCH_{}", arch));
+        cmd.arg(format!("-D__TARGET_ARCH_{arch}"));
     }
 
     cmd.arg("-g")
@@ -227,7 +227,7 @@ pub fn build(
     if debug && !to_compile.is_empty() {
         println!("Found bpf progs to compile:");
         for obj in &to_compile {
-            println!("\t{:?}", obj);
+            println!("\t{obj:?}");
         }
     } else if to_compile.is_empty() {
         bail!("Did not find any bpf progs to compile");

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -118,7 +118,7 @@ fn strip_dwarf_info(file: &Path) -> Result<()> {
     let mut linker =
         libbpf_rs::Linker::new(file).context("Failed to instantiate libbpf object file linker")?;
     linker
-        .add(temp_file)
+        .add_file(temp_file)
         .context("Failed to add object file to BPF linker")?;
     linker.link().context("Failed to link object file")?;
     Ok(())

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -236,7 +236,7 @@ impl SkeletonBuilder {
         if self.obj.is_none() {
             let name = filename.split('.').next().unwrap();
             let dir = tempdir().map_err(|e| Error::Build(e.to_string()))?;
-            let objfile = dir.path().join(format!("{}.o", name));
+            let objfile = dir.path().join(format!("{name}.o"));
             self.obj = Some(objfile);
             // Hold onto tempdir so that it doesn't get deleted early
             self.dir = Some(dir);

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -37,11 +37,11 @@ pub fn make(
     let status = cmd.status().context("Failed to spawn child")?;
     if !status.success() {
         let reason = match status.code() {
-            Some(rc) => format!("exit code {}", rc),
+            Some(rc) => format!("exit code {rc}"),
             None => "killed by signal".to_string(),
         };
 
-        bail!("Failed to `cargo build`: {}", reason);
+        bail!("Failed to `cargo build`: {reason}");
     }
 
     Ok(())

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -116,7 +116,7 @@ fn add_vmlinux_header(project: &Path) {
         .write(true)
         .open(project.join("src/bpf/vmlinux.h"))
         .expect("failed to open vmlinux.h");
-    write!(vmlinux, "{}", VMLINUX).expect("failed to write vmlinux.h");
+    write!(vmlinux, "{VMLINUX}").expect("failed to write vmlinux.h");
 }
 
 #[test]
@@ -1068,7 +1068,7 @@ fn build_btf_prog(prog_text: &str) -> Btf {
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
-    write!(prog, "{}", prog_text).expect("failed to write prog.bpf.c");
+    write!(prog, "{prog_text}").expect("failed to write prog.bpf.c");
 
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
@@ -1104,11 +1104,11 @@ fn assert_definition(btf: &Btf, btf_item: u32, expected_output: &str) {
     println!("---------------");
     println!("expected output");
     println!("---------------");
-    println!("{}", eo);
+    println!("{eo}");
     println!("-------------");
     println!("actual output");
     println!("-------------");
-    println!("{}", ao);
+    println!("{ao}");
 
     assert!(eo == ao);
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -929,14 +929,14 @@ fn test_skeleton_builder_deterministic() {
     write(
         proj_dir.join("src/bpf/prog.bpf.c"),
         r#"
-            #include <linux/bpf.h>
+            #include "vmlinux.h"
             #include <bpf/bpf_helpers.h>
 
             struct {
                 __uint(type, BPF_MAP_TYPE_REUSEPORT_SOCKARRAY);
             } sock_map SEC(".maps");
 
-            SEC("sk_reuseport/reuse_pass")
+            SEC("sk_reuseport")
             long prog_select_sk(struct sk_reuseport_md *reuse_md)
             {
                 unsigned int index = 0;
@@ -946,6 +946,8 @@ fn test_skeleton_builder_deterministic() {
         "#,
     )
     .expect("failed to write prog.bpf.c");
+
+    add_vmlinux_header(&proj_dir);
 
     let skel1 = NamedTempFile::new().unwrap();
     SkeletonBuilder::new()

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -37,7 +37,7 @@ impl Linker {
     }
 
     /// Add a file to the set of files to link.
-    pub fn add<P>(&mut self, file: P) -> Result<()>
+    pub fn add_file<P>(&mut self, file: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
@@ -52,7 +52,8 @@ impl Linker {
         }
     }
 
-    /// Link all BPF object files [`add`](Self::add)ed to this object into a single one.
+    /// Link all BPF object files [added](Self::add_file) to this object into
+    /// a single one.
     pub fn link(&self) -> Result<()> {
         // SAFETY: `linker` is a valid pointer.
         let err = unsafe { libbpf_sys::bpf_linker__finalize(self.linker) };

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -240,7 +240,7 @@ impl Map {
         if self.ptr.is_null() {
             match std::fs::remove_file(path) {
                 Ok(_) => Ok(()),
-                Err(e) => Err(Error::Internal(format!("remove pin map failed: {}", e))),
+                Err(e) => Err(Error::Internal(format!("remove pin map failed: {e}"))),
             }
         } else {
             let path_c = util::path_to_cstring(path)?;

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -29,7 +29,7 @@ impl ObjectBuilder {
     /// currently in use.
     pub fn debug(&mut self, dbg: bool) -> &mut Self {
         if dbg {
-            set_print(Some((PrintLevel::Debug, |_, s| print!("{}", s))));
+            set_print(Some((PrintLevel::Debug, |_, s| print!("{s}"))));
         } else {
             set_print(None);
         }

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -61,7 +61,7 @@ extern "C" fn outer_print_cb(
         if level <= min_level {
             let msg = match unsafe { vsprintf::vsprintf(fmtstr, va_list) } {
                 Ok(s) => s,
-                Err(e) => format!("Failed to parse libbpf output: {}", e),
+                Err(e) => format!("Failed to parse libbpf output: {e}"),
             };
             func(level, msg);
         }

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -240,7 +240,7 @@ impl<'a> ObjectSkeletonConfig<'a> {
     /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
     pub fn map_mmap_ptr(&mut self, index: usize) -> Result<*mut c_void> {
         if index >= self.maps.len() {
-            return Err(Error::Internal(format!("Invalid map index: {}", index)));
+            return Err(Error::Internal(format!("Invalid map index: {index}")));
         }
 
         self.maps[index].mmaped.as_ref().map_or_else(
@@ -257,7 +257,7 @@ impl<'a> ObjectSkeletonConfig<'a> {
     /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
     pub fn prog_link_ptr(&mut self, index: usize) -> Result<*mut bpf_link> {
         if index >= self.progs.len() {
-            return Err(Error::Internal(format!("Invalid prog index: {}", index)));
+            return Err(Error::Internal(format!("Invalid prog index: {index}")));
         }
 
         Ok(*self.progs[index].link)

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1027,7 +1027,7 @@ fn test_object_link_files() {
         let mut linker = Linker::new(output_file.path()).unwrap();
         let () = files
             .into_iter()
-            .try_for_each(|file| linker.add(file))
+            .try_for_each(|file| linker.add_file(file))
             .unwrap();
         let () = linker.link().unwrap();
 


### PR DESCRIPTION
This patch changes a few nuisances from recent pull requests:
- Rename `Linker::add()` to `add_file` to follow libbpf naming more
  closely (I still kept `Linker::link()` (as opposed to finalize)) as it
  seems apt.
- Fix `SEC` used in `test_skeleton_builder_deterministic`. The program
  would no longer load with libbpf 1.0.
- Use `vmlinux.h` instead of `<linux/bpf.h>` for consistency with other
  skeletons.

Signed-off-by: Daniel Müller <deso@posteo.net>