### PR TITLE
libbpf-rs: Change ObjectBuilder opts semantics

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -695,11 +695,11 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
 
         impl<'a> SkelBuilder<'a> for {name}SkelBuilder {{
             type Output = Open{name}Skel<'a>;
-            fn open(mut self) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
+            fn open(self) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
                 let mut skel_config = build_skel_config()?;
-                let open_opts = self.obj_builder.opts(std::ptr::null());
+                let open_opts = self.obj_builder.opts();
 
-                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), &open_opts) }};
+                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), open_opts) }};
                 if ret != 0 {{
                     return Err(libbpf_rs::Error::System(-ret));
                 }}

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -120,10 +120,26 @@ fn test_object_build_from_memory() {
     let contents = fs::read(obj_path).expect("failed to read object file");
     let mut builder = ObjectBuilder::default();
     let obj = builder
-        .open_memory("memory name", &contents)
+        .name("memory name")
+        .unwrap()
+        .open_memory(&contents)
         .expect("failed to build object");
     let name = obj.name().expect("failed to get object name");
     assert!(name == "memory name");
+}
+
+#[test]
+fn test_object_build_from_memory_empty_name() {
+    let obj_path = get_test_object_path("runqslower.bpf.o");
+    let contents = fs::read(obj_path).expect("failed to read object file");
+    let mut builder = ObjectBuilder::default();
+    let obj = builder
+        .name("")
+        .unwrap()
+        .open_memory(&contents)
+        .expect("failed to build object");
+    let name = obj.name().expect("failed to get object name");
+    assert!(name.is_empty());
 }
 
 /// Check that loading an object from an empty file fails as expected.
@@ -140,7 +156,7 @@ fn test_sudo_object_load_invalid() {
 fn test_object_name() {
     let obj_path = get_test_object_path("runqslower.bpf.o");
     let mut builder = ObjectBuilder::default();
-    builder.name("test name");
+    builder.name("test name").unwrap();
     let obj = builder.open_file(obj_path).expect("failed to build object");
     let obj_name = obj.name().expect("failed to get object name");
     assert!(obj_name == "test name");


### PR DESCRIPTION
By stashing an opts struct internally and converting name from a String to a CString, we can return a reference to an opt struct. This allows us to stack the lifetimes so that we don't need to copy-paste the name_ptr logic everywhere we call it.

The motivation for doing this was so that I could do the same for pin_root_path without adding another 3 copies of the name implementation.
