### PR TITLE
Support parsing btf files in raw format and add load_vmlinux_btf function 

### DIFF
--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -149,6 +149,17 @@ impl Btf<'static> {
         inner(path.as_ref())
     }
 
+    /// Load the vmlinux btf information from few well-known locations.
+    pub fn from_vmlinux() -> Result<Self> {
+        let ptr = create_bpf_entity_checked(|| unsafe { libbpf_sys::btf__load_vmlinux_btf() })?;
+
+        Ok(Btf {
+            ptr,
+            drop_policy: DropPolicy::SelfPtrOnly,
+            _marker: PhantomData,
+        })
+    }
+
     /// Load the btf information of an bpf object from a program id.
     pub fn from_prog_id(id: u32) -> Result<Self> {
         let fd = parse_ret_i32(unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) })?;
@@ -648,4 +659,14 @@ pub unsafe trait ReferencesType<'btf>:
 
 mod sealed {
     pub trait Sealed {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_vmlinux() {
+        assert!(Btf::from_vmlinux().is_ok());
+    }
 }

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -131,14 +131,14 @@ pub struct Btf<'source> {
 }
 
 impl Btf<'static> {
-    /// Load the btf information from an ELF file.
+    /// Load the btf information from specified path.
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         fn inner(path: &Path) -> Result<Btf<'static>> {
             let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
                 Error::InvalidInput(format!("invalid path {path:?}, has null bytes"))
             })?;
             let ptr = create_bpf_entity_checked(|| unsafe {
-                libbpf_sys::btf__parse_elf(path.as_ptr(), std::ptr::null_mut())
+                libbpf_sys::btf__parse(path.as_ptr(), std::ptr::null_mut())
             })?;
             Ok(Btf {
                 ptr,


### PR DESCRIPTION
Because most of the btf files that come with the kernel are in raw format, the btf from_path function needs to support parsing btf files in raw format. In addition, the load_vmlinux_btf function is added, which is very convenient and does not need to manually specify the btf path.

Thanks!