### PR TITLE
Implement Default for struct containing pointers

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added `Default` impl for generated `struct` types containing pointers
+- Fixed handling of function prototype type declaration inference in BTF and
+  skeleton generation
 - Improved error reporting in build script usage
 - Bumped minimum Rust version to `1.64`
 

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `Default` impl for generated `struct` types containing pointers
 - Improved error reporting in build script usage
 - Bumped minimum Rust version to `1.64`
 

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -134,12 +134,12 @@ impl<'s> GenBtf<'s> {
             }
             BtfKind::Struct | BtfKind::Union | BtfKind::Enum | BtfKind::Enum64 =>
                 self.get_type_name_handling_anon_types(&ty).into_owned(),
-            //    // The only way a variable references a function is through a function pointer.
-            //    // Return c_void here so the final def will look like `*mut c_void`.
-            //    //
-            //    // It's not like rust code can call a function inside a bpf prog either so we don't
-            //    // really need a full definition. `void *` is totally sufficient for sharing a pointer.
-            BtfKind::Func => "std::ffi::c_void".to_string(),
+            // The only way a variable references a function is through a function pointer.
+            // Return c_void here so the final def will look like `*mut c_void`.
+            //
+            // It's not like rust code can call a function inside a bpf prog either so we don't
+            // really need a full definition. `void *` is totally sufficient for sharing a pointer.
+            BtfKind::Func | BtfKind::FuncProto => "std::ffi::c_void".to_string(),
             BtfKind::Var(t) => self.type_declaration(t.referenced_type())?,
             _ => bail!("Invalid type: {ty:?}"),
         });

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -357,6 +357,15 @@ impl<'s> GenBtf<'s> {
                         gen_impl_default = true
                     }
                 }
+
+                // Rust does not implement `Default` for pointers, no matter if
+                // the pointee implements it.
+                if self
+                    .type_by_id::<types::Ptr<'_>>(field_ty.type_id())
+                    .is_some()
+                {
+                    gen_impl_default = true
+                }
             }
 
             match self.type_default(field_ty) {


### PR DESCRIPTION
Rust does not implement `Default` for pointers, no matter if the pointee implements the trait. As such, a bunch of our generated code does not compile. Specifically, bindings for struct types with a `Default` auto-derive and which contain pointers do not compile. Adjust the generation logic to emit a `Default` impl when a struct contains a pointer.