### PR TITLE
Remove Program::fd() method

### DIFF
--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -1,6 +1,10 @@
+use std::os::unix::io::AsFd as _;
+
 use anyhow::bail;
 use anyhow::Result;
+
 use clap::Parser;
+
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::MapFlags;
@@ -66,7 +70,7 @@ fn main() -> Result<()> {
     let progs = skel.progs();
     let ifidx = nix::net::if_::if_nametoindex(opts.iface.as_str())? as i32;
 
-    let mut tc_builder = TcHookBuilder::new(progs.handle_tc().fd());
+    let mut tc_builder = TcHookBuilder::new(progs.handle_tc().as_fd());
     tc_builder
         .ifindex(ifidx)
         .replace(true)
@@ -79,7 +83,7 @@ fn main() -> Result<()> {
     custom.parent(TC_H_CLSACT, TC_H_MIN_INGRESS).handle(2);
 
     // we can create a TcHook w/o the builder
-    let mut destroy_all = libbpf_rs::TcHook::new(progs.handle_tc().fd());
+    let mut destroy_all = libbpf_rs::TcHook::new(progs.handle_tc().as_fd());
     destroy_all
         .ifindex(ifidx)
         .attach_point(TC_EGRESS | TC_INGRESS);

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::os::unix::io::AsFd as _;
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -71,7 +72,7 @@ fn main() -> Result<()> {
     let skel = open_skel.load()?;
     let progs = skel.progs();
     // Set up and attach ingress TC hook
-    let mut ingress = TcHookBuilder::new(progs.tproxy().fd())
+    let mut ingress = TcHookBuilder::new(progs.tproxy().as_fd())
         .ifindex(opts.ifindex)
         .replace(true)
         .handle(1)

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 - Removed support for creating `Map` objects standalone (i.e. maps not created
   by libbpf)
 - Removed `Map::fd()` in favor of `Map::as_fd()`
+- Removed `Program::fd()` in favor of `Program::as_fd()`
 - Improved `btf_type_match!` macro, adding support for most of Rust's `match`
   capabilities
 - Added `skel` module exposing skeleton related traits

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -12,8 +12,8 @@ Unreleased
   `Map`
 - Removed support for creating `Map` objects standalone (i.e. maps not created
   by libbpf)
-- Removed `Map::fd()` in favor of `Map::as_fd()`
-- Removed `Program::fd()` in favor of `Program::as_fd()`
+- Removed various `<object-type>::fd()` methods in favor of
+  `<object-type>::as_fd()`
 - Improved `btf_type_match!` macro, adding support for most of Rust's `match`
   capabilities
 - Added `skel` module exposing skeleton related traits

--- a/libbpf-rs/src/iter.rs
+++ b/libbpf-rs/src/iter.rs
@@ -1,7 +1,10 @@
+use std::io;
+use std::os::unix::io::AsFd as _;
+use std::os::unix::io::AsRawFd as _;
+
 use nix::errno;
 use nix::libc;
 use nix::unistd;
-use std::io;
 
 use crate::libbpf_sys;
 use crate::Error;
@@ -22,7 +25,7 @@ pub struct Iter {
 impl Iter {
     /// Create a new `Iter` wrapping the provided `Link`.
     pub fn new(link: &Link) -> Result<Self> {
-        let link_fd = link.fd();
+        let link_fd = link.as_fd().as_raw_fd();
         let fd = unsafe { libbpf_sys::bpf_iter_create(link_fd) };
         if fd < 0 {
             return Err(Error::System(errno::errno()));

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -83,11 +83,6 @@ impl Link {
         util::parse_ret(ret)
     }
 
-    /// Returns the file descriptor of the link.
-    pub fn fd(&self) -> i32 {
-        unsafe { libbpf_sys::bpf_link__fd(self.ptr.as_ptr()) }
-    }
-
     /// Returns path to BPF FS file or `None` if not pinned.
     pub fn pin_path(&self) -> Option<PathBuf> {
         let path_ptr = unsafe { libbpf_sys::bpf_link__pin_path(self.ptr.as_ptr()) };

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -416,11 +416,6 @@ impl Program {
         }
     }
 
-    /// Returns a file descriptor to the underlying program.
-    pub fn fd(&self) -> BorrowedFd {
-        self.as_fd()
-    }
-
     /// Returns program fd by id
     pub fn get_fd_by_id(id: u32) -> Result<OwnedFd> {
         let ret = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) };
@@ -710,7 +705,12 @@ impl Program {
     /// Attach a verdict/parser to a [sockmap/sockhash](https://lwn.net/Articles/731133/)
     pub fn attach_sockmap(&self, map_fd: i32) -> Result<()> {
         let err = unsafe {
-            libbpf_sys::bpf_prog_attach(self.fd().as_raw_fd(), map_fd, self.attach_type() as u32, 0)
+            libbpf_sys::bpf_prog_attach(
+                self.as_fd().as_raw_fd(),
+                map_fd,
+                self.attach_type() as u32,
+                0,
+            )
         };
         util::parse_ret(err)
     }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1448,7 +1448,7 @@ fn test_sudo_program_get_fd_and_id() {
         .prog("handle__sched_wakeup")
         .expect("failed to find program");
 
-    let prog_fd = prog.fd();
+    let prog_fd = prog.as_fd();
     let prog_id = Program::get_id_by_fd(prog_fd).expect("failed to get program id by fd");
     let owned_prog_fd = Program::get_fd_by_id(prog_id).expect("failed to get program fd by id");
     close(owned_prog_fd.as_raw_fd()).expect("failed to close owned program fd");

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,3 +1,4 @@
+use std::os::unix::io::AsFd as _;
 use std::os::unix::io::BorrowedFd;
 
 use serial_test::serial;
@@ -45,7 +46,7 @@ fn test_sudo_tc_basic_cycle() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -87,7 +88,7 @@ fn test_sudo_tc_attach_no_qdisc() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -112,7 +113,7 @@ fn test_sudo_tc_attach_basic() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -141,7 +142,7 @@ fn test_sudo_tc_attach_repeat() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -180,7 +181,7 @@ fn test_sudo_tc_attach_repeat() {
 fn test_sudo_tc_attach_custom() {
     bump_rlimit_mlock();
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -233,7 +234,7 @@ fn test_sudo_tc_attach_custom() {
 fn test_sudo_tc_detach_basic() {
     bump_rlimit_mlock();
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -280,7 +281,7 @@ fn test_sudo_tc_query() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder
@@ -352,7 +353,7 @@ fn test_sudo_tc_double_create() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let fd = obj.prog("handle_tc").unwrap().fd();
+    let fd = obj.prog("handle_tc").unwrap().as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
     tc_builder


### PR DESCRIPTION
In recent times we started using file descriptor abstractions over "raw" integers. As part of that we also relied on the `AsFd` trait and provided implementations for the same.
Given that we implement this trait, it no longer makes sense to have a dedicated `fd()` method. With this change we remove it from the `Program` type.