### PR TITLE
Add CHANGELOG for keeping track of changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,11 @@ not pushed out as a separate commit.
 Please make an effort to add regression tests for bug fixes and unit or
 integration tests for newly added functionality.
 
+- **Add a CHANGELOG note.**
+If your change is user facing or otherwise notable, it should likely be
+mentioned in the respective `CHANGELOG.md` files of the crates being
+touched.
+
 - **Run rustfmt before submitting.**.
 Running rustfmt (`cargo fmt`) will help fix any styling inconsistencies.
 It is checked by CI, but running rustfmt before submitting will help reduce

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,0 +1,9 @@
+Unreleased
+----------
+- Added `Map::as_libbpf_bpf_map_ptr` and `Object::as_libbpf_bpf_object_ptr`
+  accessors
+
+
+0.20.0
+------
+- Initial documented release


### PR DESCRIPTION
Introduce a CHANGELOG for keeping track of changes. Right now, we intend to have separate logs for the two crates (only one for libbpf-rs is created as part of this change, because only it has changes over the last release). The format is mostly free-form and expected to evolve over time. The contents will eventually appear in the corresponding GitHub release.

Closes: #281