### PR TITLE
Use `Swatinem/rust-cache@v2`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         sudo apt-get install -y clang-14 libelf-dev zlib1g-dev linux-headers-$(uname -r)
         sudo ln -s /usr/include/asm-generic /usr/include/asm
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-14 /bin/clang
-    - uses: Swatinem/rust-cache@v2.2.0
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --profile=${{ matrix.profile }} --locked --verbose --workspace --exclude runqslower
     - name: Run tests
@@ -86,7 +86,7 @@ jobs:
           toolchain: 1.64.0
           components: rustfmt
           default: true
-      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --verbose --workspace --exclude runqslower
 
@@ -102,7 +102,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: Swatinem/rust-cache@v2
       - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --locked --package capable --features=static
   build-aarch64:
     name: Build for aarch64
@@ -128,7 +128,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libelf-dev:arm64 zlib1g-dev:arm64 gcc-aarch64-linux-gnu
-      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         env:
           CARGO_BUILD_TARGET: aarch64-unknown-linux-gnu
@@ -158,7 +158,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libelf-dev:armhf zlib1g-dev:armhf gcc-arm-linux-gnueabihf
-      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         env:
           CARGO_BUILD_TARGET: armv7-unknown-linux-gnueabihf
@@ -181,7 +181,7 @@ jobs:
           toolchain: 1.68.2
           components: clippy,rustfmt
           override: true
-      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --locked --no-deps --all-targets --tests -- -D warnings
   rustfmt:
     name: Check code formatting


### PR DESCRIPTION
Let's depended on `Swatinem/rust-cache@v2` instead of `Swatinem/rust-cache@v2.2.0`. The former gets automatically bumped when a new release is cut, which is more convenient than having a pull request created every time (though it comes at the cost of being less obvious).