### PR TITLE
Use single line use statements

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "item"

--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -1,5 +1,6 @@
 use libbpf_cargo::SkeletonBuilder;
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 const SRC: &str = "src/bpf/capable.bpf.c";
 

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -6,7 +6,8 @@
 use core::time::Duration;
 use std::str::FromStr;
 
-use anyhow::{bail, Result};
+use anyhow::bail;
+use anyhow::Result;
 use clap::Parser;
 use libbpf_rs::PerfBufferBuilder;
 use phf::phf_map;

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,5 +1,6 @@
 use libbpf_cargo::SkeletonBuilder;
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 const SRC: &str = "src/bpf/runqslower.bpf.c";
 

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -2,7 +2,8 @@
 
 use core::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::bail;
+use anyhow::Result;
 use clap::Parser;
 use libbpf_rs::PerfBufferBuilder;
 use plain::Plain;

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -1,5 +1,6 @@
 use libbpf_cargo::SkeletonBuilder;
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 const SRC: &str = "src/bpf/tc.bpf.c";
 

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -1,8 +1,13 @@
-use anyhow::{bail, Result};
+use anyhow::bail;
+use anyhow::Result;
 use clap::Parser;
-use libbpf_rs::{
-    MapFlags, TcHookBuilder, TC_CUSTOM, TC_EGRESS, TC_H_CLSACT, TC_H_MIN_INGRESS, TC_INGRESS,
-};
+use libbpf_rs::MapFlags;
+use libbpf_rs::TcHookBuilder;
+use libbpf_rs::TC_CUSTOM;
+use libbpf_rs::TC_EGRESS;
+use libbpf_rs::TC_H_CLSACT;
+use libbpf_rs::TC_H_MIN_INGRESS;
+use libbpf_rs::TC_INGRESS;
 
 mod tc {
     include!(concat!(env!("OUT_DIR"), "/tc.skel.rs"));

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -1,5 +1,6 @@
 use libbpf_cargo::SkeletonBuilder;
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 const SRC: &str = "src/bpf/tproxy.bpf.c";
 

--- a/examples/tproxy/src/bin/proxy.rs
+++ b/examples/tproxy/src/bin/proxy.rs
@@ -1,14 +1,21 @@
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
+use std::net::TcpStream;
 use std::os::unix::io::FromRawFd;
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
+use anyhow::Result;
 use clap::Parser;
-use nix::sys::socket::{
-    bind, listen, setsockopt, socket,
-    sockopt::{IpTransparent, ReuseAddr},
-    AddressFamily, SockFlag, SockType, SockaddrIn,
-};
+use nix::sys::socket::bind;
+use nix::sys::socket::listen;
+use nix::sys::socket::setsockopt;
+use nix::sys::socket::socket;
+use nix::sys::socket::sockopt::IpTransparent;
+use nix::sys::socket::sockopt::ReuseAddr;
+use nix::sys::socket::AddressFamily;
+use nix::sys::socket::SockFlag;
+use nix::sys::socket::SockType;
+use nix::sys::socket::SockaddrIn;
 
 /// Fake proxy
 ///

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -1,13 +1,16 @@
 use std::net::Ipv4Addr;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
+use anyhow::Result;
 use clap::Parser;
-use libbpf_rs::{TcHookBuilder, TC_INGRESS};
+use libbpf_rs::TcHookBuilder;
+use libbpf_rs::TC_INGRESS;
 
 mod tproxy {
     include!(concat!(env!("OUT_DIR"), "/tproxy.skel.rs"));

--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -1,15 +1,22 @@
-use std::cmp::{max, min};
+use std::cmp::max;
+use std::cmp::min;
 use std::collections::BTreeSet;
 use std::convert::TryFrom;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::c_void;
+use std::ffi::CStr;
+use std::ffi::CString;
 use std::fmt::Write;
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::os::raw::{c_char, c_ulong};
+use std::os::raw::c_char;
+use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::ensure;
+use anyhow::Result;
 use scroll::Pread;
 
 use crate::btf::c_types::*;

--- a/libbpf-cargo/src/btf/c_types.rs
+++ b/libbpf-cargo/src/btf/c_types.rs
@@ -1,4 +1,7 @@
-use scroll_derive::{IOread, Pread as DerivePread, Pwrite, SizeWith};
+use scroll_derive::IOread;
+use scroll_derive::Pread as DerivePread;
+use scroll_derive::Pwrite;
+use scroll_derive::SizeWith;
 
 pub const BTF_MAGIC: u16 = 0xEB9F;
 pub const BTF_VERSION: u8 = 1;

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -1,9 +1,13 @@
 use std::collections::HashSet;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
 use regex::Regex;
 use semver::Version;
 use tempfile::tempdir;

--- a/libbpf-cargo/src/gen.rs
+++ b/libbpf-cargo/src/gen.rs
@@ -1,18 +1,25 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::c_void;
+use std::ffi::CStr;
+use std::ffi::CString;
 use std::fmt::Write as fmt_write;
 use std::fs::File;
 use std::io::stdout;
 use std::io::ErrorKind;
 use std::io::Write;
 use std::os::raw::c_ulong;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
 use std::ptr;
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::bail;
+use anyhow::ensure;
+use anyhow::Context;
+use anyhow::Result;
 use memmap2::Mmap;
 
 use crate::btf;

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -57,12 +57,12 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use std::{
-    path::{Path, PathBuf},
-    result,
-};
+use std::path::Path;
+use std::path::PathBuf;
+use std::result;
 
-use tempfile::{tempdir, TempDir};
+use tempfile::tempdir;
+use tempfile::TempDir;
 use thiserror::Error;
 
 // libbpf-cargo binary is the primary consumer of the following modules. As such,

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{AppSettings, Parser, Subcommand};
+use clap::AppSettings;
+use clap::Parser;
+use clap::Subcommand;
 
 mod btf;
 #[doc(hidden)]

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -1,9 +1,12 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use anyhow::{bail, Context, Result};
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
 
-use crate::{build, gen};
+use crate::build;
+use crate::gen;
 
 pub fn make(
     debug: bool,

--- a/libbpf-cargo/src/metadata.rs
+++ b/libbpf-cargo/src/metadata.rs
@@ -2,8 +2,10 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
-use cargo_metadata::{MetadataCommand, Package};
+use anyhow::bail;
+use anyhow::Result;
+use cargo_metadata::MetadataCommand;
+use cargo_metadata::Package;
 use serde::Deserialize;
 use serde_json::value::Value;
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1,16 +1,26 @@
-use std::{
-    convert::TryInto,
-    fs::{create_dir, read, read_to_string, write, File, OpenOptions},
-    io::Write,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::convert::TryInto;
+use std::fs::create_dir;
+use std::fs::read;
+use std::fs::read_to_string;
+use std::fs::write;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
 
 use goblin::Object;
 use memmap2::Mmap;
-use tempfile::{tempdir, NamedTempFile, TempDir};
+use tempfile::tempdir;
+use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
-use crate::{btf, btf::Btf, build::build, make::make, SkeletonBuilder};
+use crate::btf;
+use crate::btf::Btf;
+use crate::build::build;
+use crate::make::make;
+use crate::SkeletonBuilder;
 
 static VMLINUX: &str = include_str!("../test_data/vmlinux.h");
 

--- a/libbpf-rs/src/iter.rs
+++ b/libbpf-rs/src/iter.rs
@@ -1,4 +1,6 @@
-use nix::{errno, libc, unistd};
+use nix::errno;
+use nix::libc;
+use nix::unistd;
 use std::io;
 
 use crate::*;

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -92,20 +92,41 @@ mod util;
 
 pub use libbpf_sys;
 
-pub use crate::error::{Error, Result};
+pub use crate::error::Error;
+pub use crate::error::Result;
 pub use crate::iter::Iter;
 pub use crate::link::Link;
 pub use crate::linker::Linker;
-pub use crate::map::{Map, MapFlags, MapType, OpenMap};
-pub use crate::object::{Object, ObjectBuilder, OpenObject};
-pub use crate::perf_buffer::{PerfBuffer, PerfBufferBuilder};
-pub use crate::print::{get_print, set_print, PrintCallback, PrintLevel};
-pub use crate::program::{
-    OpenProgram, Program, ProgramAttachType, ProgramType, TracepointOpts, UprobeOpts, UsdtOpts,
-};
-pub use crate::ringbuf::{RingBuffer, RingBufferBuilder};
-pub use crate::tc::{
-    TcAttachPoint, TcHook, TcHookBuilder, TC_CUSTOM, TC_EGRESS, TC_H_CLSACT, TC_H_INGRESS,
-    TC_H_MIN_EGRESS, TC_H_MIN_INGRESS, TC_INGRESS,
-};
+pub use crate::map::Map;
+pub use crate::map::MapFlags;
+pub use crate::map::MapType;
+pub use crate::map::OpenMap;
+pub use crate::object::Object;
+pub use crate::object::ObjectBuilder;
+pub use crate::object::OpenObject;
+pub use crate::perf_buffer::PerfBuffer;
+pub use crate::perf_buffer::PerfBufferBuilder;
+pub use crate::print::get_print;
+pub use crate::print::set_print;
+pub use crate::print::PrintCallback;
+pub use crate::print::PrintLevel;
+pub use crate::program::OpenProgram;
+pub use crate::program::Program;
+pub use crate::program::ProgramAttachType;
+pub use crate::program::ProgramType;
+pub use crate::program::TracepointOpts;
+pub use crate::program::UprobeOpts;
+pub use crate::program::UsdtOpts;
+pub use crate::ringbuf::RingBuffer;
+pub use crate::ringbuf::RingBufferBuilder;
+pub use crate::tc::TcAttachPoint;
+pub use crate::tc::TcHook;
+pub use crate::tc::TcHookBuilder;
+pub use crate::tc::TC_CUSTOM;
+pub use crate::tc::TC_EGRESS;
+pub use crate::tc::TC_H_CLSACT;
+pub use crate::tc::TC_H_INGRESS;
+pub use crate::tc::TC_H_MIN_EGRESS;
+pub use crate::tc::TC_H_MIN_INGRESS;
+pub use crate::tc::TC_INGRESS;
 pub use crate::util::num_possible_cpus;

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::ptr::NonNull;
 
 use crate::*;

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 use std::ptr::null_mut;
 use std::ptr::NonNull;
 
-use crate::util::{self, path_to_cstring};
+use crate::util::path_to_cstring;
+use crate::util::{self};
 use crate::Error;
 use crate::Result;
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1,14 +1,17 @@
 use core::ffi::c_void;
+use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt::Debug;
 use std::path::Path;
 use std::ptr;
 use std::ptr::null;
-use std::{convert::TryFrom, ptr::NonNull};
+use std::ptr::NonNull;
 
 use bitflags::bitflags;
-use nix::{errno, unistd};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
+use nix::errno;
+use nix::unistd;
+use num_enum::IntoPrimitive;
+use num_enum::TryFromPrimitive;
 use strum_macros::Display;
 
 use crate::*;

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -1,14 +1,14 @@
 use core::ffi::c_void;
-use std::{
-    collections::HashMap,
-    ffi::CStr,
-    mem,
-    os::raw::c_char,
-    path::Path,
-    ptr::{self, NonNull},
-};
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::mem;
+use std::os::raw::c_char;
+use std::path::Path;
+use std::ptr::NonNull;
+use std::ptr::{self};
 
-use crate::{util, *};
+use crate::util;
+use crate::*;
 
 /// Builder for creating an [`OpenObject`]. Typically the entry point into libbpf-rs.
 #[derive(Default, Debug)]

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use lazy_static::lazy_static;
-use std::io::{self, Write};
+use std::io::Write;
+use std::io::{self};
 use std::os::raw::c_char;
 use std::sync::Mutex;
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -2,7 +2,8 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::mem;
 use std::path::Path;
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
+use std::ptr::{self};
 
 use libbpf_sys::bpf_func_id;
 use num_enum::TryFromPrimitive;

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -17,7 +17,8 @@ use std::os::raw::c_char;
 use std::string::String;
 use std::time::Duration;
 
-use nix::{errno, unistd::close};
+use nix::errno;
+use nix::unistd::close;
 
 use crate::*;
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -1,15 +1,22 @@
 use core::ffi::c_void;
-use std::alloc::{alloc_zeroed, dealloc, Layout};
+use std::alloc::alloc_zeroed;
+use std::alloc::dealloc;
+use std::alloc::Layout;
 use std::boxed::Box;
 use std::ffi::CString;
 use std::mem::size_of;
-use std::os::raw::{c_char, c_ulong};
-use std::ptr::{self, NonNull};
+use std::os::raw::c_char;
+use std::os::raw::c_ulong;
+use std::ptr::NonNull;
+use std::ptr::{self};
 
-use libbpf_sys::{
-    bpf_link, bpf_map, bpf_map_skeleton, bpf_object, bpf_object_skeleton, bpf_prog_skeleton,
-    bpf_program,
-};
+use libbpf_sys::bpf_link;
+use libbpf_sys::bpf_map;
+use libbpf_sys::bpf_map_skeleton;
+use libbpf_sys::bpf_object;
+use libbpf_sys::bpf_object_skeleton;
+use libbpf_sys::bpf_prog_skeleton;
+use libbpf_sys::bpf_program;
 
 use crate::util;
 use crate::*;

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -1,4 +1,5 @@
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
+use std::ffi::CString;
 use std::os::raw::c_char;
 use std::path::Path;
 use std::ptr::NonNull;

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,13 +1,12 @@
-use std::{
-    collections::HashSet,
-    ffi::c_void,
-    fs,
-    io::Read,
-    path::{Path, PathBuf},
-    slice,
-    sync::mpsc::channel,
-    time::Duration,
-};
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+use std::slice;
+use std::sync::mpsc::channel;
+use std::time::Duration;
 
 use nix::errno;
 use plain::Plain;
@@ -16,10 +15,19 @@ use scopeguard::defer;
 use std::ptr;
 use tempfile::NamedTempFile;
 
-use libbpf_rs::{
-    num_possible_cpus, Iter, Linker, Map, MapFlags, MapType, Object, ObjectBuilder, OpenObject,
-    ProgramType, TracepointOpts, UprobeOpts, UsdtOpts,
-};
+use libbpf_rs::num_possible_cpus;
+use libbpf_rs::Iter;
+use libbpf_rs::Linker;
+use libbpf_rs::Map;
+use libbpf_rs::MapFlags;
+use libbpf_rs::MapType;
+use libbpf_rs::Object;
+use libbpf_rs::ObjectBuilder;
+use libbpf_rs::OpenObject;
+use libbpf_rs::ProgramType;
+use libbpf_rs::TracepointOpts;
+use libbpf_rs::UprobeOpts;
+use libbpf_rs::UsdtOpts;
 
 fn get_test_object_path(filename: &str) -> PathBuf {
     let mut path = PathBuf::new();
@@ -1069,7 +1077,8 @@ fn buffer<'a>(perf: &'a libbpf_rs::PerfBuffer, buf_idx: usize) -> &'a [u8] {
 /// value we have sent.
 #[test]
 fn test_object_perf_buffer_raw() {
-    use memmem::{Searcher, TwoWaySearcher};
+    use memmem::Searcher;
+    use memmem::TwoWaySearcher;
 
     bump_rlimit_mlock();
 

--- a/libbpf-rs/tests/test_print.rs
+++ b/libbpf-rs/tests/test_print.rs
@@ -5,9 +5,14 @@
 //!
 //! For the same reason, all tests here must run serially.
 
-use libbpf_rs::{get_print, set_print, ObjectBuilder, PrintCallback, PrintLevel};
+use libbpf_rs::get_print;
+use libbpf_rs::set_print;
+use libbpf_rs::ObjectBuilder;
+use libbpf_rs::PrintCallback;
+use libbpf_rs::PrintLevel;
 use serial_test::serial;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 #[test]
 #[serial]

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,14 +1,23 @@
 use serial_test::serial;
 
 mod test;
-use test::{bump_rlimit_mlock, get_test_object};
+use test::bump_rlimit_mlock;
+use test::get_test_object;
 
-use nix::errno::Errno::{EINVAL, ENOENT};
+use nix::errno::Errno::EINVAL;
+use nix::errno::Errno::ENOENT;
 
-use libbpf_rs::{
-    Error, Object, Result, TcHook, TcHookBuilder, TC_CUSTOM, TC_EGRESS, TC_H_CLSACT,
-    TC_H_MIN_EGRESS, TC_H_MIN_INGRESS, TC_INGRESS,
-};
+use libbpf_rs::Error;
+use libbpf_rs::Object;
+use libbpf_rs::Result;
+use libbpf_rs::TcHook;
+use libbpf_rs::TcHookBuilder;
+use libbpf_rs::TC_CUSTOM;
+use libbpf_rs::TC_EGRESS;
+use libbpf_rs::TC_H_CLSACT;
+use libbpf_rs::TC_H_MIN_EGRESS;
+use libbpf_rs::TC_H_MIN_INGRESS;
+use libbpf_rs::TC_INGRESS;
 // do all TC tests on the lo network interface
 const LO_IFINDEX: i32 = 1;
 


### PR DESCRIPTION
The
>  use <...>::{XXX, YYY, ZZZ}

style for `use` statements is causing unnecessarily difficult to read diffs and is prone to merge conflicts. Switch to a different style that is less prone to such issues.