### PR TITLE
Specify libbpf-rs version in libbpf-cargo/Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use in your project, add into your `Cargo.toml`:
 
 ```toml
 [dependencies]
-libbpf-rs = "0.19"
+libbpf-rs = "0.20"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).
@@ -31,7 +31,7 @@ To use in your project, add into your `Cargo.toml`:
 
 ```toml
 [build-dependencies]
-libbpf-cargo = "0.13"
+libbpf-cargo = "0.20"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ novendor = ["libbpf-sys/novendor"]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
 libbpf-sys = { version = "1.0.3" }
-libbpf-rs = { path = "../libbpf-rs" }
+libbpf-rs = { version = "0.20", path = "../libbpf-rs" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }


### PR DESCRIPTION
libbpf-cargo fails to publish because of:
> error: all dependencies must have a version specified when publishing.
> dependency `libbpf-rs` does not specify a version
> Note: The published dependency will use the version from crates.io,
> the `path` specification will be removed from the dependency declaration.

Hence, explicitly specify the version to use. Also bump the recommended versions to use in the README.