### PR TITLE
Invoke `clang` with `-fno-stack-protector`

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Fixed potential build failures on systems defaulting to stack
+  protector usage by passing `-fno-stack-protector` to `clang`
+
+
 0.20.0
 ------
 - Fixed mismatch in size of generated types with respect to corresponding C

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -265,11 +265,16 @@ pub fn build_single(
     check_clang(debug, &clang, skip_clang_version_checks)?;
     let header_parent_dir = tempdir()?;
     let header_dir = extract_libbpf_headers_to_disk(header_parent_dir.path())?;
-    let compiler_options = if let Some(dir) = &header_dir {
+    let mut compiler_options = if let Some(dir) = &header_dir {
         format!("{} -I{}", options, dir.to_str().unwrap())
     } else {
         options.to_string()
     };
+
+    // Explicitly disable stack protector logic, which doesn't work with
+    // BPF. See https://lkml.org/lkml/2020/2/21/1000.
+    compiler_options += " -fno-stack-protector";
+
     compile_one(debug, source, out, &clang, &compiler_options)?;
 
     Ok(())


### PR DESCRIPTION
Compilation of libbpf-cargo generated skeletons on a Gentoo system may fail, as stack protection may be enabled implicitly there, but it is not supported by BPF [0].
Make sure to invoke clang with -fno-stack-protector to prevent compilation failures.

[0] https://lkml.org/lkml/2020/2/21/1000

Closes: #337