### PR TITLE
Build with --locked in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,12 +49,12 @@ jobs:
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
     - uses: Swatinem/rust-cache@v2.2.0
     - name: Build
-      run: cargo build --verbose --workspace --exclude runqslower
+      run: cargo build --locked --verbose --workspace --exclude runqslower
     - name: Run tests
       # Skip BTF tests which require sudo
-      run: cargo test --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc --include-ignored
+      run: cargo test --locked --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc --include-ignored
     - name: Run BTF tests
-      run: cd libbpf-rs && cargo test --verbose -- test_object test_tc
+      run: cd libbpf-rs && cargo test --locked --verbose -- test_object test_tc
 
   build-minimum:
     name: Build using minimum versions of dependencies
@@ -95,7 +95,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
-      - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --package capable --features=static
+      - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --locked --package capable --features=static
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
-      - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
+      - run: cargo clippy --locked --no-deps --all-targets --tests -- -D warnings
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest
@@ -137,4 +137,4 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo doc --no-deps
+      - run: cargo doc --locked --no-deps


### PR DESCRIPTION
If we bump dependencies manually in `Cargo.toml` we may end up forgetting about adjusting `Cargo.lock` in the process, depending on how we go about it. That's not great for users as it will cause spurious changes when they build a checkout.
Luckily for us, it's an easy thing to detect: we should build with `--locked`, which will cause the build process to fail if the two files do not agree. Use it in our CI workflow accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>