### PR TITLE
Run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     versioning-strategy: "lockfile-only"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
It is easier to manage small batches of dependency updates than it is for large once. Run Dependabot daily instead of weekly to get closer to this ideal.