### PR TITLE
Mark set_print as unsafe

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -175,7 +175,12 @@ fn main() -> Result<()> {
 
     let mut skel_builder = CapableSkelBuilder::default();
     if opts.debug {
-        skel_builder.obj_builder.debug(true);
+        unsafe {
+            // SAFETY:
+            // no other thread is running which could cause undefined behaviour due
+            // to this call.
+            skel_builder.obj_builder.debug(true);
+        }
     }
 
     bump_memlock_rlimit()?;

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -79,7 +79,12 @@ fn main() -> Result<()> {
 
     let mut skel_builder = RunqslowerSkelBuilder::default();
     if opts.verbose {
-        skel_builder.obj_builder.debug(true);
+        unsafe {
+            // SAFETY:
+            // no other thread is running which could cause undefined behaviour due
+            // to this call.
+            skel_builder.obj_builder.debug(true);
+        }
     }
 
     bump_memlock_rlimit()?;

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -53,7 +53,12 @@ fn main() -> Result<()> {
 
     let mut skel_builder = TproxySkelBuilder::default();
     if opts.verbose {
-        skel_builder.obj_builder.debug(true);
+        unsafe {
+            // SAFETY:
+            // no other thread is running which could cause undefined behaviour due
+            // to this call.
+            skel_builder.obj_builder.debug(true);
+        }
     }
 
     // Set constants

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -32,14 +32,18 @@ impl ObjectBuilder {
 
     /// Option to print debug output to stderr.
     ///
+    /// # Safety
+    ///
+    /// See [`set_print`](set_print#safety).
+    ///
+    /// Also it is guarenteed that the only parts of the `ObjectBuilder` that interacts with libbpf
+    /// are the [`open_file`](Self::open_file) and [`open_memory`](Self::open_memory) methods.
+    ///
     /// Note: This function uses [`set_print`] internally and will overwrite any callbacks
     /// currently in use.
-    pub fn debug(&mut self, dbg: bool) -> &mut Self {
-        if dbg {
-            set_print(Some((PrintLevel::Debug, |_, s| print!("{s}"))));
-        } else {
-            set_print(None);
-        }
+    pub unsafe fn debug(&mut self, dbg: bool) -> &mut Self {
+        let callback = dbg.then(|| (PrintLevel::Debug, (|_, s| print!("{s}")) as PrintCallback));
+        unsafe { set_print(callback) };
         self
     }
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -38,7 +38,7 @@ pub fn open_test_object(filename: &str) -> OpenObject {
     //     cargo test -- --nocapture
     //
     // To get all the output
-    builder.debug(true);
+    unsafe { builder.debug(true) };
     builder.open_file(obj_path).expect("failed to open object")
 }
 
@@ -112,8 +112,8 @@ fn test_object_build_from_memory() {
 #[test]
 fn test_object_load_invalid() {
     let empty_file = NamedTempFile::new().unwrap();
-    let _err = ObjectBuilder::default()
-        .debug(true)
+    let mut builder = ObjectBuilder::default();
+    let _err = unsafe { builder.debug(true) }
         .open_file(empty_file.path())
         .unwrap_err();
 }
@@ -488,7 +488,7 @@ fn test_object_reuse_pined_map() {
     // Reuse the pinned map
     let obj_path = get_test_object_path("runqslower.bpf.o");
     let mut builder = ObjectBuilder::default();
-    builder.debug(true);
+    unsafe { builder.debug(true) };
     let mut open_obj = builder.open_file(obj_path).expect("failed to open object");
 
     let start = open_obj.map_mut("start").expect("failed to find map");
@@ -1035,8 +1035,8 @@ fn test_object_link_files() {
         let () = linker.link().unwrap();
 
         // Check that we can load the resulting object file.
-        let _object = ObjectBuilder::default()
-            .debug(true)
+        let mut builder = ObjectBuilder::default();
+        let _object = unsafe { builder.debug(true) }
             .open_file(output_file.path())
             .unwrap();
     }

--- a/libbpf-rs/tests/test_print.rs
+++ b/libbpf-rs/tests/test_print.rs
@@ -25,7 +25,9 @@ fn test_set_print() {
         }
     }
 
-    set_print(Some((PrintLevel::Debug, callback)));
+    unsafe {
+        set_print(Some((PrintLevel::Debug, callback)));
+    }
     // expect_err requires that OpenObject implement Debug, which it does not.
     let obj = ObjectBuilder::default().open_file("/dev/null");
     assert!(obj.is_err(), "Successfully loaded /dev/null?");
@@ -46,11 +48,15 @@ fn test_set_restore_print() {
         println!("two");
     }
 
-    set_print(Some((PrintLevel::Warn, callback1)));
+    unsafe {
+        set_print(Some((PrintLevel::Warn, callback1)));
+    }
     let prev = get_print();
     assert_eq!(prev, Some((PrintLevel::Warn, callback1 as PrintCallback)));
 
-    set_print(Some((PrintLevel::Debug, callback2)));
+    unsafe {
+        set_print(Some((PrintLevel::Debug, callback2)));
+    }
     let prev = get_print();
     assert_eq!(prev, Some((PrintLevel::Debug, callback2 as PrintCallback)));
 }
@@ -65,10 +71,12 @@ fn test_set_and_save_print() {
         println!("two");
     }
 
-    set_print(Some((PrintLevel::Warn, callback1)));
-    let prev = set_print(Some((PrintLevel::Debug, callback2)));
+    unsafe {
+        set_print(Some((PrintLevel::Warn, callback1)));
+    }
+    let prev = unsafe { set_print(Some((PrintLevel::Debug, callback2))) };
     assert_eq!(prev, Some((PrintLevel::Warn, callback1 as PrintCallback)));
 
-    let prev = set_print(None);
+    let prev = unsafe { set_print(None) };
     assert_eq!(prev, Some((PrintLevel::Debug, callback2 as PrintCallback)));
 }


### PR DESCRIPTION
Unfortunately `set_print` cannot be safely wrapped as the underlying call is not thread safe, as documented in another `libbpf_` function [here](https://github.com/libbpf/libbpf/blob/cf46d44f0a06aa8b9400691ea3eb86ca4f066d5c/src/libbpf.h#L1602-L1607)

As such I think it needs to be marked `unsafe` for this library to be considered a safe wrapper around `libbpf`

I also deleted the "Temporarily disable printing" example as it seem unlikely that usage pattern is realistic outside the most trivial of programs.