### PR TITLE
Use nightly rustfmt in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
           override: true
       - run: cargo fmt --package libbpf-cargo libbpf-rs -- --check


### PR DESCRIPTION
I forgot to include that earlier, but with commit bf09e444d410 ("Use single line use statements") we include rustfmt configuration options that are only used on nightly.
With this change we adjust CI to use a nightly toolchain so that we can actually enforce the new style.