### PR TITLE
Adjust CONTRIBUTING to mention building commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ smaller commits. Smaller commits are much easier to review and more likely
 to get merged in. Please make sure each commit is an isolated change (eg if
 the commit does 2 separate things, please split it).
 
+- **Maintain a fully working commit history.**
+Each commit should represent a fully working state, i.e., not be breaking builds
+or causing test failures. Doing so helps when bisecting issues in the future.
+
 - **Use a descriptive title.**
 
 - **Include useful details in the commit messages.**


### PR DESCRIPTION
We require all commits in a pull request (and the broader repository history in general) to represent a compilable and testable (i.e., all tests passing successfully) snapshot of all components in the repository.
Make that explicit in the CONTRIBUTING guide.