### PR TITLE
Make padding fields of generated types `pub`

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Adjusted named padding members in generated types to have `pub` visibility
+
+
 0.21.0
 ------
 - Adjusted skeleton generation code to ensure implementation of `libbpf-rs`'s

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -345,7 +345,7 @@ impl<'s> GenBtf<'s> {
                 )?;
 
                 if padding != 0 {
-                    agg_content.push(format!(r#"    __pad_{offset}: [u8; {padding}],"#,));
+                    agg_content.push(format!(r#"    pub __pad_{offset}: [u8; {padding}],"#,));
 
                     impl_default.push(format!(
                         r#"            __pad_{offset}: [u8::default(); {padding}]"#,
@@ -395,7 +395,7 @@ impl<'s> GenBtf<'s> {
             let struct_size = t.size();
             let padding = self.required_padding(offset, struct_size, &t, packed)?;
             if padding != 0 {
-                agg_content.push(format!(r#"    __pad_{offset}: [u8; {padding}],"#,));
+                agg_content.push(format!(r#"    pub __pad_{offset}: [u8; {padding}],"#,));
                 impl_default.push(format!(
                     r#"            __pad_{offset}: [u8::default(); {padding}]"#,
                 ));

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1205,7 +1205,7 @@ struct Foo foo = {1};
 #[repr(C)]
 pub struct Foo {
     pub x: i32,
-    __pad_4: [u8; 12],
+    pub __pad_4: [u8; 12],
 }
 "#;
 
@@ -1306,7 +1306,7 @@ pub struct Foo {
     pub ip: *mut i32,
     pub ipp: *mut *mut i32,
     pub bar: Bar,
-    __pad_18: [u8; 6],
+    pub __pad_18: [u8; 6],
     pub pb: *mut Bar,
     pub v: u64,
     pub cv: i64,
@@ -1361,7 +1361,7 @@ pub struct Foo {
     pub ip: *mut i32,
     pub ipp: *mut *mut i32,
     pub bar: Bar,
-    __pad_84: [u8; 4],
+    pub __pad_84: [u8; 4],
     pub pb: *mut Bar,
     pub v: u64,
     pub cv: i64,
@@ -1879,10 +1879,10 @@ struct Foo foo;
 pub struct Foo {
     pub x: i32,
     pub bar: __anon_1,
-    __pad_36: [u8; 4],
+    pub __pad_36: [u8; 4],
     pub baz: __anon_2,
     pub w: i32,
-    __pad_52: [u8; 4],
+    pub __pad_52: [u8; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -1961,7 +1961,7 @@ pub struct Foo {
     pub bar: __anon_1,
     pub baz: __anon_2,
     pub w: i32,
-    __pad_68: [u8; 4],
+    pub __pad_68: [u8; 4],
 }
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
@@ -1973,7 +1973,7 @@ pub struct __anon_1 {
 #[repr(C)]
 pub struct __anon_2 {
     pub w: u32,
-    __pad_4: [u8; 4],
+    pub __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 "#;
@@ -2026,7 +2026,7 @@ pub struct Foo {
     pub zerg: __anon_2,
     pub baz: __anon_3,
     pub w: i32,
-    __pad_76: [u8; 4],
+    pub __pad_76: [u8; 4],
     pub flarg: __anon_4,
 }
 #[derive(Debug, Default, Copy, Clone)]
@@ -2057,7 +2057,7 @@ impl Default for __anon_2 {
 #[repr(C)]
 pub struct __anon_3 {
     pub w: u32,
-    __pad_4: [u8; 4],
+    pub __pad_4: [u8; 4],
     pub u: *mut u64,
 }
 #[derive(Copy, Clone)]
@@ -2201,7 +2201,7 @@ struct bpf_sock_tuple_5_15 tup;
 #[repr(C)]
 pub struct bpf_sock_tuple_5_15 {
     pub __anon_1: __anon_1,
-    __pad_36: [u8; 4],
+    pub __pad_36: [u8; 4],
     pub __anon_2: __anon_2,
 }
 #[derive(Copy, Clone)]


### PR DESCRIPTION
It arguably makes very little sense for all "regular" fields in libbpf-cargo generated types to be publicly accessible, while padding fields are not.
Mark them as public as well. That's similar to what cbindgen does, with its named padding members.

Closes: #421