### PR TITLE
Switch to using resolver version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ members = [
   "examples/tc_port_whitelist",
   "examples/tproxy",
 ]
+resolver = "2"


### PR DESCRIPTION
Cargo's v2 version & feature resolver got introduced a while back. Apparently, however, it's not enabled by default for virtual workspaces:

> warning: some crates are on edition 2021 which defaults to `resolver =
>          "2"`, but virtual workspaces default to `resolver = "1"`
> note: to keep the current resolver, specify `workspace.resolver = "1"`
>       in the workspace root's manifest
> note: to use the edition 2021 resolver, specify `workspace.resolver =
>       "2"` in the workspace root's manifest

Let's switch to using resolver v2.