### PR TITLE
Remove `Error` enumeration from libbpf-cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
 ]
 
 [[package]]

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Removed `Error` enum in favor of `anyhow::Error`
 - Bumped minimum Rust version to `1.65`
 
 

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -43,7 +43,6 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3"
-thiserror = "1.0"
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The `Error` enumeration in `libbpf-cargo` doesn't really serve any meaningful purposes at this point: sure, it helps users differentiate between build and generation errors, but the difference arguably has no semantic significance that is worth preserving. On top of that, users can always invoke `build()` and `generate()` instead of `build_and_generate()` to have literally the same information at their finger tips.
Remove the `Error` type in favor of just exposing a `anyhow::Error`, which is probably the most flexible.