### PR TITLE
Introduce AsRawLibbpf trait

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
   - Adjusted `opts` to return a reference to `libbpf_sys::bpf_object_open_opts`
   - Removed object name argument from `open_memory` constructor
   - Added `pin_root_path` setter
+- Added `AsRawLibbpf` trait as a unified way to retrieve `libbpf` equivalents
+  for `libbpf-rs` objects
 - Implemented `Send` for `Link`
 - Updated `bitflags` dependency to `2.0`
 

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -31,14 +31,16 @@ use std::os::unix::prelude::OwnedFd;
 use std::path::Path;
 use std::ptr::NonNull;
 
+use num_enum::IntoPrimitive;
+use num_enum::TryFromPrimitive;
+
 use crate::libbpf_sys;
 use crate::util::create_bpf_entity_checked;
 use crate::util::create_bpf_entity_checked_opt;
 use crate::util::parse_ret_i32;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Result;
-use num_enum::IntoPrimitive;
-use num_enum::TryFromPrimitive;
 
 use self::types::Composite;
 
@@ -347,6 +349,15 @@ impl<'btf> Btf<'btf> {
             .map(TypeId::from)
             .filter_map(|id| self.type_by_id(id))
             .filter_map(|t| K::try_from(t).ok())
+    }
+}
+
+impl AsRawLibbpf for Btf<'_> {
+    type LibbpfType = libbpf_sys::btf;
+
+    /// Retrieve the underlying [`libbpf_sys::btf`] object.
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
     }
 }
 

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -109,6 +109,7 @@ pub use crate::map::MapHandle;
 pub use crate::map::MapInfo;
 pub use crate::map::MapType;
 pub use crate::map::OpenMap;
+pub use crate::object::AsRawLibbpf;
 pub use crate::object::Object;
 pub use crate::object::ObjectBuilder;
 pub use crate::object::OpenObject;

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -7,6 +7,7 @@ use std::ptr::NonNull;
 
 use crate::libbpf_sys;
 use crate::util;
+use crate::AsRawLibbpf;
 use crate::Program;
 use crate::Result;
 
@@ -102,6 +103,15 @@ impl Link {
     pub fn detach(&self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__detach(self.ptr.as_ptr()) };
         util::parse_ret(ret)
+    }
+}
+
+impl AsRawLibbpf for Link {
+    type LibbpfType = libbpf_sys::bpf_link;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_link`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
     }
 }
 

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -2,8 +2,9 @@ use std::path::Path;
 use std::ptr::null_mut;
 use std::ptr::NonNull;
 
+use crate::util;
 use crate::util::path_to_cstring;
-use crate::util::{self};
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Result;
 
@@ -59,6 +60,15 @@ impl Linker {
             return Err(Error::System(err));
         }
         Ok(())
+    }
+}
+
+impl AsRawLibbpf for Linker {
+    type LibbpfType = libbpf_sys::bpf_linker;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_linker`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.linker
     }
 }
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -31,6 +31,7 @@ use strum_macros::Display;
 
 use crate::util;
 use crate::util::parse_ret_i32;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Link;
 use crate::Result;
@@ -170,6 +171,15 @@ impl OpenMap {
     }
 }
 
+impl AsRawLibbpf for OpenMap {
+    type LibbpfType = libbpf_sys::bpf_map;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_map`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
+    }
+}
+
 #[derive(Debug)]
 enum MapFd {
     Owned(OwnedFd),
@@ -302,9 +312,13 @@ impl Map {
             Link::new(ptr)
         })
     }
+}
+
+impl AsRawLibbpf for Map {
+    type LibbpfType = libbpf_sys::bpf_map;
 
     /// Retrieve the underlying [`libbpf_sys::bpf_map`].
-    pub fn as_libbpf_bpf_map_ptr(&self) -> NonNull<libbpf_sys::bpf_map> {
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
         self.ptr
     }
 }

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use crate::libbpf_sys;
 use crate::util;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Map;
 use crate::MapType;
@@ -227,9 +228,13 @@ impl PerfBuffer<'_> {
         };
         util::parse_ret_i32(ret)
     }
+}
+
+impl AsRawLibbpf for PerfBuffer<'_> {
+    type LibbpfType = libbpf_sys::perf_buffer;
 
     /// Retrieve the underlying [`libbpf_sys::perf_buffer`].
-    pub fn as_libbpf_perf_buffer_ptr(&self) -> NonNull<libbpf_sys::perf_buffer> {
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
         self.ptr
     }
 }

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -1,7 +1,7 @@
 use crate::libbpf_sys;
 use lazy_static::lazy_static;
+use std::io;
 use std::io::Write;
-use std::io::{self};
 use std::os::raw::c_char;
 use std::sync::Mutex;
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -17,6 +17,7 @@ use strum_macros::Display;
 
 use crate::libbpf_sys;
 use crate::util;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Link;
 use crate::Result;
@@ -228,6 +229,15 @@ impl OpenProgram {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
         unsafe { std::slice::from_raw_parts(ptr, count) }
+    }
+}
+
+impl AsRawLibbpf for Program {
+    type LibbpfType = libbpf_sys::bpf_program;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_program`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
     }
 }
 

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use crate::libbpf_sys;
 use crate::util;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::MapHandle;
 use crate::MapType;
@@ -179,6 +180,15 @@ impl RingBuffer<'_> {
     /// Get an fd that can be used to sleep until data is available
     pub fn epoll_fd(&self) -> i32 {
         unsafe { libbpf_sys::ring_buffer__epoll_fd(self.ptr.as_ptr()) }
+    }
+}
+
+impl AsRawLibbpf for RingBuffer<'_> {
+    type LibbpfType = libbpf_sys::ring_buffer;
+
+    /// Retrieve the underlying [`libbpf_sys::ring_buffer`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
     }
 }
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -7,8 +7,8 @@ use std::ffi::CString;
 use std::mem::size_of;
 use std::os::raw::c_char;
 use std::os::raw::c_ulong;
+use std::ptr;
 use std::ptr::NonNull;
-use std::ptr::{self};
 
 use libbpf_sys::bpf_link;
 use libbpf_sys::bpf_map;

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -23,6 +23,7 @@ use std::ptr;
 use tempfile::NamedTempFile;
 
 use libbpf_rs::num_possible_cpus;
+use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::Iter;
 use libbpf_rs::Linker;
 use libbpf_rs::Map;
@@ -1430,7 +1431,7 @@ fn test_object_link_files() {
 
 /// Get access to the underlying per-cpu ring buffer data.
 fn buffer<'a>(perf: &'a libbpf_rs::PerfBuffer, buf_idx: usize) -> &'a [u8] {
-    let perf_buff_ptr = perf.as_libbpf_perf_buffer_ptr();
+    let perf_buff_ptr = perf.as_libbpf_object();
     let mut buffer_data_ptr: *mut c_void = ptr::null_mut();
     let mut buffer_size: usize = 0;
     let ret = unsafe {


### PR DESCRIPTION
`libbpf-rs` aims to be a convenient but thin wrapper around `libbpf` functionality. Not all functionality provided of `libbpf` is exposed through its API. This can quickly become a blocker if, say, some getter is not hooked up, but the value required to perform an operation. In the spirit of being a thin wrapper, it makes sense for us to provide access to the underlying `libbpf` objects. When nothing else is available, these can be used directly in conjunction with `libbpf-sys` to, effectively, write Rust-syntax C code.
So far we have provided very ad-hoc accessor methods for retrieving pointers to the underlying `libbpf` objects. With this change we formalize this approach some more, by introducing the `AsLibbpfObject` trait and implementing it for major `libbpf-rs` types.
Using a trait is not the only possible way. We could also continue that path we were on earlier where relevant types had custom named accessors without a common trait (e.g., `Map::as_libbpf_bpf_map_ptr`). The benefits a trait brings to the table is that it unifies naming and makes it reasonably easy to get an overview of types that have `libbpf` counterparts.
The risk is that we may have to adjust the trait signature in one way or another if a newly added type has different constraints (e.g., if a `libbpf-rs` object has a potentially-`NULL` libbpf object).