### PR TITLE
Verify packages in workspace member directories

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         toolchain: stable
         override: true
     - name: Dry-run package creation
-      run: cargo package --no-verify
+      run: cargo package --package libbpf-rs --package libbpf-cargo --locked --no-verify
     - name: Create git tag
       env:
         version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Running cargo --no-verify in the root of the workspace checks packaging of all workspace members, including the examples.
We do not currently (and have no intention to) publish the examples, however. As such, let's verify only the members that we intend to publish. Also make use of Cargo's --package argument for the package and publish sub-commands we use, as that minimizes hard coded paths.