### PR TITLE
Don't dry-run package libbpf-cargo as part of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,8 @@ jobs:
         toolchain: stable
         override: true
     - name: Dry-run package creation
-      run: cargo package --package libbpf-rs --package libbpf-cargo --locked --no-verify
+      # Can't verify libbpf-cargo for it may depend on yet-to-be-published libbpf-rs.
+      run: cargo package --package libbpf-rs --locked --no-verify
     - name: Create git tag
       env:
         version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
We can't really verify the `libbpf-cargo` package because it unconditionally attempts to pull `libbpf-rs` from `crates.io`, where it can't find the specified version because it has not yet been published. For the time being, make do without checking `libbpf-cargo`.