### PR TITLE
Split Maps into Maps and MapHandles (fixes #448)

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -8,6 +8,12 @@ Unreleased
 - Added `Program::attach_iter` for attaching of programs to an iterator
 - Added `Map::delete_batch` method for bulk deletion of elements
 - Added read/update/delete support for queue and stack `Map` types
+- Changed `Map` API:
+    - Added a new `MapHandle` which provides most functionality previously found in `Map`.
+      Those can be obtained from a `Map` and can be duplicated.
+    - Removed support for creating `Map` objects standalone (i.e. maps not created by libbpf).
+      This functionality has been moved to `MapHandle`.
+    - Removed `Map::fd()`. Use `Map::as_fd()` instead.
 - Improved `btf_type_match!` macro, adding support for most of Rust's `match`
   capabilities
 - Added `skel` module exposing skeleton related traits

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -103,6 +103,7 @@ pub use crate::link::Link;
 pub use crate::linker::Linker;
 pub use crate::map::Map;
 pub use crate::map::MapFlags;
+pub use crate::map::MapHandle;
 pub use crate::map::MapInfo;
 pub use crate::map::MapType;
 pub use crate::map::OpenMap;

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -836,12 +836,38 @@ impl MapHandle {
         })
     }
 
+    /// Fetch extra map information
+    #[inline]
+    pub fn info(&self) -> Result<MapInfo> {
+        MapInfo::new(self.fd.as_fd())
+    }
+
+    /// Retrieve the `Map`'s name.
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns a file descriptor to the underlying map.
+    #[inline]
+    pub fn fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+
+    /// Retrieve type of the map.
+    #[inline]
     pub fn map_type(&self) -> MapType {
         self.ty
     }
+
+    /// Key size in bytes
+    #[inline]
     pub fn key_size(&self) -> u32 {
         self.key_size
     }
+
+    /// Value size in bytes
+    #[inline]
     pub fn value_size(&self) -> u32 {
         self.value_size
     }
@@ -925,6 +951,230 @@ impl MapHandle {
                 flags.bits,
             )
         };
+
+        util::parse_ret(ret)
+    }
+
+    /// Returns map value as `Vec` of `u8`.
+    ///
+    /// `key` must have exactly [`Map::key_size()`] elements.
+    ///
+    /// If the map is one of the per-cpu data structures, the function [`Map::lookup_percpu()`]
+    /// must be used.
+    pub fn lookup(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<u8>>> {
+        if self.map_type().is_percpu() {
+            return Err(Error::InvalidInput(format!(
+                "lookup_percpu() must be used for per-cpu maps (type of the map is {})",
+                self.map_type(),
+            )));
+        }
+
+        let out_size = self.value_size() as usize;
+        self.lookup_raw(key, flags, out_size)
+    }
+
+    /// Returns one value per cpu as `Vec` of `Vec` of `u8` for per per-cpu maps.
+    ///
+    /// For normal maps, [`Map::lookup()`] must be used.
+    pub fn lookup_percpu(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<Vec<u8>>>> {
+        if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
+            return Err(Error::InvalidInput(format!(
+                "lookup() must be used for maps that are not per-cpu (type of the map is {})",
+                self.map_type(),
+            )));
+        }
+
+        let val_size = self.value_size() as usize;
+        let aligned_val_size = self.percpu_aligned_value_size();
+        let out_size = self.percpu_buffer_size()?;
+
+        let raw_res = self.lookup_raw(key, flags, out_size)?;
+        if let Some(raw_vals) = raw_res {
+            let mut out = Vec::new();
+            for chunk in raw_vals.chunks_exact(aligned_val_size) {
+                out.push(chunk[..val_size].to_vec());
+            }
+            Ok(Some(out))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Deletes an element from the map.
+    ///
+    /// `key` must have exactly [`Map::key_size()`] elements.
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        if key.len() != self.key_size() as usize {
+            return Err(Error::InvalidInput(format!(
+                "key_size {} != {}",
+                key.len(),
+                self.key_size()
+            )));
+        };
+
+        let ret = unsafe {
+            libbpf_sys::bpf_map_delete_elem(self.fd.as_raw_fd(), key.as_ptr() as *const c_void)
+        };
+        util::parse_ret(ret)
+    }
+
+    /// Deletes many elements in batch mode from the map.
+    ///
+    /// `keys` must have exactly [`Map::key_size()` * count] elements.
+    pub fn delete_batch(
+        &self,
+        keys: &[u8],
+        count: u32,
+        elem_flags: MapFlags,
+        flags: MapFlags,
+    ) -> Result<()> {
+        if keys.len() as u32 / count != self.key_size() || (keys.len() as u32) % count != 0 {
+            return Err(Error::InvalidInput(format!(
+                "batch key_size {} != {} * {}",
+                keys.len(),
+                self.key_size(),
+                count
+            )));
+        };
+
+        let opts = libbpf_sys::bpf_map_batch_opts {
+            sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as u64,
+            elem_flags: elem_flags.bits,
+            flags: flags.bits,
+        };
+
+        let mut count = count;
+        let ret = unsafe {
+            libbpf_sys::bpf_map_delete_batch(
+                self.fd.as_raw_fd(),
+                keys.as_ptr() as *const c_void,
+                (&mut count) as *mut u32,
+                &opts as *const libbpf_sys::bpf_map_batch_opts,
+            )
+        };
+        util::parse_ret(ret)
+    }
+
+    /// Same as [`Map::lookup()`] except this also deletes the key from the map.
+    ///
+    /// Note that this operation is currently only implemented in the kernel for [`MapType::Queue`]
+    /// and [`MapType::Stack`].
+    ///
+    /// `key` must have exactly [`Map::key_size()`] elements.
+    pub fn lookup_and_delete(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        if key.len() != self.key_size() as usize {
+            return Err(Error::InvalidInput(format!(
+                "key_size {} != {}",
+                key.len(),
+                self.key_size()
+            )));
+        };
+
+        let mut out: Vec<u8> = Vec::with_capacity(self.value_size() as usize);
+
+        let ret = unsafe {
+            libbpf_sys::bpf_map_lookup_and_delete_elem(
+                self.fd.as_raw_fd(),
+                self.map_key(key),
+                out.as_mut_ptr() as *mut c_void,
+            )
+        };
+
+        if ret == 0 {
+            unsafe {
+                out.set_len(self.value_size() as usize);
+            }
+            Ok(Some(out))
+        } else {
+            let errno = errno::errno();
+            if errno::Errno::from_i32(errno) == errno::Errno::ENOENT {
+                Ok(None)
+            } else {
+                Err(Error::System(errno))
+            }
+        }
+    }
+
+    /// Update an element.
+    ///
+    /// `key` must have exactly [`Map::key_size()`] elements. `value` must have exactly
+    /// [`Map::value_size()`] elements.
+    ///
+    /// For per-cpu maps, [`Map::update_percpu()`] must be used.
+    pub fn update(&self, key: &[u8], value: &[u8], flags: MapFlags) -> Result<()> {
+        if self.map_type().is_percpu() {
+            return Err(Error::InvalidInput(format!(
+                "update_percpu() must be used for per-cpu maps (type of the map is {})",
+                self.map_type(),
+            )));
+        }
+
+        if value.len() != self.value_size() as usize {
+            return Err(Error::InvalidInput(format!(
+                "value_size {} != {}",
+                value.len(),
+                self.value_size()
+            )));
+        };
+
+        self.update_raw(key, value, flags)
+    }
+
+    /// Update an element in an per-cpu map with one value per cpu.
+    ///
+    /// `key` must have exactly [`Map::key_size()`] elements. `value` must have one
+    /// element per cpu (see [`num_possible_cpus`][crate::num_possible_cpus])
+    /// with exactly [`Map::value_size()`] elements each.
+    ///
+    /// For per-cpu maps, [`Map::update_percpu()`] must be used.
+    pub fn update_percpu(&self, key: &[u8], values: &[Vec<u8>], flags: MapFlags) -> Result<()> {
+        if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
+            return Err(Error::InvalidInput(format!(
+                "update() must be used for maps that are not per-cpu (type of the map is {})",
+                self.map_type(),
+            )));
+        }
+
+        if values.len() != crate::num_possible_cpus()? {
+            return Err(Error::InvalidInput(format!(
+                "number of values {} != number of cpus {}",
+                values.len(),
+                crate::num_possible_cpus()?
+            )));
+        };
+
+        let val_size = self.value_size() as usize;
+        let aligned_val_size = self.percpu_aligned_value_size();
+        let buf_size = self.percpu_buffer_size()?;
+
+        let mut value_buf = Vec::new();
+        value_buf.resize(buf_size, 0);
+
+        for (i, val) in values.iter().enumerate() {
+            if val.len() != val_size {
+                return Err(Error::InvalidInput(format!(
+                    "value size for cpu {} is {} != {}",
+                    i,
+                    val.len(),
+                    val_size
+                )));
+            }
+
+            value_buf[(i * aligned_val_size)..(i * aligned_val_size + val_size)]
+                .copy_from_slice(val);
+        }
+
+        self.update_raw(key, &value_buf, flags)
+    }
+
+    /// Freeze the map as read-only from user space.
+    ///
+    /// Entries from a frozen map can no longer be updated or deleted with the
+    /// bpf() system call. This operation is not reversible, and the map remains
+    /// immutable from user space until its destruction. However, read and write
+    /// permissions for BPF programs to the map remain unchanged.
+    pub fn freeze(&self) -> Result<()> {
+        let ret = unsafe { libbpf_sys::bpf_map_freeze(self.fd.as_raw_fd()) };
 
         util::parse_ret(ret)
     }

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -122,7 +122,9 @@ impl OpenMap {
     }
 
     pub fn set_inner_map_fd(&mut self, inner: &Map) {
-        unsafe { libbpf_sys::bpf_map__set_inner_map_fd(self.ptr.as_ptr(), inner.fd().as_raw_fd()) };
+        unsafe {
+            libbpf_sys::bpf_map__set_inner_map_fd(self.ptr.as_ptr(), inner.as_fd().as_raw_fd())
+        };
     }
 
     pub fn set_map_extra(&mut self, map_extra: u64) -> Result<()> {
@@ -955,7 +957,7 @@ impl<'a> Iterator for MapKeyIter<'a> {
 
         let ret = unsafe {
             libbpf_sys::bpf_map_get_next_key(
-                self.map.fd().as_raw_fd(),
+                self.map.as_fd().as_raw_fd(),
                 prev as _,
                 self.next.as_mut_ptr() as _,
             )

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -346,6 +346,16 @@ impl AsFd for Map {
 
 /// A handle to a map. Handles can be duplicated and dropped.
 ///
+/// While possible to [created directly][MapHandle::create], in many cases it is
+/// useful to create such a handle from an existing [`Map`]:
+/// ```no_run
+/// # use libbpf_rs::Map;
+/// # use libbpf_rs::MapHandle;
+/// # let get_map = || -> &Map { todo!() };
+/// let map: &Map = get_map();
+/// let map_handle = MapHandle::try_clone(map).unwrap();
+/// ```
+///
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
 #[derive(Debug)]

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -806,6 +806,44 @@ impl TryFrom<OwnedFd> for Map {
     }
 }
 
+/// A handle to a map. Handles can be duplicated and dropped.
+///
+/// Some methods require working with raw bytes. You may find libraries such as
+/// [`plain`](https://crates.io/crates/plain) helpful.
+#[derive(Debug)]
+pub struct MapHandle {
+    fd: MapFd,
+    name: String,
+    ty: MapType,
+    key_size: u32,
+    value_size: u32,
+}
+
+impl MapHandle {
+    /// Try cloning this handle by duplicating its underlying file descriptor.
+    pub fn try_clone(this: &MapHandle) -> Result<Self> {
+        let new_fd = this
+            .as_fd()
+            .try_clone_to_owned()
+            .map_err(|e| Error::Internal(e.to_string()))?;
+        let fd = MapFd::Owned(new_fd);
+        Ok(MapHandle {
+            fd,
+            name: this.name.clone(),
+            ty: this.ty,
+            key_size: this.key_size,
+            value_size: this.value_size,
+        })
+    }
+}
+
+impl AsFd for MapHandle {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
 bitflags! {
     /// Flags to configure [`Map`] operations.
     pub struct MapFlags: u64 {

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -3,6 +3,7 @@ use std::boxed::Box;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
+use std::os::unix::io::AsFd;
 use std::os::unix::prelude::AsRawFd;
 use std::ptr::NonNull;
 use std::slice;
@@ -130,7 +131,7 @@ impl<'a, 'b> PerfBufferBuilder<'a, 'b> {
 
         util::create_bpf_entity_checked(|| unsafe {
             libbpf_sys::perf_buffer__new(
-                self.map.fd().as_raw_fd(),
+                self.map.as_fd().as_raw_fd(),
                 self.pages as libbpf_sys::size_t,
                 c_sample_cb,
                 c_lost_cb,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -5,6 +5,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::ops::Deref as _;
 use std::os::raw::c_ulong;
+use std::os::unix::io::AsFd;
 use std::os::unix::prelude::AsRawFd;
 use std::os::unix::prelude::BorrowedFd;
 use std::ptr::NonNull;
@@ -76,7 +77,7 @@ impl<'a> RingBufferBuilder<'a> {
             return Err(Error::InvalidInput("Must use a RingBuf map".into()));
         }
         self.fd_callbacks
-            .push((map.fd(), RingBufferCallback::new(callback)));
+            .push((map.as_fd(), RingBufferCallback::new(callback)));
         Ok(self)
     }
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -24,6 +24,7 @@ use libbpf_rs::Iter;
 use libbpf_rs::Linker;
 use libbpf_rs::Map;
 use libbpf_rs::MapFlags;
+use libbpf_rs::MapHandle;
 use libbpf_rs::MapInfo;
 use libbpf_rs::MapType;
 use libbpf_rs::Object;
@@ -244,7 +245,7 @@ pub fn test_sudo_map_info() {
         map_ifindex: 0,
     };
 
-    let map = Map::create(MapType::Hash, Some("simple_map"), 8, 64, 1024, &opts).unwrap();
+    let map = MapHandle::create(MapType::Hash, Some("simple_map"), 8, 64, 1024, &opts).unwrap();
     let map_info = MapInfo::new(map.fd()).unwrap();
     let name_received = map_info.name().unwrap();
     assert_eq!(name_received, "simple_map");
@@ -580,7 +581,7 @@ fn test_sudo_object_loading_pinned_map_from_path() {
 
     map.pin(path).expect("pinning map failed");
 
-    let pinned_map = Map::from_pinned_path(path).expect("loading a map from a path failed");
+    let pinned_map = MapHandle::from_pinned_path(path).expect("loading a map from a path failed");
     map.unpin(path).expect("unpinning map failed");
 
     assert_eq!(map.name(), pinned_map.name());
@@ -599,7 +600,7 @@ fn test_sudo_object_loading_loaded_map_from_id() {
 
     let id = map.info().expect("to get info from map 'start'").info.id;
 
-    let map_by_id = Map::from_map_id(id).expect("map to load from id");
+    let map_by_id = MapHandle::from_map_id(id).expect("map to load from id");
 
     assert_eq!(map.name(), map_by_id.name());
     assert_eq!(
@@ -934,7 +935,7 @@ fn test_sudo_object_map_iter() {
         map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
         ..Default::default()
     };
-    let map = Map::create(
+    let map = MapHandle::create(
         MapType::Hash,
         Some("mymap_test_object_map_iter"),
         4,
@@ -985,7 +986,7 @@ fn test_sudo_object_map_create_and_pin() {
         ..Default::default()
     };
 
-    let mut map = Map::create(
+    let mut map = MapHandle::create(
         MapType::Hash,
         Some("mymap_test_sudo_object_map_create_and_pin"),
         4,
@@ -1037,7 +1038,7 @@ fn test_sudo_object_map_create_without_name() {
         map_ifindex: 0,
     };
 
-    let map = Map::create(MapType::Hash, Option::<&str>::None, 4, 8, 8, &opts)
+    let map = MapHandle::create(MapType::Hash, Option::<&str>::None, 4, 8, 8, &opts)
         .expect("failed to create map");
 
     assert!(map.name().is_empty());
@@ -1400,7 +1401,7 @@ fn test_sudo_map_pinned_status() {
         .map("auto_pin_map")
         .expect("failed to find map 'auto_pin_map'");
 
-    let is_pinned = map.is_pinned().expect("get map pin status failed");
+    let is_pinned = map.is_pinned();
     assert!(is_pinned);
     let expected_path = "/sys/fs/bpf/auto_pin_map";
     let get_path = map.get_pin_path().expect("get map pin path failed");

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -5,6 +5,7 @@ use std::hint;
 use std::io::Read;
 use std::mem::size_of;
 use std::os::fd::AsRawFd;
+use std::os::unix::io::AsFd;
 use std::path::Path;
 use std::path::PathBuf;
 use std::slice;
@@ -246,7 +247,7 @@ pub fn test_sudo_map_info() {
     };
 
     let map = MapHandle::create(MapType::Hash, Some("simple_map"), 8, 64, 1024, &opts).unwrap();
-    let map_info = MapInfo::new(map.fd()).unwrap();
+    let map_info = MapInfo::new(map.as_fd()).unwrap();
     let name_received = map_info.name().unwrap();
     assert_eq!(name_received, "simple_map");
     assert_eq!(map_info.map_type(), MapType::Hash);
@@ -957,7 +958,7 @@ fn test_sudo_object_map_iter() {
     let mut obj = get_test_object("mapiter.bpf.o");
     let prog = obj.prog_mut("map_iter").expect("Failed to find program");
     let link = prog
-        .attach_iter(map.fd())
+        .attach_iter(map.as_fd())
         .expect("Failed to attach map iter prog");
     let mut iter = Iter::new(&link).expect("Failed to create map iterator");
 


### PR DESCRIPTION
So, this is a first idea on how these handles could look like.

As it turns out, the vast majority of the current `Map` logic can be put into a `MapHandle`. In this first proposal I've done exactly that: Move most things from `Map` to `MapHandle`. This results in a rather large diff, but I've tried to keep commits small(er).

These handles are currently marked as `Send + Sync` (auto-derived by the compiler), which should be fine since all libbpf functions called are (effectively) threadsafe small syscall wrappers. Since their only reference is an FD, they can also be (safely) cloned (though the kernel may return I/O errors when DUP'ing FDs). There is no new unsafe code in this PR (as of now).

In order to avoid code duplication and to allow generic code, I've added a trait and moved code so that `Map` is now a relatively thin wrapper around `MapHandle`. This results in the `MapHandle`s being less lightweight than I had originally imagined. Let me know what you think about this.

This is still WIP and a few things are missing (new tests perhaps, changelog & version bump at least). The new handles do result in slight breaking changes: Most usages of `Map` now require the new trait `BpfMap` to be imported, and you can only create `MapHandle`s from userspace, not `Map`s.

This PR fixes issue #448.