### PR TITLE
Improve error context chaining

### DIFF
--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -1,6 +1,9 @@
+#![allow(clippy::let_unit_value)]
+
 use std::os::unix::io::AsFd as _;
 
 use anyhow::bail;
+use anyhow::Context as _;
 use anyhow::Result;
 
 use clap::Parser;
@@ -119,9 +122,11 @@ fn main() -> Result<()> {
         for (i, port) in opts.ports.iter().enumerate() {
             let key = (i as u32).to_ne_bytes();
             let val = port.to_ne_bytes();
-            if let Err(e) = skel.maps_mut().ports().update(&key, &val, MapFlags::ANY) {
-                bail!("Example limited to 10 ports: {e}");
-            }
+            let () = skel
+                .maps_mut()
+                .ports()
+                .update(&key, &val, MapFlags::ANY)
+                .context("Example limited to 10 ports")?;
         }
         ingress.create()?;
 

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -373,7 +373,7 @@ impl<'s> GenBtf<'s> {
                 }
                 Err(e) => {
                     if gen_impl_default || !t.is_struct {
-                        bail!("Could not construct a necessary Default Impl: {}", e);
+                        return Err(e.context("Could not construct a necessary Default Impl"));
                     }
                 }
             };

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -55,6 +55,7 @@
 //! build`. This is a convenience command so you don't forget any steps. Alternatively, you could
 //! write a Makefile for your project.
 
+#![allow(clippy::let_unit_value)]
 #![warn(
     elided_lifetimes_in_paths,
     single_use_lifetimes,

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_unit_value)]
+
 use std::path::PathBuf;
 
 use anyhow::Result;


### PR DESCRIPTION
There are a bunch of occasions where we wrongly embed errors into a string and report the resulting string as a new error. Fix them by creating proper error chains.