### PR TITLE
libbpf-rs document data section skeleton methods.

### DIFF
--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -340,6 +340,36 @@ pub trait SkelBuilder<'a> {
 }
 
 /// A trait for opened skeleton.
+///
+/// In addition to the methods defined in this trait, skeletons that implement this trait will also
+/// have bespoke implementations of a few additional methods to facilitate access to global
+/// variables of the BPF program. These methods will be named `bss()`, `data()`, and `rodata()`.
+/// Each corresponds to the variables stored in the BPF ELF program section of the same name.
+/// However if your BPF program lacks one of these sections the corresponding rust method will not
+/// be generated.
+///
+/// The type of the value returned by each of these methods will be specific to your BPF program.
+/// A common convention for BPF CO-RE programs is to define a single global variable in the BPF
+/// program with a struct type containing a field for each configuration parameter
+/// <sup>\[[source]\]</sup>.  libbpf-rs auto-generates this pattern for you without you having to
+/// define such a struct type in your BPF program. It does this by examining each of the global
+/// variables in your BPF program's `.bss`, `.data`, and `.rodata` sections and then creating rust
+/// struct types `yourprogram_bss_types`, `yourprogram_data_types`, and `yourprogram_rodata_types`.
+/// Since these struct types are specific to the layout of your BPF program, they are not
+/// documented in this crate. However you can see documentation for them by running `cargo doc` in
+/// your own project and looking at the `imp` module. You can also view their implementation by
+/// looking at the `*.skel.rs` files in your `target` directory. To find the latest one you can run
+/// a command such as:
+///
+/// `find target -name '*.skel.rs' | xargs -- ls -1tr | tail -n1`
+///
+/// If you ever doubt whether libbpf-rs has placed a particular variable in the correct struct
+/// type, you can see which section each global variable is stored in by examing the output of the
+/// following command (after a successful build):
+///
+/// `bpf-objdump --sym s ./target/bpf/*.bpf.o`
+///
+/// [source]: https://facebookmicrosites.github.io/bpf/blog/2020/02/20/bcc-to-libbpf-howto-guide.html#application-configuration
 pub trait OpenSkel {
     /// Define that when BPF object is loaded, the returned type should implement the [`Skel`] trait
     type Output: Skel;

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -349,27 +349,24 @@ pub trait SkelBuilder<'a> {
 /// be generated.
 ///
 /// The type of the value returned by each of these methods will be specific to your BPF program.
-/// A common convention for BPF CO-RE programs is to define a single global variable in the BPF
-/// program with a struct type containing a field for each configuration parameter
-/// <sup>\[[source]\]</sup>.  libbpf-rs auto-generates this pattern for you without you having to
-/// define such a struct type in your BPF program. It does this by examining each of the global
-/// variables in your BPF program's `.bss`, `.data`, and `.rodata` sections and then creating rust
-/// struct types `yourprogram_bss_types`, `yourprogram_data_types`, and `yourprogram_rodata_types`.
-/// Since these struct types are specific to the layout of your BPF program, they are not
-/// documented in this crate. However you can see documentation for them by running `cargo doc` in
-/// your own project and looking at the `imp` module. You can also view their implementation by
-/// looking at the `*.skel.rs` files in your `target` directory. To find the latest one you can run
-/// a command such as:
-///
-/// `find target -name '*.skel.rs' | xargs -- ls -1tr | tail -n1`
+/// A common convention is to define a single global variable in the BPF program with a struct type
+/// containing a field for each configuration parameter <sup>\[[source]\]</sup>.  libbpf-rs
+/// auto-generates this pattern for you without you having to define such a struct type in your BPF
+/// program. It does this by examining each of the global variables in your BPF program's `.bss`,
+/// `.data`, and `.rodata` sections and then creating rust struct types `<yourprogram>_bss_types`,
+/// `<yourprogram>_data_types`, and `<yourprogram>_rodata_types`. Since these struct types are
+/// specific to the layout of your BPF program, they are not documented in this crate. However you
+/// can see documentation for them by running `cargo doc` in your own project and looking at the
+/// `imp` module. You can also view their implementation by looking at the generated skeleton rust
+/// source file.
 ///
 /// If you ever doubt whether libbpf-rs has placed a particular variable in the correct struct
 /// type, you can see which section each global variable is stored in by examing the output of the
 /// following command (after a successful build):
 ///
-/// `bpf-objdump --sym s ./target/bpf/*.bpf.o`
+/// `bpf-objdump --syms ./target/bpf/*.bpf.o`
 ///
-/// [source]: https://facebookmicrosites.github.io/bpf/blog/2020/02/20/bcc-to-libbpf-howto-guide.html#application-configuration
+/// [source]: https://nakryiko.com/posts/bcc-to-libbpf-howto-guide/#application-configuration
 pub trait OpenSkel {
     /// Define that when BPF object is loaded, the returned type should implement the [`Skel`] trait
     type Output: Skel;

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -358,7 +358,8 @@ pub trait SkelBuilder<'a> {
 /// specific to the layout of your BPF program, they are not documented in this crate. However you
 /// can see documentation for them by running `cargo doc` in your own project and looking at the
 /// `imp` module. You can also view their implementation by looking at the generated skeleton rust
-/// source file.
+/// source file. The use of these methods can also be seen in the examples 'capable', 'runqslower',
+/// and 'tproxy'.
 ///
 /// If you ever doubt whether libbpf-rs has placed a particular variable in the correct struct
 /// type, you can see which section each global variable is stored in by examing the output of the


### PR DESCRIPTION
When attempting to implement a configuration capability for my program I struggled to translate documentation and examples related to plain libbpf usage to the libbpf-rs API. This documentation update is meant to partially bridge the gap between the actual API of the libbpf-rs crate and the API of the generated skeleton.

This will partially address https://github.com/libbpf/libbpf-rs/issues/572. However I've written this based on my own observations and I'm not sure whether what I've written is in line with the libbpf-rs project's forward-looking vision for how to support global variable access. If this documentation is indeed accurate I'd also be happy to add an example showing how to make use of these methods.

Just for reviewing convenience, this is what is rendered when I run `cargo doc` against this branch:

![Screenshot from 2023-09-04 11-26-04](https://github.com/libbpf/libbpf-rs/assets/45699/fd652500-d8d2-4fc9-a51f-4207827117e6)
