### PR TITLE
Fill in notable changes made for 0.20.0

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,0 +1,13 @@
+0.20.0
+------
+- Fixed mismatch in size of generated types with respect to corresponding C
+  types
+- Fixed generated skeleton potentially being unstable (changing each time)
+- Implemented `Sync` for generated skeletons
+- Made formatting using `rustfmt` optional
+- Updated various dependencies
+
+
+0.19.1
+------
+- Initial documented release

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -6,4 +6,28 @@ Unreleased
 
 0.20.0
 ------
+- Added support for USDT probes
+- Added BPF linker support with new `Linker` type
+- Added `Program::attach_uprobe_with_opts` for attaching Uprobes with additional
+  options
+- Added `tproxy` example
+- Added option to `RingBuffer::poll` to block indefinitely
+- Added support for querying BPF program type using `OpenProgram::prog_type`
+- Added support for retrieving a BPF program's instructions using
+  `OpenProgram::insns` & `Program::insns`
+- Added `MapType::is_supported`, `ProgramType::is_supported`, and
+  `ProgramType::is_helper_supported` methods
+- Added `PerfBuffer::as_libbpf_perf_buffer_ptr` to access underlying
+  `libbpf-sys` object
+- Adjusted various `Map` methods to work on shared receivers
+- Fixed `Link::open` constructor to be a static method
+- Fixed unsoundness in skeleton logic caused by aliased `Box` contents
+- Implemented `Send` for `PerfBuffer` and `RingBuffer`
+- Made more types implement `Clone` and `Debug`
+- Run leak sanitizer in CI
+- Updated various dependencies
+
+
+0.19.1
+------
 - Initial documented release


### PR DESCRIPTION
I went back over the notable changes made to libbpf-rs and libbpf-cargo and populated our CHANGELOG files accordingly.