### PR TITLE
Check package creation as part of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - name: Dry-run package creation
+      run: cargo package --no-verify
     - name: Create git tag
       env:
         version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Currently publishing multiple crates in a workspace is not an atomic operation. That will hopefully change eventually on the Cargo side, but currently it means that we may end up publishing one crate version and then failing to publish the other in our workflow. To minimize the chances of that happening, let's include a cargo package run, which does some basic sanity checking, before evening attempting to publish.