### PR TITLE
Remove explicit allowance of derive default clippy lint warning

### DIFF
--- a/libbpf-cargo/src/btf/btf.rs
+++ b/libbpf-cargo/src/btf/btf.rs
@@ -968,11 +968,18 @@ impl Btf {
                         }
                     }
 
-                    writeln!(def, r#"#[derive(Debug, Copy, Clone, PartialEq, Eq)]"#)?;
+                    writeln!(
+                        def,
+                        r#"#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]"#
+                    )?;
                     writeln!(def, r#"#[repr({signed}{repr_size})]"#)?;
                     writeln!(def, r#"pub enum {name} {{"#, name = t.name)?;
 
-                    for value in &t.values {
+                    for (i, value) in t.values.iter().enumerate() {
+                        if i == 0 {
+                            writeln!(def, r#"    #[default]"#)?;
+                        }
+
                         writeln!(
                             def,
                             r#"    {name} = {value},"#,
@@ -982,23 +989,6 @@ impl Btf {
                     }
 
                     writeln!(def, "}}")?;
-
-                    // write an impl Default for this enum
-                    if !t.values.is_empty() {
-                        // TODO: remove #[allow(clippy::derivable_impls)]
-                        //       once minimum rust at 1.62+
-                        writeln!(def, r#"#[allow(clippy::derivable_impls)]"#)?;
-                        writeln!(def, r#"impl Default for {name} {{"#, name = t.name)?;
-                        writeln!(def, r#"    fn default() -> Self {{"#)?;
-                        writeln!(
-                            def,
-                            r#"        {name}::{value}"#,
-                            name = t.name,
-                            value = t.values[0].name
-                        )?;
-                        writeln!(def, r#"    }}"#)?;
-                        writeln!(def, r#"}}"#)?;
-                    }
                 }
                 BtfType::Datasec(t) => {
                     let mut sec_name = t.name.to_string();

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1485,18 +1485,13 @@ enum Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 #[repr(u32)]
 pub enum Foo {
+    #[default]
     Zero = 0,
     One = 1,
     seven = 7,
-}
-#[allow(clippy::derivable_impls)]
-impl Default for Foo {
-    fn default() -> Self {
-        Foo::Zero
-    }
 }
 "#;
 
@@ -2083,16 +2078,11 @@ struct Foo foo;
 pub struct Foo {
     pub test: __anon_1,
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 #[repr(u32)]
 pub enum __anon_1 {
+    #[default]
     FOO = 1,
-}
-#[allow(clippy::derivable_impls)]
-impl Default for __anon_1 {
-    fn default() -> Self {
-        __anon_1::FOO
-    }
 }
 "#;
 


### PR DESCRIPTION
Now that we have bumped our minimum supported Rust version, we can revert commit 5553d9ce572e ("Ignore clippy lint warning for derive default") and tag default variants with `#[default]` instead.