### PR TITLE
Use util::parse() in Map::create constructor

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -667,10 +667,7 @@ impl Map {
                 opts,
             )
         };
-
-        if fd < 0 {
-            return Err(Error::System(fd));
-        }
+        let () = util::parse_ret(fd)?;
 
         Ok(Map {
             fd: MapFd::Owned(unsafe {


### PR DESCRIPTION
Fix `Map::create()` to use `util::parse()` instead of directly evaluating the return code and getting it wrong by not negating.