### PR TITLE
Annotate `assert_definition()` helper with `#[track_caller]`

### DIFF
--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1120,6 +1120,7 @@ fn btf_from_mmap(mmap: &Mmap) -> GenBtf<'_> {
 /// Will trim leading and trailing whitespace from both expected output and from
 /// the generated type_definition
 /// fails calling text if type_definition does not match expected_output
+#[track_caller]
 fn assert_definition(btf: &GenBtf<'_>, btf_item: &BtfType<'_>, expected_output: &str) {
     let actual_output = btf
         .type_definition(*btf_item)


### PR DESCRIPTION
When assert_definition() fails we currently end up reporting the very assert!() invocation as failure location. That's not exactly useful. Annotate the function with #[track_caller] to make sure that we see the call site instead.

Before:
> thread 'test::test_btf_dump_definition_struct_inner_anon_union' panicked at 'assertion failed: eo == ao', libbpf-cargo/src/test.rs:1139:5

(that's
https://github.com/libbpf/libbpf-rs/blob/fb30a431a878a7d5da8e33091d6eb4e837577dba/libbpf-cargo/src/test.rs#L1139)

Now:
> thread 'test::test_btf_dump_definition_struct_inner_anon_union' panicked at 'assertion failed: eo == ao', libbpf-cargo/src/test.rs:1932:5

(that's
https://github.com/libbpf/libbpf-rs/blob/fb30a431a878a7d5da8e33091d6eb4e837577dba/libbpf-cargo/src/test.rs#L1931)