### PR TITLE
Remove deprecated `Link::get_fd()` method

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -84,7 +84,7 @@ impl<'s> GenBtf<'s> {
                 let mut anon_table = self.anon_types.borrow_mut();
                 let len = anon_table.len() + 1; // use 1 index anon ids for backwards compat
                 let anon_id = anon_table.entry(t.type_id()).or_insert(len);
-                format!("{}{}", ANON_PREFIX, anon_id).into()
+                format!("{ANON_PREFIX}{anon_id}").into()
             }
             Some(n) => n.to_string_lossy(),
         }

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -198,7 +198,7 @@ impl<'btf> Btf<'btf> {
         })
     }
 
-    /// From raw bytes comming from an object file.
+    /// From raw bytes coming from an object file.
     pub fn from_raw(name: &'btf str, object_file: &'btf [u8]) -> Result<Option<Self>> {
         let cname = CString::new(name)
             .map_err(|_| Error::InvalidInput(format!("invalid path {name:?}, has null bytes")))

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -82,12 +82,6 @@ impl Link {
     }
 
     /// Returns the file descriptor of the link.
-    #[deprecated(since = "0.17.0", note = "please use `fd` instead")]
-    pub fn get_fd(&self) -> i32 {
-        unsafe { libbpf_sys::bpf_link__fd(self.ptr.as_ptr()) }
-    }
-
-    /// Returns the file descriptor of the link.
     pub fn fd(&self) -> i32 {
         unsafe { libbpf_sys::bpf_link__fd(self.ptr.as_ptr()) }
     }


### PR DESCRIPTION
This change removes the `Link::get_fd()` method, which has been deprecated for several releases by now.