### PR TITLE
Properly fix license symlinks

### DIFF
--- a/examples/bpf_query/LICENSE.LGPL-2.1
+++ b/examples/bpf_query/LICENSE.LGPL-2.1
@@ -1,1 +1,1 @@
-../../LICENSE-LGPL-2.1
+../../LICENSE.LGPL-2.1

--- a/examples/capable/LICENSE.LGPL-2.1
+++ b/examples/capable/LICENSE.LGPL-2.1
@@ -1,1 +1,1 @@
-../../LICENSE-LGPL-2.1
+../../LICENSE.LGPL-2.1

--- a/examples/runqslower/LICENSE.LGPL-2.1
+++ b/examples/runqslower/LICENSE.LGPL-2.1
@@ -1,1 +1,1 @@
-../../LICENSE-LGPL-2.1
+../../LICENSE.LGPL-2.1

--- a/examples/tc_port_whitelist/LICENSE.LGPL-2.1
+++ b/examples/tc_port_whitelist/LICENSE.LGPL-2.1
@@ -1,1 +1,1 @@
-../../LICENSE-LGPL-2.1
+../../LICENSE.LGPL-2.1

--- a/examples/tproxy/LICENSE.LGPL-2.1
+++ b/examples/tproxy/LICENSE.LGPL-2.1
@@ -1,1 +1,1 @@
-../../LICENSE-LGPL-2.1
+../../LICENSE.LGPL-2.1


### PR DESCRIPTION
The previous PR initially used the wrong filenames when linking the LGPL license texts into the example crates, and when fixing them I only renamed the symlinks and not what they point to.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>