### PR TITLE
Implement Send for Link

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
   - Adjusted `opts` to return a reference to `libbpf_sys::bpf_object_open_opts`
   - Removed object name argument from `open_memory` constructor
   - Added `pin_root_path` setter
+- Implemented `Send` for `Link`
 - Updated `bitflags` dependency to `2.0`
 
 

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -105,6 +105,9 @@ impl Link {
     }
 }
 
+// SAFETY: `bpf_link` objects can safely be sent to a different thread.
+unsafe impl Send for Link {}
+
 impl AsFd for Link {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {


### PR DESCRIPTION
It seems as if `Link` objects (`bpf_link`) are fine to send across thread boundaries. Mark the type as `Send` accordingly.

Fixes: #546