### PR TITLE
Ignore build & test issues on nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - rust: stable
             profile: release
+    # Anything nightly is treated as informational-only.
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
     - name: "Set environmental variables"
       shell: bash


### PR DESCRIPTION
Ignore build and test issues on nightly and treat them solely as informational. Nightly may occasionally break, but such breakages should generally not block submissions.