### PR TITLE
Update `actions/checkout` GitHub Action to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 25
+    rebase-strategy: "auto"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "cargo"
     versioning-strategy: "lockfile-only"
     directory: "/"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: version
       shell: bash
       run: |
@@ -31,7 +31,7 @@ jobs:
     needs: [test, version]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         tc_var RUSTFLAGS
         tc_var CFLAGS
         tc_var CXXFLAGS
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
@@ -68,7 +68,7 @@ jobs:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         run: sudo apt-get install -y libelf-dev
       - name: Install Nightly Rust
@@ -94,7 +94,7 @@ jobs:
     name: Build capable example with static libelf and libz
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         run: sudo apt-get install -y libelf-dev
       - uses: actions-rs/toolchain@v1
@@ -108,7 +108,7 @@ jobs:
     name: Build for aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add apt sources for arm64
         run: |
           dpkg --add-architecture arm64
@@ -138,7 +138,7 @@ jobs:
     name: Build for aarch32
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add apt sources for armhf
         run: |
           dpkg --add-architecture armhf
@@ -168,7 +168,7 @@ jobs:
     name: Lint with clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         run: sudo apt-get install -y libelf-dev
       - uses: actions-rs/toolchain@v1
@@ -187,7 +187,7 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -201,7 +201,7 @@ jobs:
     env:
       RUSTDOCFLAGS: '-D warnings'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         run: sudo apt-get install -y libelf-dev
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Update `actions/checkout` GitHub Action to the most recently released version `v4`.