### PR TITLE
Correctly cast *const c_char to *mut c_char without changing the type

### DIFF
--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -22,6 +22,7 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Deref;
+use std::os::raw::c_char;
 use std::os::raw::c_void;
 use std::os::unix::prelude::AsRawFd;
 use std::os::unix::prelude::FromRawFd;
@@ -236,7 +237,7 @@ impl<'btf> Btf<'btf> {
             // Assuming that btf is a valid pointer, this is always okay to call.
             libbpf_sys::btf__name_by_offset(self.ptr.as_ptr(), offset)
         };
-        NonNull::new(name as *mut i8)
+        NonNull::new(name as *mut c_char)
             .map(|p| unsafe {
                 // SAFETY: a non-null pointer comming from libbpf is always valid
                 CStr::from_ptr(p.as_ptr())


### PR DESCRIPTION
The code as it stands now (in master) doesn't compile on platforms where c_char is an alias to u8.

This bug could have been avoided by using [`pointer::cast_mut`](https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_mut) instead of manually casting the pointer, but back in the orginal PR we didn't want to raise the MSRV.

Is this enough of a reason to raise the MSRV to 1.65?