### PR TITLE
Stop eliding lifetimes

### DIFF
--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -55,7 +55,11 @@
 //! build`. This is a convenience command so you don't forget any steps. Alternatively, you could
 //! write a Makefile for your project.
 
-#![warn(clippy::wildcard_imports)]
+#![warn(
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    clippy::wildcard_imports
+)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use std::path::Path;

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -877,7 +877,7 @@ macro_rules! btf_type_match {
             $($pattern:tt)+
         }
     ) => {{
-        let ty: $crate::btf::BtfType = $ty;
+        let ty: $crate::btf::BtfType<'_> = $ty;
         $crate::__btf_type_match!(match ty.kind() { } $($pattern)*)
     }};
 }
@@ -1014,7 +1014,7 @@ mod test {
         };
     }
 
-    fn foo(_: super::Int) -> &'static str {
+    fn foo(_: super::Int<'_>) -> &'static str {
         "int"
     }
 

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -68,8 +68,10 @@
 
 #![allow(clippy::let_unit_value)]
 #![warn(
+    elided_lifetimes_in_paths,
     missing_debug_implementations,
     missing_docs,
+    single_use_lifetimes,
     clippy::wildcard_imports,
     rustdoc::broken_intra_doc_links
 )]

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -290,7 +290,7 @@ impl Map {
     /// Note that if the map is not stable (stable meaning no updates or deletes) during iteration,
     /// iteration can skip keys, restart from the beginning, or duplicate keys. In other words,
     /// iteration becomes unpredictable.
-    pub fn keys(&self) -> MapKeyIter {
+    pub fn keys(&self) -> MapKeyIter<'_> {
         MapKeyIter::new(self, self.key_size())
     }
 
@@ -953,7 +953,7 @@ impl<'a> MapKeyIter<'a> {
     }
 }
 
-impl<'a> Iterator for MapKeyIter<'a> {
+impl Iterator for MapKeyIter<'_> {
     type Item = Vec<u8>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -985,7 +985,7 @@ pub struct MapInfo {
 
 impl MapInfo {
     /// Create a `MapInfo` object from a fd.
-    pub fn new(fd: BorrowedFd) -> Result<Self> {
+    pub fn new(fd: BorrowedFd<'_>) -> Result<Self> {
         // SAFETY: `bpf_map_info` is valid for any bit pattern.
         let mut map_info = unsafe { mem::zeroed::<bpf_map_info>() };
         let mut size = mem::size_of_val(&map_info) as u32;

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -373,7 +373,7 @@ impl Object {
     }
 
     /// Parse the btf information associated with this bpf object.
-    pub fn btf(&self) -> Result<Btf> {
+    pub fn btf(&self) -> Result<Btf<'_>> {
         Btf::from_bpf_object(unsafe { &*self.ptr.as_ptr() })
     }
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -427,7 +427,7 @@ impl Program {
     }
 
     /// Returns program id by fd
-    pub fn get_id_by_fd(fd: BorrowedFd) -> Result<u32> {
+    pub fn get_id_by_fd(fd: BorrowedFd<'_>) -> Result<u32> {
         let mut prog_info = libbpf_sys::bpf_prog_info::default();
         let prog_info_ptr: *mut libbpf_sys::bpf_prog_info = &mut prog_info;
         let mut len = mem::size_of::<libbpf_sys::bpf_prog_info>() as u32;
@@ -815,7 +815,7 @@ impl Program {
     /// Attach this program to a
     /// [BPF Iterator](https://www.kernel.org/doc/html/latest/bpf/bpf_iterators.html).
     /// The entry point of the program must be defined with `SEC("iter")` or `SEC("iter.s")`.
-    pub fn attach_iter(&mut self, map_fd: BorrowedFd) -> Result<Link> {
+    pub fn attach_iter(&mut self, map_fd: BorrowedFd<'_>) -> Result<Link> {
         util::create_bpf_entity_checked(|| unsafe {
             let mut linkinfo = libbpf_sys::bpf_iter_link_info::default();
             linkinfo.map.map_fd = map_fd.as_raw_fd() as u32;

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -131,7 +131,7 @@ impl<'a> RingBufferBuilder<'a> {
     }
 
     unsafe extern "C" fn call_sample_cb(ctx: *mut c_void, data: *mut c_void, size: c_ulong) -> i32 {
-        let callback_struct = ctx as *mut RingBufferCallback;
+        let callback_struct = ctx as *mut RingBufferCallback<'_>;
         let callback = unsafe { (*callback_struct).cb.as_mut() };
         let slice = unsafe { slice::from_raw_parts(data as *const u8, size as usize) };
 
@@ -151,7 +151,7 @@ pub struct RingBuffer<'a> {
     _cbs: Vec<Box<RingBufferCallback<'a>>>,
 }
 
-impl<'a> RingBuffer<'a> {
+impl RingBuffer<'_> {
     /// Poll from all open ring buffers, calling the registered callback for
     /// each one. Polls continually until we either run out of events to consume
     /// or `timeout` is reached. If `timeout` is Duration::MAX, this will block
@@ -206,6 +206,6 @@ mod test {
         {
         }
 
-        test::<RingBuffer>();
+        test::<RingBuffer<'_>>();
     }
 }

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -236,7 +236,7 @@ pub struct ObjectSkeletonConfig<'a> {
     _string_pool: Vec<CString>,
 }
 
-impl<'a> ObjectSkeletonConfig<'a> {
+impl ObjectSkeletonConfig<'_> {
     #[allow(missing_docs)]
     pub fn get(&mut self) -> &mut bpf_object_skeleton {
         &mut self.inner
@@ -289,7 +289,7 @@ impl<'a> ObjectSkeletonConfig<'a> {
     }
 }
 
-impl<'a> Drop for ObjectSkeletonConfig<'a> {
+impl Drop for ObjectSkeletonConfig<'_> {
     // Note we do *not* run `libbpf_sys::bpf_object__destroy_skeleton` here.
     //
     // Couple reasons:
@@ -317,7 +317,7 @@ impl<'a> Drop for ObjectSkeletonConfig<'a> {
             }
         }
 
-        unsafe { Box::from_raw(self.inner.obj) };
+        let _ = unsafe { Box::from_raw(self.inner.obj) };
     }
 }
 


### PR DESCRIPTION
It's arguably confusing to see a definition such as
```rust
  impl<'a> OpenTproxySkel<'a> {
      pub fn maps(&self) -> OpenTproxyMaps {
          OpenTproxyMaps { inner: &self.obj }
      }
  }
```
because it omits the fact that the `OpenTproxyMaps` type actually has a lifetime associated with it.
Let's make sure to make lifetimes explicit to prevent such confusion from the start.