### PR TITLE
Revert "Revert "Bump bitflags to 2.0""

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 name = "libbpf-rs"
 version = "0.21.2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cc",
  "lazy_static",
  "libbpf-sys",

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 - Enabled key iteration on `MapHandle` objects (formerly possible only on `Map`
   objects)
+- Updated `bitflags` dependency to `2.0`
 - Bumped minimum Rust version to `1.64`
 
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -21,7 +21,7 @@ novendor = ["libbpf-sys/novendor"]
 static = ["libbpf-sys/static"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.0"
 lazy_static = "1.4"
 libbpf-sys = { version = "1.0.3" }
 libc = "0.2"

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -549,7 +549,7 @@ impl MapHandle {
                 self.fd.as_raw_fd(),
                 self.map_key(key),
                 out.as_mut_ptr() as *mut c_void,
-                flags.bits,
+                flags.bits(),
             )
         };
 
@@ -584,7 +584,7 @@ impl MapHandle {
                 self.fd.as_raw_fd(),
                 self.map_key(key),
                 value.as_ptr() as *const c_void,
-                flags.bits,
+                flags.bits(),
             )
         };
 
@@ -675,8 +675,8 @@ impl MapHandle {
 
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
-            elem_flags: elem_flags.bits,
-            flags: flags.bits,
+            elem_flags: elem_flags.bits(),
+            flags: flags.bits(),
         };
 
         let mut count = count;
@@ -853,6 +853,7 @@ impl AsFd for MapHandle {
 
 bitflags! {
     /// Flags to configure [`Map`] operations.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct MapFlags: u64 {
         /// See [`libbpf_sys::BPF_ANY`].
         const ANY      = libbpf_sys::BPF_ANY as _;


### PR DESCRIPTION
This change reverts commit 7134192d21747dd32621d84700fb573fe17e0b91 now that `0.21.2` has been released.