### PR TITLE
Add utilities to work with pinned maps without going through `Object`

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 ----------
+- Added `Map` constructors from pinned paths and from map id.
+- Added `Map::info` to `Map` to make it easier to derive `MapInfo` from a `Map`
+  instance.
 - Added bindings for BTF via newly introduced `btf` module
 - Added `Map::as_libbpf_bpf_map_ptr` and `Object::as_libbpf_bpf_object_ptr`
   accessors

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -208,6 +208,16 @@ impl Map {
         })
     }
 
+    /// Fetch extra map information
+    pub fn info(&self) -> Result<MapInfo> {
+        MapInfo::new(unsafe {
+            // SAFETY
+            // This BorrowedFd instance doesn't live longer than this scope, so it satisfies its
+            // invariants.
+            BorrowedFd::borrow_raw(self.fd)
+        })
+    }
+
     /// Retrieve the `Map`'s name.
     pub fn name(&self) -> &str {
         &self.name

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -387,6 +387,45 @@ fn test_object_map_pin() {
 }
 
 #[test]
+fn test_object_loading_pinned_map_from_path() {
+    bump_rlimit_mlock();
+
+    let mut obj = get_test_object("runqslower.bpf.o");
+    let map = obj.map_mut("start").expect("failed to find map 'start'");
+
+    let path = "/sys/fs/bpf/mymap_test_pin_to_load_from_path";
+
+    map.pin(path).expect("pinning map failed");
+
+    let pinned_map = Map::from_pinned_path(path).expect("loading a map from a path failed");
+    map.unpin(path).expect("unpinning map failed");
+
+    assert_eq!(map.name(), pinned_map.name());
+    assert_eq!(
+        map.info().unwrap().info.id,
+        pinned_map.info().unwrap().info.id
+    );
+}
+
+#[test]
+fn test_object_loading_loaded_map_from_id() {
+    bump_rlimit_mlock();
+
+    let mut obj = get_test_object("runqslower.bpf.o");
+    let map = obj.map_mut("start").expect("failed to find map 'start'");
+
+    let id = map.info().expect("to get info from map 'start'").info.id;
+
+    let map_by_id = Map::from_map_id(id).expect("map to load from id");
+
+    assert_eq!(map.name(), map_by_id.name());
+    assert_eq!(
+        map.info().unwrap().info.id,
+        map_by_id.info().unwrap().info.id
+    );
+}
+
+#[test]
 fn test_object_programs() {
     bump_rlimit_mlock();
 


### PR DESCRIPTION
In order to work with pinned maps or already loaded maps, you don't need the entire bpf_object, you can just interact with them by filesystem path or id. So I added some new constructors and getters for additional useful information.

This might have warranted different PRs, since the getters aren't 100% related to the main point of the PR (the constructors) but I need these getters and they seemed too small for a standalone PR. Hopefully that's okay.