### PR TITLE
Bump bitflags to 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           profile: minimal
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.63.0
+          toolchain: 1.64.0
           components: rustfmt
           default: true
       - uses: Swatinem/rust-cache@v2.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 name = "libbpf-rs"
 version = "0.21.1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cc",
  "lazy_static",
  "libbpf-sys",

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Improved error reporting in build script usage
+- Bumped minimum Rust version to `1.64`
 
 
 0.21.1

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.21.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.64"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.63+-blue.svg)](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
 
 # libbpf-cargo
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Enabled key iteration on `MapHandle` objects (formerly possible only on `Map`
   objects)
+- Updated `bitflags` dependency to `2.0`
 - Bumped minimum Rust version to `1.64`
 
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Enabled key iteration on `MapHandle` objects (formerly possible only on `Map`
   objects)
+- Bumped minimum Rust version to `1.64`
 
 
 0.21.1

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 version = "0.21.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.64"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -21,7 +21,7 @@ novendor = ["libbpf-sys/novendor"]
 static = ["libbpf-sys/static"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.0"
 lazy_static = "1.4"
 libbpf-sys = { version = "1.0.3" }
 libc = "0.2"

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.63+-blue.svg)](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
 
 # libbpf-rs
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -549,7 +549,7 @@ impl MapHandle {
                 self.fd.as_raw_fd(),
                 self.map_key(key),
                 out.as_mut_ptr() as *mut c_void,
-                flags.bits,
+                flags.bits(),
             )
         };
 
@@ -584,7 +584,7 @@ impl MapHandle {
                 self.fd.as_raw_fd(),
                 self.map_key(key),
                 value.as_ptr() as *const c_void,
-                flags.bits,
+                flags.bits(),
             )
         };
 
@@ -675,8 +675,8 @@ impl MapHandle {
 
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
-            elem_flags: elem_flags.bits,
-            flags: flags.bits,
+            elem_flags: elem_flags.bits(),
+            flags: flags.bits(),
         };
 
         let mut count = count;
@@ -853,6 +853,7 @@ impl AsFd for MapHandle {
 
 bitflags! {
     /// Flags to configure [`Map`] operations.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct MapFlags: u64 {
         /// See [`libbpf_sys::BPF_ANY`].
         const ANY      = libbpf_sys::BPF_ANY as _;


### PR DESCRIPTION
Update the bitflags dependency to 2.0. Some changes to this new major version were breaking our code and required adjustments. See https://github.com/bitflags/bitflags/releases/tag/2.0.0 for relevant details.