### PR TITLE
link: pass program as mut reference to update_prog

### DIFF
--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -41,7 +41,7 @@ impl Link {
     }
 
     /// Replace the underlying prog with `prog`.
-    pub fn update_prog(&mut self, prog: Program) -> Result<()> {
+    pub fn update_prog(&mut self, prog: &Program) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__update_program(self.ptr, prog.ptr) };
         util::parse_ret(ret)
     }


### PR DESCRIPTION
`Program` is a re-usable object and must not be consumed while updating the `link`.

Follow-up for #369

When an eBPF program is loaded and attached by a custom loader based on `libbpf-rs`, one or more `Link` objects are created and pinned to bpffs. Once the loader is restarted to attach another program, it needs to load existing `Link` pins and call `update_prog()` method.
Since a single eBPF program can be assigned to more than one hook and since dropping of `Program` may invoke its unloading, the `update_prog()` must not consume the `Program` instance, but must use it as a mut reference. Just Like the underlying `libbpf-sys` function.