### PR TITLE
Make unsafe blocks explicit

### DIFF
--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -55,6 +55,8 @@
 //! build`. This is a convenience command so you don't forget any steps. Alternatively, you could
 //! write a Makefile for your project.
 
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use std::{
     path::{Path, PathBuf},
     result,

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -71,6 +71,7 @@
     missing_docs,
     rustdoc::broken_intra_doc_links
 )]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 mod error;
 mod iter;

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -145,15 +145,16 @@ impl<'a, 'b> PerfBufferBuilder<'a, 'b> {
     unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, cpu: i32, data: *mut c_void, size: u32) {
         let callback_struct = ctx as *mut CbStruct;
 
-        if let Some(cb) = &mut (*callback_struct).sample_cb {
-            cb(cpu, slice::from_raw_parts(data as *const u8, size as usize));
+        if let Some(cb) = unsafe { &mut (*callback_struct).sample_cb } {
+            let slice = unsafe { slice::from_raw_parts(data as *const u8, size as usize) };
+            cb(cpu, slice);
         }
     }
 
     unsafe extern "C" fn call_lost_cb(ctx: *mut c_void, cpu: i32, count: u64) {
         let callback_struct = ctx as *mut CbStruct;
 
-        if let Some(cb) = &mut (*callback_struct).lost_cb {
+        if let Some(cb) = unsafe { &mut (*callback_struct).lost_cb } {
             cb(cpu, count);
         }
     }

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -123,9 +123,10 @@ impl<'a> RingBufferBuilder<'a> {
 
     unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: c_ulong) -> i32 {
         let callback_struct = ctx as *mut RingBufferCallback;
-        let callback = (*callback_struct).cb.as_mut();
+        let callback = unsafe { (*callback_struct).cb.as_mut() };
+        let slice = unsafe { slice::from_raw_parts(data as *const u8, size as usize) };
 
-        callback(slice::from_raw_parts(data as *const u8, size as usize))
+        callback(slice)
     }
 }
 


### PR DESCRIPTION
We have a few implicitly `unsafe` operations in `unsafe` functions. Currently these don't require explicit wrapping in `unsafe {}`. That has arguably been identified as a wrong design decision of Rust, but it may only be changed in a new edition (if at all), because it would be a breaking change.
The `unsafe_block_in_unsafe_fn` lint [0] has been devised to fix this behavior, but it has to explicitly be opted in (though it may become the default eventually). Let's deny it, forcing us to make all `unsafe` blocks explicit.

[0] https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md

Signed-off-by: Daniel Müller <deso@posteo.net>