### PR TITLE
Remove undefined behavior from ObjectSkeletonConfig.

### DIFF
--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -187,8 +187,8 @@ impl OpenObject {
     ///     - points to a loaded `bpf_object`
     ///
     /// It is not safe to manipulate `ptr` after this operation.
-    pub unsafe fn from_ptr(ptr: *mut libbpf_sys::bpf_object) -> Result<Self> {
-        unsafe { Self::new(NonNull::new_unchecked(ptr)) }
+    pub unsafe fn from_ptr(ptr: NonNull<libbpf_sys::bpf_object>) -> Result<Self> {
+        unsafe { Self::new(ptr) }
     }
 
     /// Takes underlying `libbpf_sys::bpf_object` pointer.

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -134,23 +134,23 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
     }
 
     fn build_progs(
-        &mut self,
+        progs: &mut [ProgSkelConfig],
         s: &mut bpf_object_skeleton,
         string_pool: &mut Vec<CString>,
     ) -> Option<Layout> {
-        if self.progs.is_empty() {
+        if progs.is_empty() {
             return None;
         }
 
-        s.prog_cnt = self.progs.len() as i32;
+        s.prog_cnt = progs.len() as i32;
         s.prog_skel_sz = size_of::<bpf_prog_skeleton>() as i32;
 
-        let layout = Layout::array::<bpf_prog_skeleton>(self.progs.len())
+        let layout = Layout::array::<bpf_prog_skeleton>(progs.len())
             .expect("Failed to allocate memory for progs skeleton");
 
         unsafe {
             s.progs = alloc_zeroed(layout) as *mut bpf_prog_skeleton;
-            for (i, prog) in self.progs.iter_mut().enumerate() {
+            for (i, prog) in progs.iter_mut().enumerate() {
                 let current_prog = s.progs.add(i);
 
                 // See above for `expect()` rationale
@@ -184,7 +184,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
         s.obj = &mut *self.p;
 
         let maps_layout = Self::build_maps(&mut self.maps, &mut s, &mut string_pool);
-        let progs_layout = self.build_progs(&mut s, &mut string_pool);
+        let progs_layout = Self::build_progs(&mut self.progs, &mut s, &mut string_pool);
 
         Ok(ObjectSkeletonConfig {
             inner: s,

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -98,23 +98,23 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
     }
 
     fn build_maps(
-        &mut self,
+        maps: &mut [MapSkelConfig],
         s: &mut bpf_object_skeleton,
         string_pool: &mut Vec<CString>,
     ) -> Option<Layout> {
-        if self.maps.is_empty() {
+        if maps.is_empty() {
             return None;
         }
 
-        s.map_cnt = self.maps.len() as i32;
+        s.map_cnt = maps.len() as i32;
         s.map_skel_sz = size_of::<bpf_map_skeleton>() as i32;
 
-        let layout = Layout::array::<bpf_map_skeleton>(self.maps.len())
+        let layout = Layout::array::<bpf_map_skeleton>(maps.len())
             .expect("Failed to allocate memory for maps skeleton");
 
         unsafe {
             s.maps = alloc_zeroed(layout) as *mut bpf_map_skeleton;
-            for (i, map) in self.maps.iter_mut().enumerate() {
+            for (i, map) in maps.iter_mut().enumerate() {
                 let current_map = s.maps.add(i);
 
                 // Opt to panic on error here. We've already allocated memory and we'd rather not
@@ -183,7 +183,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 
         s.obj = &mut *self.p;
 
-        let maps_layout = self.build_maps(&mut s, &mut string_pool);
+        let maps_layout = Self::build_maps(&mut self.maps, &mut s, &mut string_pool);
         let progs_layout = self.build_progs(&mut s, &mut string_pool);
 
         Ok(ObjectSkeletonConfig {


### PR DESCRIPTION
According to the [documentation](https://doc.rust-lang.org/alloc/boxed/index.html#considerations-for-unsafe-code), any use of aliases of a box, be it raw pointers or references, is invalid after the box has been moved/mutated/borrowed, thus the box aliasing that was happening here was Undefined Behaviour. Since the only reason the box was kept was so that it would be dropped in the destructor, I removed it from the fields of the struct and then dropped it manually in the destructor.

I also added the one missing NonNull check. This will guarantee that bugs in the generated code fail faster since uninitialized pointers will be detected sooner from a panic instead of a seg-fault