### PR TITLE
Properly zero initialize uprobe opts `sz` member

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,16 @@ on:
 
 jobs:
   build:
+    name: Test [${{ matrix.rust }}, ${{ matrix.profile }}]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         rust: [stable, nightly]
+        profile: [dev]
+        include:
+          - rust: stable
+            profile: release
     steps:
     - name: "Set environmental variables"
       shell: bash
@@ -50,12 +55,12 @@ jobs:
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
     - uses: Swatinem/rust-cache@v2.2.0
     - name: Build
-      run: cargo build --locked --verbose --workspace --exclude runqslower
+      run: cargo build --profile=${{ matrix.profile }} --locked --verbose --workspace --exclude runqslower
     - name: Run tests
       # Skip BTF & map tests which require sudo
-      run: cargo test --locked --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc --skip test_map_info --include-ignored
+      run: cargo test --profile=${{ matrix.profile }} --locked --verbose --workspace --exclude runqslower -- --skip test_object --skip test_tc --skip test_map_info --include-ignored
     - name: Run BTF tests
-      run: cd libbpf-rs && cargo test --locked --verbose -- test_object test_tc
+      run: cd libbpf-rs && cargo test --profile=${{ matrix.profile }} --locked --verbose -- test_object test_tc
 
   build-minimum:
     name: Build using minimum versions of dependencies

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
   capabilities
 - Fixed issue where instances of `Map` created or opened without going through
   `Object` would leak file descriptors
+- Fixed potential Uprobe attachment failures on optimized builds caused by
+  improper `libbpf_sys::bpf_object_open_opts` object initialization
 - Adjusted various methods to work with `BorrowedFd` instead of raw file
   descriptors
 - Made `RingBufferBuilder::add` enforce that `self` cannot outlive the maps

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -5,8 +5,8 @@ use std::os::unix::io::AsFd;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::BorrowedFd;
 use std::path::Path;
+use std::ptr;
 use std::ptr::NonNull;
-use std::ptr::{self};
 
 use libbpf_sys::bpf_func_id;
 use num_enum::TryFromPrimitive;
@@ -545,7 +545,7 @@ impl Program {
 
         let func_name = util::str_to_cstring(&func_name)?;
         let opts = libbpf_sys::bpf_uprobe_opts {
-            sz: mem::size_of::<Self>() as u64,
+            sz: mem::size_of::<libbpf_sys::bpf_uprobe_opts>() as _,
             ref_ctr_offset: ref_ctr_offset as libbpf_sys::size_t,
             bpf_cookie: cookie,
             retprobe,

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -80,7 +80,7 @@ pub fn create_bpf_entity_checked<B: 'static, F: FnOnce() -> *mut B>(f: F) -> Res
                                            //
                                            // One way to fix the bug might be to change to calling
                                            // create_bpf_entity_checked_opt and handling Ok(None)
-                                           // as a meaningfull value.
+                                           // as a meaningful value.
             ))
         })
     })

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::ffi::c_void;
 use std::fs;
+use std::hint;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
@@ -1102,7 +1103,8 @@ fn test_object_tracepoint_with_opts() {
 #[inline(never)]
 #[no_mangle]
 extern "C" fn uprobe_target() -> usize {
-    42
+    // Use `black_box` here as an additional barrier to inlining.
+    hint::black_box(42)
 }
 
 /// Check that we can attach a BPF program to a uprobe.


### PR DESCRIPTION
This change fixes the `sz` member initialization of `bpf_uprobe_opts` objects that we use in the uprobe attach code. The previously incorrect size could lead to libbpf failing the attachment on optimized builds, where the size of Program objects was different to dev ones.

Fixes: #447 
