### PR TITLE
Improve error reporting on BPF C file compilation failure

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Adjusted skeleton generation code to ensure implementation of `libbpf-rs`'s
   `SkelBuilder`, `OpenSkel`, and `Skel` traits
+- Improved error reporting on BPF C file compilation failure
 
 
 0.20.1


### PR DESCRIPTION
Error reporting when a BPF C file fails to compile is a bit of a mess. The formatting is all over the place and the command being executed is not printed at all, perhaps making it harder than necessary to iterate quickly to get issues fixed. E.g., this is the output for an induced compilation failure:

```
Compiling BPF objects
Error: Failed to compile BPF objects

Caused by:
    Failed to compile progs: Failed to compile obj=<path>/libbpf-rs/target/bpf/basic.bpf.o with status=exit status: 1
     stdout=

     stderr=
     <path>/libbpf-rs/examples/basic/src/bpf/basic.bpf.c:11:2: error: FOobar
    #error FOobar
     ^
    1 error generated.
```

With this change we reformat the output a bit and make sure to include the actual command being run in there as well. For the same error we now see a proper error chain:

```
Compiling BPF objects
Error: Failed to compile BPF objects

Caused by:
    0: Failed to compile progs
    1: Failed to compile <path>/libbpf-rs/target/bpf/basic.bpf.o from <path>/libbpf-rs/examples/basic/src/bpf/basic.bpf.c
    2: Command `clang -I<path>/libbpf-rs/target/bpf/src -D__TARGET_ARCH_x86 -g -O2 -target bpf -c <path>/libbpf-rs/examples/basic/src/bpf/basic.bpf.c -o <path>/libbpf-rs/target/bpf/basic.bpf.o` failed (exit status: 1)
    3: <path>/libbpf-rs/examples/basic/src/bpf/basic.bpf.c:11:2: error: FOobar
       #error FOobar
        ^
       1 error generated.
```

The command printed can be copy and pasted directly and will allow for fast compilation without libbpf-rs involvement.