### PR TITLE
Bump nix from version 0.25 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "libbpf-rs",
- "nix 0.25.1",
+ "nix",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
 dependencies = [
- "nix 0.26.2",
+ "nix",
  "windows-sys",
 ]
 
@@ -239,7 +239,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "log",
- "nix 0.25.1",
+ "nix",
  "num_enum",
  "pkg-config",
  "plain",
@@ -299,24 +299,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -328,6 +315,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset",
  "static_assertions",
 ]
 
@@ -781,7 +769,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "nix 0.25.1",
+ "nix",
  "plain",
 ]
 
@@ -872,7 +860,7 @@ dependencies = [
  "ctrlc",
  "libbpf-cargo",
  "libbpf-rs",
- "nix 0.25.1",
+ "nix",
 ]
 
 [[package]]

--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }
-nix = { version = "0.25", default-features = false, features = ["net", "user"] }
+nix = { version = "0.26", default-features = false, features = ["net", "user"] }
 clap = { version = "3.1", default-features = false, features = ["std", "derive"] }

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
-nix = { version = "0.25", default-features = false, features = ["net", "user"] }
+nix = { version = "0.26", default-features = false, features = ["net", "user"] }
 clap = { version = "3.1", default-features = false, features = ["std", "derive"] }
 
 [build-dependencies]

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 clap = { version = "3.2.1", default-features = false, features = ["std", "derive"] }
 ctrlc = "3.2"
 libbpf-rs = { path = "../../libbpf-rs" }
-nix = { version = "0.25", default-features = false, features = ["net", "user"] }
+nix = { version = "0.26", default-features = false, features = ["net", "user"] }
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -24,7 +24,7 @@ static = ["libbpf-sys/static"]
 bitflags = "1.3"
 lazy_static = "1.4"
 libbpf-sys = { version = "1.0.3" }
-nix = { version = "0.25", default-features = false, features = ["net", "user"] }
+nix = { version = "0.26", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.24"
 thiserror = "1.0"


### PR DESCRIPTION
Some of our examples use nix in version `0.25` while others use `0.26`. That's detrimental to compile time and potentially binary size (though not really that relevant here, because it's only examples we are talking about).
Switch to using version `0.26` everywhere.

Signed-off-by: Daniel Müller <deso@posteo.net>