### PR TITLE
Run clippy on 1.68.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,8 +137,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          components: clippy
+          # TODO: Move back to `stable` once we are past 1.69
+          # See:
+          # https://github.com/clap-rs/clap/issues/4849
+          # https://github.com/rust-lang/rust-clippy/issues/10421
+          toolchain: 1.68.2
+          components: clippy,rustfmt
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
       - run: cargo clippy --locked --no-deps --all-targets --tests -- -D warnings

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -135,7 +135,7 @@ impl Btf<'static> {
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         fn inner(path: &Path) -> Result<Btf<'static>> {
             let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-                Error::InvalidInput(format!("invalid path {:?}, has null bytes", path))
+                Error::InvalidInput(format!("invalid path {path:?}, has null bytes"))
             })?;
             let ptr = create_bpf_entity_checked(|| unsafe {
                 libbpf_sys::btf__parse_elf(path.as_ptr(), std::ptr::null_mut())


### PR DESCRIPTION
CI and the clippy step specifically choke on the `bpf_query` example with Rust `1.69`, because of some false positive warning that we cannot disable.
Work with `1.68.2` for the time being.