### PR TITLE
Add btf metadata inspection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           profile: minimal
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.58.0
+          toolchain: 1.63.0
           components: rustfmt
           default: true
       - uses: Swatinem/rust-cache@v2.2.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.58+-blue.svg)](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.63+-blue.svg)](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 WARNING: The API is not stable and is subject to breakage. Any breakage will
 include a minor version bump pre-1.0 and a major version bump post-1.0.

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 version = "0.20.0"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.63"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Raised minimum rust version to 1.63
 - Added `Map::as_libbpf_bpf_map_ptr` and `Object::as_libbpf_bpf_object_ptr`
   accessors
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 version = "0.20.0"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.63"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -382,29 +382,35 @@ impl Debug for BtfType<'_> {
 
 impl<'btf> BtfType<'btf> {
     /// This type's type id.
+    #[inline(always)]
     pub fn type_id(&self) -> TypeId {
         self.type_id
     }
 
     /// This type's name.
+    #[inline(always)]
     pub fn name(&'_ self) -> Option<&'btf CStr> {
         self.name
     }
 
     /// This type's kind.
+    #[inline(always)]
     pub fn kind(&self) -> BtfKind {
         ((self.ty.info >> 24) & 0x1f).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn vlen(&self) -> u32 {
         self.ty.info & 0xffff
     }
 
+    #[inline(always)]
     fn kind_flag(&self) -> bool {
         (self.ty.info >> 31) == 1
     }
 
     /// Whether this represent's a modifier.
+    #[inline(always)]
     pub fn is_mod(&self) -> bool {
         matches!(
             self.kind(),
@@ -413,16 +419,19 @@ impl<'btf> BtfType<'btf> {
     }
 
     /// Whether this represents any kind of enum.
+    #[inline(always)]
     pub fn is_any_enum(&self) -> bool {
         matches!(self.kind(), BtfKind::Enum | BtfKind::Enum64)
     }
 
     /// Whether this btf type is core compatible to `other`.
+    #[inline(always)]
     pub fn is_core_compat(&self, other: &Self) -> bool {
         self.kind() == other.kind() || (self.is_any_enum() && other.is_any_enum())
     }
 
     /// Whether this type represents a composite type (struct/union).
+    #[inline(always)]
     pub fn is_composite(&self) -> bool {
         matches!(self.kind(), BtfKind::Struct | BtfKind::Union)
     }
@@ -439,6 +448,7 @@ impl<'btf> BtfType<'btf> {
     ///   - [`BtfKind::Union`],
     ///   - [`BtfKind::DataSec`],
     ///   - [`BtfKind::Enum64`],
+    #[inline(always)]
     unsafe fn size_unchecked(&self) -> u32 {
         unsafe { self.ty.__bindgen_anon_1.size }
     }
@@ -457,6 +467,7 @@ impl<'btf> BtfType<'btf> {
     ///     - [`BtfKind::Var`],
     ///     - [`BtfKind::DeclTag`],
     ///     - [`BtfKind::TypeTag`],
+    #[inline(always)]
     unsafe fn referenced_type_id_unchecked(&self) -> TypeId {
         unsafe { self.ty.__bindgen_anon_1.type_ }.into()
     }
@@ -589,6 +600,7 @@ impl<'btf> BtfType<'btf> {
 /// [`BtfKind`] can implement this trait.
 pub unsafe trait HasSize<'btf>: Deref<Target = BtfType<'btf>> + sealed::Sealed {
     /// The size of the described type.
+    #[inline(always)]
     fn size(&self) -> usize {
         unsafe { self.size_unchecked() as usize }
     }
@@ -606,11 +618,13 @@ pub unsafe trait ReferencesType<'btf>:
     Deref<Target = BtfType<'btf>> + sealed::Sealed
 {
     /// The refered type.
+    #[inline(always)]
     fn referenced_type_id(&self) -> TypeId {
         unsafe { self.referenced_type_id_unchecked() }
     }
 
     /// The referenced type.
+    #[inline(always)]
     fn referenced_type(&self) -> BtfType<'btf> {
         self.source.type_by_id(self.referenced_type_id()).unwrap()
     }

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -184,7 +184,7 @@ impl<'btf> Btf<'btf> {
 
     /// Gets a string at a given offset.
     ///
-    /// Returns `None` when the offset is out of bounds.
+    /// Returns [`None`] when the offset is out of bounds or if the name is empty.
     fn name_at(&self, offset: u32) -> Option<&CStr> {
         let name = unsafe {
             // SAFETY:
@@ -196,7 +196,7 @@ impl<'btf> Btf<'btf> {
                 // SAFETY: a non-null pointer comming from libbpf is always valid
                 CStr::from_ptr(p.as_ptr())
             })
-            .filter(|s| s.to_bytes().is_empty()) // treat empty strings as none
+            .filter(|s| !s.to_bytes().is_empty()) // treat empty strings as none
     }
 
     /// Whether this btf instance has no types.

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -12,6 +12,8 @@
 //! [`Btf::type_by_kind`]). If you want to get a type independently of the kind, just make sure `K`
 //! binds to [`BtfType`].
 
+pub mod types;
+
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::fmt;

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -43,9 +43,8 @@ use num_enum::TryFromPrimitive;
 #[derive(IntoPrimitive, TryFromPrimitive, Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
 pub enum BtfKind {
-    /// An unknown type kind. Usually an error.
-    #[num_enum(default)]
-    Unknown = 0,
+    /// [Void](types::Void)
+    Void = 0,
     /// [Int](types::Int)
     Int,
     /// [Ptr](types::Ptr)

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -1,0 +1,149 @@
+//! Parse and introspect btf information, from files or loaded objects.
+//!
+//! To find a specific type you can use one of 3 methods
+//!
+//! - [Btf::type_by_name]
+//! - [Btf::type_by_id]
+//! - [Btf::type_by_kind]
+//!
+//! All of these are generic over `K`, which is any type that can be created from a [`BtfType`],
+//! for all of these methods, not finding any type by the passed parameter or finding a type of
+//! another [`BtfKind`] will result in a [`None`] being returned (or filtered out in the case of
+//! [`Btf::type_by_kind`]). If you want to get a type independently of the kind, just make sure `K`
+//! binds to [`BtfType`].
+
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::os::raw::c_void;
+use std::os::unix::prelude::AsRawFd;
+use std::os::unix::prelude::FromRawFd;
+use std::os::unix::prelude::OsStrExt;
+use std::os::unix::prelude::OwnedFd;
+use std::path::Path;
+use std::ptr::NonNull;
+
+use crate::libbpf_sys;
+use crate::util::create_bpf_entity_checked;
+use crate::util::create_bpf_entity_checked_opt;
+use crate::util::parse_ret_i32;
+use crate::Error;
+use crate::Result;
+
+/// The btf information of a bpf object.
+///
+/// The lifetime bound protects against this object outliving its source. This can happen when it
+/// was derived from an [`Object`](super::Object), which owns the data this structs points too. When
+/// instead the [`Btf::from_path`] method is used, the lifetime will be `'static` since it doesn't
+/// borrow from anything.
+#[derive(Debug)]
+pub struct Btf<'source> {
+    ptr: NonNull<libbpf_sys::btf>,
+    needs_drop: bool,
+    _marker: PhantomData<&'source ()>,
+}
+
+impl Btf<'static> {
+    /// Load the btf information from an ELF file.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = {
+            let mut v = path.as_ref().as_os_str().as_bytes().to_vec();
+            v.push(0);
+            CString::from_vec_with_nul(v).map_err(|_| {
+                Error::InvalidInput(format!("invalid path {:?}, has null bytes", path.as_ref()))
+            })?
+        };
+        let ptr = create_bpf_entity_checked(|| unsafe {
+            libbpf_sys::btf__parse_elf(path.as_ptr(), std::ptr::null_mut())
+        })?;
+        Ok(Self {
+            ptr,
+            needs_drop: true,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Load the btf information of an bpf object from a program id.
+    pub fn from_prog_id(id: u32) -> Result<Self> {
+        let fd = parse_ret_i32(unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) })?;
+        let fd = unsafe {
+            // SAFETY: parse_ret_i32 will check that this fd is above -1
+            OwnedFd::from_raw_fd(fd)
+        };
+        let mut info = libbpf_sys::bpf_prog_info::default();
+        parse_ret_i32(unsafe {
+            libbpf_sys::bpf_obj_get_info_by_fd(
+                fd.as_raw_fd(),
+                (&mut info as *mut libbpf_sys::bpf_prog_info).cast::<c_void>(),
+                &mut (size_of::<libbpf_sys::bpf_prog_info>() as u32),
+            )
+        })?;
+
+        let ptr = create_bpf_entity_checked(|| unsafe {
+            libbpf_sys::btf__load_from_kernel_by_id(info.btf_id)
+        })?;
+
+        Ok(Self {
+            ptr,
+            needs_drop: true,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<'btf> Btf<'btf> {
+    pub(crate) fn from_bpf_object(obj: &'btf libbpf_sys::bpf_object) -> Result<Self> {
+        let ptr = create_bpf_entity_checked_opt(|| unsafe {
+            // SAFETY: the obj pointer is valid since it's behind a reference.
+            libbpf_sys::bpf_object__btf(obj)
+        })?
+        .ok_or_else(|| Error::Internal("btf not found".into()))?;
+        Ok(Self {
+            ptr,
+            needs_drop: false,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Gets a string at a given offset.
+    ///
+    /// Returns `None` when the offset is out of bounds.
+    fn name_at(&self, offset: u32) -> Option<&CStr> {
+        let name = unsafe {
+            // SAFETY:
+            // Assuming that btf is a valid pointer, this is always okay to call.
+            libbpf_sys::btf__name_by_offset(self.ptr.as_ptr(), offset)
+        };
+        NonNull::new(name as *mut i8)
+            .map(|p| unsafe {
+                // SAFETY: a non-null pointer comming from libbpf is always valid
+                CStr::from_ptr(p.as_ptr())
+            })
+            .filter(|s| s.to_bytes().is_empty()) // treat empty strings as none
+    }
+
+    /// Whether this btf instance has no types.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of [BtfType]s in this object.
+    pub fn len(&self) -> usize {
+        unsafe {
+            // SAFETY: the btf pointer is valid.
+            libbpf_sys::btf__type_cnt(self.ptr.as_ptr()) as usize
+        }
+    }
+}
+
+impl Drop for Btf<'_> {
+    fn drop(&mut self) {
+        if self.needs_drop {
+            unsafe {
+                // SAFETY: the btf pointer is valid.
+                libbpf_sys::btf__free(self.ptr.as_ptr())
+            }
+        }
+    }
+}

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -261,6 +261,9 @@ impl Display for Linkage {
     }
 }
 
+// Void
+gen_fieldless_concrete_type!(Void);
+
 // Int
 
 #[derive(Debug)]

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -130,11 +130,13 @@ macro_rules! gen_collection_members_concrete_type {
 
         impl<'btf> $name<'btf> {
             /// Whether this type has no members
+            #[inline(always)]
             pub fn is_empty(&self) -> bool {
                 self.members.is_empty()
             }
 
             #[doc = ::core::concat!("How many members this [`", ::core::stringify!($name), "`] has")]
+            #[inline(always)]
             pub fn len(&self) -> usize {
                 self.members.len()
             }
@@ -248,10 +250,12 @@ pub enum MemberAttr {
 }
 
 impl MemberAttr {
+    #[inline(always)]
     fn normal(offset: u32) -> Self {
         Self::Normal { offset }
     }
 
+    #[inline(always)]
     fn bif_field(offset: u32) -> Self {
         Self::BitField {
             size: (offset >> 24) as u8,
@@ -374,21 +378,25 @@ gen_concrete_type!(btf_array as Array);
 
 impl<'s> Array<'s> {
     /// The type id of the stored type.
+    #[inline(always)]
     pub fn ty(&self) -> TypeId {
         self.ptr.type_.into()
     }
 
     /// The type of index used.
+    #[inline(always)]
     pub fn index_ty(&self) -> TypeId {
         self.ptr.index_type.into()
     }
 
     /// The capacity of the array.
+    #[inline(always)]
     pub fn capacity(&self) -> usize {
         self.ptr.nelems as usize
     }
 
     /// The type contained in this array.
+    #[inline(always)]
     pub fn contained_type(&self) -> BtfType<'s> {
         self.source
             .source
@@ -598,6 +606,7 @@ gen_fieldless_concrete_type!(Func with ReferencesType);
 
 impl Func<'_> {
     /// This function's linkage.
+    #[inline(always)]
     pub fn linkage(&self) -> Linkage {
         self.source.vlen().try_into().unwrap_or(Linkage::Unknown)
     }
@@ -626,6 +635,7 @@ gen_concrete_type!(btf_var as Var with ReferencesType);
 
 impl Var<'_> {
     /// The kind of linkage this variable has.
+    #[inline(always)]
     pub fn linkage(&self) -> Linkage {
         self.ptr.linkage.try_into().unwrap_or(Linkage::Unknown)
     }
@@ -664,6 +674,7 @@ impl DeclTag<'_> {
     /// The component index is present only when the tag points to a struct/union member or a
     /// function argument.
     /// And component_idx indicates which member or argument, this decl tag refers to.
+    #[inline(always)]
     pub fn component_index(&self) -> Option<u32> {
         self.ptr.component_idx.try_into().ok()
     }

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -1,0 +1,557 @@
+//! Wrappers representing concrete btf types.
+
+use num_enum::IntoPrimitive;
+use num_enum::TryFromPrimitive;
+
+use super::BtfKind;
+use super::BtfType;
+use super::HasSize;
+use super::ReferencesType;
+use super::TypeId;
+use std::ffi::CStr;
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Deref;
+
+// Generate a btf type that doesn't have any fields, i.e. there is no data after the BtfType
+// pointer.
+macro_rules! gen_fieldless_concrete_type {
+    ($name:ident $(with $trait:ident)?) => {
+        #[allow(missing_docs)]
+        #[derive(Debug)]
+        pub struct $name<'btf> {
+            source: BtfType<'btf>,
+        }
+
+        impl<'btf> TryFrom<BtfType<'btf>> for $name<'btf> {
+            type Error = BtfType<'btf>;
+
+            fn try_from(t: BtfType<'btf>) -> ::core::result::Result<Self, Self::Error> {
+                if t.kind() == BtfKind::$name {
+                    Ok($name { source: t })
+                } else {
+                    Err(t)
+                }
+            }
+        }
+
+        impl<'btf> ::std::ops::Deref for $name<'btf> {
+            type Target = BtfType<'btf>;
+            fn deref(&self) -> &Self::Target {
+                &self.source
+            }
+        }
+
+        $(
+            impl super::sealed::Sealed for $name<'_> {}
+            unsafe impl<'btf> $trait<'btf> for $name<'btf> {}
+        )*
+    };
+}
+
+// Generate a btf type that has at least one field, and as such, there is data following the
+// btf_type pointer.
+macro_rules! gen_concrete_type {
+    ($libbpf_ty:ident as $name:ident $(with $trait:ident)?) => {
+        #[allow(missing_docs)]
+        #[derive(Debug)]
+        pub struct $name<'btf> {
+            source: BtfType<'btf>,
+            ptr: &'btf libbpf_sys::$libbpf_ty,
+        }
+
+        impl<'btf> TryFrom<BtfType<'btf>> for $name<'btf> {
+            type Error = BtfType<'btf>;
+
+            fn try_from(t: BtfType<'btf>) -> ::core::result::Result<Self, Self::Error> {
+                if t.kind() == BtfKind::$name {
+                    let ptr = unsafe {
+                        // SAFETY:
+                        //
+                        // It's in bounds to access the memory following this btf_type
+                        // because we've checked the type
+                        (t.ty as *const libbpf_sys::btf_type).offset(1)
+                    };
+                    let ptr = ptr.cast::<libbpf_sys::$libbpf_ty>();
+                    Ok($name {
+                        source: t,
+                        // SAFETY:
+                        //
+                        // This pointer is aligned.
+                        //      all fields of all struct have size and
+                        //      alignment of u32, if t.ty was aligned, then this must be as well
+                        //
+                        // It's initialized
+                        //      libbpf guarantees this since we've checked the type
+                        //
+                        // The lifetime will match the lifetime of the original t.ty reference.
+                        ptr: unsafe { &*ptr },
+                    })
+                } else {
+                    Err(t)
+                }
+            }
+        }
+
+        impl<'btf> ::std::ops::Deref for $name<'btf> {
+            type Target = BtfType<'btf>;
+            fn deref(&self) -> &Self::Target {
+                &self.source
+            }
+        }
+
+        $(
+            impl super::sealed::Sealed for $name<'_> {}
+            unsafe impl<'btf> $trait<'btf> for $name<'btf> {}
+        )*
+    };
+}
+
+macro_rules! gen_collection_concrete_type {
+
+    (
+        $libbpf_ty:ident as $name:ident $(with $trait:ident)?;
+
+        $(#[$docs:meta])*
+        struct $member_name:ident $(<$lt:lifetime>)? {
+            $(
+                $(#[$field_docs:meta])*
+                pub $field:ident : $type:ty
+            ),* $(,)?
+        }
+
+        |$btf:ident, $member:ident $(, $kind_flag:ident)?| $convert:expr
+    ) => {
+        #[allow(missing_docs)]
+        #[derive(Debug)]
+        pub struct $name<'btf> {
+            source: BtfType<'btf>,
+            members: &'btf [libbpf_sys::$libbpf_ty],
+        }
+
+        impl<'btf> TryFrom<BtfType<'btf>> for $name<'btf> {
+            type Error = BtfType<'btf>;
+
+            fn try_from(t: BtfType<'btf>) -> ::core::result::Result<Self, Self::Error> {
+                if t.kind() == BtfKind::$name {
+                    let base_ptr = unsafe {
+                        // SAFETY:
+                        //
+                        // It's in bounds to access the memory following this btf_type
+                        // because we've checked the type
+                        (t.ty as *const libbpf_sys::btf_type).offset(1)
+                    };
+                    let members = unsafe {
+                        // SAFETY:
+                        //
+                        // This pointer is aligned.
+                        //      all fields of all struct have size and
+                        //      alignment of u32, if t.ty was aligned, then this must be as well
+                        //
+                        // It's initialized
+                        //      libbpf guarantees this since we've checked the type
+                        //
+                        // The lifetime will match the lifetime of the original t.ty reference.
+                        //
+                        // The docs specify the length of the array is stored in vlen.
+                        std::slice::from_raw_parts(base_ptr.cast(), t.vlen() as usize)
+                    };
+                    Ok(Self { source: t, members })
+                } else {
+                    Err(t)
+                }
+            }
+        }
+
+        impl<'btf> ::std::ops::Deref for $name<'btf> {
+            type Target = BtfType<'btf>;
+            fn deref(&self) -> &Self::Target {
+                &self.source
+            }
+        }
+
+        impl<'btf> $name<'btf> {
+            /// Whether this type has no members
+            pub fn is_empty(&self) -> bool {
+                self.members.is_empty()
+            }
+
+            #[doc = ::core::concat!("How many members this [`", ::core::stringify!($name), "`] has")]
+            pub fn len(&self) -> usize {
+                self.members.len()
+            }
+
+            #[doc = ::core::concat!("Get a [`", ::core::stringify!($member_name), "`] at a given index")]
+            /// # Errors
+            ///
+            /// This function returns [`None`] when the index is out of bounds.
+            pub fn get(&self, index: usize) -> Option<$member_name$(<$lt>)*> {
+                self.members.get(index).map(|m| self.c_to_rust_member(m))
+            }
+
+            #[doc = ::core::concat!("Returns an iterator over the [`", ::core::stringify!($member_name), "`]'s of the [`", ::core::stringify!($name), "`]")]
+            pub fn iter(&'btf self) -> impl ExactSizeIterator<Item = $member_name$(<$lt>)*> + 'btf {
+                self.members.iter().map(|m| self.c_to_rust_member(m))
+            }
+
+            fn c_to_rust_member(&self, member: &libbpf_sys::$libbpf_ty) -> $member_name$(<$lt>)* {
+                let $btf = self.source.source;
+                let $member = member;
+                $(let $kind_flag = self.source.kind_flag();)*
+                $convert
+            }
+        }
+
+        $(#[$docs])*
+        #[derive(Debug)]
+        pub struct $member_name $(<$lt>)? {
+            $(
+                $(#[$field_docs])*
+                pub $field: $type
+            ),*
+        }
+
+        $(
+            impl super::sealed::Sealed for $name<'_> {}
+            unsafe impl<'btf> $trait<'btf> for $name<'btf> {}
+        )*
+    };
+}
+
+/// The attributes of a bitfield member.
+#[derive(Debug)]
+pub struct BitFieldAttr {
+    /// The size of the bitfield.
+    pub size: u8,
+    /// The offset of the bitfield.
+    pub offset: u32,
+}
+
+impl BitFieldAttr {
+    fn from_offset(offset: u32) -> Self {
+        Self {
+            size: (offset >> 24) as u8,
+            offset: offset & 0x00_ff_ff_ff,
+        }
+    }
+}
+
+#[derive(TryFromPrimitive, IntoPrimitive, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+#[allow(missing_docs)]
+pub enum Linkage {
+    Static = 0,
+    Global,
+    Extern,
+    Unknown,
+}
+
+impl Display for Linkage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Linkage::Static => "static",
+                Linkage::Global => "global",
+                Linkage::Extern => "extern",
+                Linkage::Unknown => "(unknown)",
+            }
+        )
+    }
+}
+
+// Int
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct Int<'btf> {
+    source: BtfType<'btf>,
+    pub encoding: IntEncoding,
+    pub offset: u8,
+    pub bits: u8,
+}
+
+/// The kinds of ways a btf [Int] can be encoded.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum IntEncoding {
+    Unsigned,
+    Signed,
+    Char,
+    Bool,
+}
+
+impl<'btf> TryFrom<BtfType<'btf>> for Int<'btf> {
+    type Error = BtfType<'btf>;
+
+    fn try_from(t: BtfType<'btf>) -> std::result::Result<Self, Self::Error> {
+        if t.kind() == BtfKind::Int {
+            let int = {
+                let base_ptr = t.ty as *const libbpf_sys::btf_type;
+                let u32_ptr = unsafe {
+                    // SAFETY:
+                    //
+                    // It's in bounds to access the memory following this btf_type
+                    // because we've checked the type
+                    base_ptr.offset(1).cast::<u32>()
+                };
+                unsafe {
+                    // SAFETY:
+                    //
+                    // This pointer is aligned.
+                    //      all fields of all struct have size and
+                    //      alignment of u32, if t.ty was aligned, then this must be as well
+                    //
+                    // It's initialized
+                    //      libbpf guarantees this since we've checked the type
+                    //
+                    // The lifetime will match the lifetime of the original t.ty reference.
+                    *u32_ptr
+                }
+            };
+            let encoding = match (int & 0x0f_00_00_00) >> 24 {
+                0b1 => IntEncoding::Signed,
+                0b10 => IntEncoding::Char,
+                0b100 => IntEncoding::Bool,
+                _ => IntEncoding::Unsigned,
+            };
+            Ok(Self {
+                source: t,
+                encoding,
+                offset: ((int & 0x00_ff_00_00) >> 24) as u8,
+                bits: (int & 0x00_00_00_ff) as u8,
+            })
+        } else {
+            Err(t)
+        }
+    }
+}
+
+impl<'btf> Deref for Int<'btf> {
+    type Target = BtfType<'btf>;
+    fn deref(&self) -> &Self::Target {
+        &self.source
+    }
+}
+
+// SAFETY: Int has the .size field set.
+impl super::sealed::Sealed for Int<'_> {}
+unsafe impl<'btf> HasSize<'btf> for Int<'btf> {}
+
+// Ptr
+gen_fieldless_concrete_type!(Ptr with ReferencesType);
+
+// Array
+gen_concrete_type!(btf_array as Array);
+
+impl Array<'_> {
+    /// The type id of the stored type.
+    pub fn ty(&self) -> TypeId {
+        self.ptr.type_.into()
+    }
+
+    /// The type of index used.
+    pub fn index_ty(&self) -> TypeId {
+        self.ptr.index_type.into()
+    }
+
+    /// The capacity of the array.
+    pub fn capacity(&self) -> usize {
+        self.ptr.nelems as usize
+    }
+}
+
+// Struct
+gen_collection_concrete_type! {
+    btf_member as Struct with HasSize;
+
+    /// A member of a [Struct]
+    struct StructMember<'btf> {
+        /// The member's name
+        pub name: Option<&'btf CStr>,
+        /// The member's type
+        pub ty: TypeId,
+        /// If this member is a bifield, these are it's attributes.
+        pub bitfield: Option<BitFieldAttr>
+    }
+
+    |btf, member, kflag| StructMember {
+        name: btf.name_at(member.name_off),
+        ty: member.type_.into(),
+        bitfield: kflag.then(|| BitFieldAttr::from_offset(member.offset) ),
+    }
+}
+
+// Union
+gen_collection_concrete_type! {
+    btf_member as Union with HasSize;
+
+    /// A member of an [Union]
+    struct UnionMember<'btf> {
+        /// The member's name
+        pub name: Option<&'btf CStr>,
+        /// The member's type
+        pub ty: TypeId,
+        /// If this member is a bifield, these are it's attributes.
+        pub bitfield: Option<BitFieldAttr>,
+    }
+
+    |btf, member, kflag| UnionMember {
+        name: btf.name_at(member.name_off),
+        ty: member.type_.into(),
+        bitfield: kflag.then(|| BitFieldAttr::from_offset(member.offset) ),
+    }
+}
+
+// Enum
+gen_collection_concrete_type! {
+    btf_enum as Enum with HasSize;
+
+    /// A member of an [Enum]
+    struct EnumMember<'btf> {
+        /// The name of this enum variant.
+        pub name: Option<&'btf CStr>,
+        /// The numeric value of this enum variant.
+        pub value: i32,
+    }
+
+    |btf, member| EnumMember {
+        name: btf.name_at(member.name_off),
+        value: member.val,
+    }
+}
+
+// Fwd
+gen_fieldless_concrete_type!(Fwd);
+
+impl Fwd<'_> {
+    #[allow(missing_docs)]
+    pub fn kind(&self) -> FwdKind {
+        if self.source.kind_flag() {
+            FwdKind::Union
+        } else {
+            FwdKind::Struct
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[allow(missing_docs)]
+pub enum FwdKind {
+    Struct,
+    Union,
+}
+
+// Typedef
+gen_fieldless_concrete_type!(Typedef with ReferencesType);
+
+// Volatile
+gen_fieldless_concrete_type!(Volatile with ReferencesType);
+
+// Const
+gen_fieldless_concrete_type!(Const with ReferencesType);
+
+// Restrict
+gen_fieldless_concrete_type!(Restrict with ReferencesType);
+
+// Func
+gen_fieldless_concrete_type!(Func with ReferencesType);
+
+impl Func<'_> {
+    /// This function's linkage.
+    pub fn linkage(&self) -> Linkage {
+        self.source.vlen().try_into().unwrap_or(Linkage::Unknown)
+    }
+}
+
+// FuncProto
+gen_collection_concrete_type! {
+    btf_param as FuncProto with ReferencesType;
+
+    /// A parameter of a [FuncProto].
+    struct FuncProtoParam<'btf> {
+        /// The parameter's name
+        pub name: Option<&'btf CStr>,
+        /// The parameter's type
+        pub ty: TypeId,
+    }
+
+    |btf, member| FuncProtoParam {
+        name: btf.name_at(member.name_off),
+        ty: member.type_.into()
+    }
+}
+
+// Var
+gen_concrete_type!(btf_var as Var with ReferencesType);
+
+impl Var<'_> {
+    /// The kind of linkage this variable has.
+    pub fn linkage(&self) -> Linkage {
+        self.ptr.linkage.try_into().unwrap_or(Linkage::Unknown)
+    }
+}
+
+// DataSec
+gen_collection_concrete_type! {
+    btf_var_secinfo as DataSec with HasSize;
+
+    /// Describes the btf var in a section.
+    ///
+    /// See [`DataSec`].
+    struct VarSecInfo {
+        /// The type id of the var
+        pub ty: TypeId,
+        /// The offset in the section
+        pub offset: u32,
+        /// The size of the type.
+        pub size: usize,
+    }
+
+    |_btf, member| VarSecInfo {
+        ty: member.type_.into(),
+        offset: member.offset,
+        size: member.size as usize
+    }
+}
+
+// Float
+gen_fieldless_concrete_type!(Float with HasSize);
+
+// DeclTag
+gen_concrete_type!(btf_decl_tag as DeclTag with ReferencesType);
+
+impl DeclTag<'_> {
+    /// The component index is present only when the tag points to a struct/union member or a
+    /// function argument.
+    /// And component_idx indicates which member or argument, this decl tag refers to.
+    pub fn component_index(&self) -> Option<u32> {
+        self.ptr.component_idx.try_into().ok()
+    }
+}
+
+// TypeTag
+gen_fieldless_concrete_type!(TypeTag with ReferencesType);
+
+// Enum64
+gen_collection_concrete_type! {
+    btf_enum64 as Enum64 with HasSize;
+
+    /// A member of an [Enum64].
+    struct Enum64Member<'btf> {
+        /// The name of this enum variant.
+        pub name: Option<&'btf CStr>,
+        /// The numeric value of this enum variant.
+        pub value: u64,
+    }
+
+    |btf, member| Enum64Member {
+        name: btf.name_at(member.name_off),
+        value: {
+            let hi: u64 = member.val_hi32.into();
+            let lo: u64 = member.val_lo32.into();
+            hi << 32 | lo
+        },
+    }
+}

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -303,7 +303,7 @@ pub struct Int<'btf> {
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub enum IntEncoding {
-    Unsigned,
+    None,
     Signed,
     Char,
     Bool,
@@ -341,7 +341,7 @@ impl<'btf> TryFrom<BtfType<'btf>> for Int<'btf> {
                 0b1 => IntEncoding::Signed,
                 0b10 => IntEncoding::Char,
                 0b100 => IntEncoding::Bool,
-                _ => IntEncoding::Unsigned,
+                _ => IntEncoding::None,
             };
             Ok(Self {
                 source: t,

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -439,6 +439,101 @@ gen_collection_concrete_type! {
     }
 }
 
+/// Sometimes it's not usefull to distinguish structs from unions, in that case, one can use this
+/// type to inspect any of them.
+#[derive(Debug)]
+pub struct Composite<'btf> {
+    source: BtfType<'btf>,
+    /// Whether this type is a struct.
+    pub is_struct: bool,
+    members: &'btf [libbpf_sys::btf_member],
+}
+
+impl<'btf> From<Struct<'btf>> for Composite<'btf> {
+    fn from(s: Struct<'btf>) -> Self {
+        Self {
+            source: s.source,
+            is_struct: true,
+            members: s.members,
+        }
+    }
+}
+
+impl<'btf> From<Union<'btf>> for Composite<'btf> {
+    fn from(s: Union<'btf>) -> Self {
+        Self {
+            source: s.source,
+            is_struct: false,
+            members: s.members,
+        }
+    }
+}
+
+impl<'btf> TryFrom<BtfType<'btf>> for Composite<'btf> {
+    type Error = BtfType<'btf>;
+
+    fn try_from(t: BtfType<'btf>) -> Result<Self, Self::Error> {
+        Struct::try_from(t)
+            .map(Self::from)
+            .or_else(|_| Union::try_from(t).map(Self::from))
+    }
+}
+
+impl<'btf> TryFrom<Composite<'btf>> for Struct<'btf> {
+    type Error = Composite<'btf>;
+
+    fn try_from(value: Composite<'btf>) -> Result<Self, Self::Error> {
+        if value.is_struct {
+            Ok(Self {
+                source: value.source,
+                members: value.members,
+            })
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl<'btf> TryFrom<Composite<'btf>> for Union<'btf> {
+    type Error = Composite<'btf>;
+
+    fn try_from(value: Composite<'btf>) -> Result<Self, Self::Error> {
+        if !value.is_struct {
+            Ok(Self {
+                source: value.source,
+                members: value.members,
+            })
+        } else {
+            Err(value)
+        }
+    }
+}
+
+// Composite
+gen_collection_members_concrete_type! {
+    btf_member as Composite with HasSize;
+
+    /// A member of a [Struct]
+    struct CompositeMember<'btf> {
+        /// The member's name
+        pub name: Option<&'btf CStr>,
+        /// The member's type
+        pub ty: TypeId,
+        /// If this member is a bifield, these are it's attributes.
+        pub attr: MemberAttr
+    }
+
+    |btf, member, kflag| CompositeMember {
+        name: btf.name_at(member.name_off),
+        ty: member.type_.into(),
+        attr: if kflag {
+            MemberAttr::bif_field(member.offset)
+        } else {
+            MemberAttr::normal(member.offset)
+        },
+    }
+}
+
 // Enum
 gen_collection_concrete_type! {
     btf_enum as Enum with HasSize;

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -372,7 +372,7 @@ gen_fieldless_concrete_type!(Ptr with ReferencesType);
 // Array
 gen_concrete_type!(btf_array as Array);
 
-impl Array<'_> {
+impl<'s> Array<'s> {
     /// The type id of the stored type.
     pub fn ty(&self) -> TypeId {
         self.ptr.type_.into()
@@ -386,6 +386,14 @@ impl Array<'_> {
     /// The capacity of the array.
     pub fn capacity(&self) -> usize {
         self.ptr.nelems as usize
+    }
+
+    /// The type contained in this array.
+    pub fn contained_type(&self) -> BtfType<'s> {
+        self.source
+            .source
+            .type_by_id(self.ty())
+            .expect("arrays should always reference an existing type")
     }
 }
 

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -73,6 +73,7 @@
 )]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+pub mod btf;
 mod error;
 mod iter;
 mod link;
@@ -92,6 +93,9 @@ mod util;
 
 pub use libbpf_sys;
 
+pub use crate::btf::Btf;
+pub use crate::btf::HasSize;
+pub use crate::btf::ReferencesType;
 pub use crate::error::Error;
 pub use crate::error::Result;
 pub use crate::iter::Iter;

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -363,6 +363,11 @@ impl Object {
         Ok(obj)
     }
 
+    /// Parse the btf information associated with this bpf object.
+    pub fn btf(&self) -> Result<Btf> {
+        Btf::from_bpf_object(unsafe { &*self.ptr.as_ptr() })
+    }
+
     /// Get a reference to `Map` with the name `name`, if one exists.
     pub fn map<T: AsRef<str>>(&self, name: T) -> Option<&Map> {
         self.maps.get(name.as_ref())


### PR DESCRIPTION
Adds BTF metadata inspection to the library.

The organization is as follows

## `src/btf.rs`
### `Btf`
This struct maps to the `libbpf_sys::btf` type, it let's you search for types in the btf data

### `BtfType`
This struct maps to `libbpf_sys::btf_type` struct and it let's you query for the data that is common among all btf types

### Extra attributes (size/type)
There is a union in `libbbpf_sys::btf_type` whose members must be accessed depending on the `BpfKind`, I encoded this in the type system through two traits, `ReferencesType` and `HasSize`.

## `src/btf/types.rs`
This file implements a different struct for each of the btf types, this also mimics the way `libbpf` is organized, since there is a different struct for each. The difference here is that every struct has a different type that derefs to the original such that it only increases the amount of information you have. For all of these there is a `TryFrom` impl that let's you convert from `BtfType` to the concrete type.

# Discussion and design decision details

Name's are always: `Option<&Cstr>`, the reasoning for each of them is:
- `Option`: I inspected a bit of the code in libbpf and it is possible for `btf__name_at_offset` to return NULL, since I didn't know if there was some guarantee that this function could never return NULL when I passed it some offset that came from btf itself I didn't risk it, but this is on `Option` I'd like to get rid of
- `CStr`: I though a bit about what to do here, using `str` forces UTF-8, but I don't know if I can assume UTF-8, since these strings are effectively user input. The 3 options I had were
    - `CStr`: (almost) 0 cost, leaves it up to the user how they want to interpret the bytes, but in this form it already implements `Display`
    - `str`: will work most of the time but take the agency out of the library user, since we will have no option but to panic if the bytes are not valid utf8
    - `Result<str, Utf8Error>`: does the check upfront for the user, but is annoying to work with out of the gate for the user
    - `String`: allocates memory, doesn't unwrap (we can use the lossy conversion), but assumes too much and is lossy