### PR TITLE
Update nix dependency to 0.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           profile: minimal
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.64.0
+          toolchain: 1.65.0
           components: rustfmt
           default: true
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "clap",
  "iced-x86",
  "libbpf-rs",
- "nix 0.26.4",
+ "nix 0.27.1",
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.26.4",
+ "nix 0.27.1",
  "num_enum",
  "pkg-config",
  "plain",
@@ -361,6 +361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,7 +378,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -382,6 +391,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -794,7 +804,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "nix 0.26.4",
+ "nix 0.27.1",
  "plain",
 ]
 
@@ -879,7 +889,7 @@ dependencies = [
  "ctrlc",
  "libbpf-cargo",
  "libbpf-rs",
- "nix 0.26.4",
+ "nix 0.27.1",
 ]
 
 [[package]]

--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }
-nix = { version = "0.26", default-features = false, features = ["net", "user"] }
+nix = { version = "0.27", default-features = false, features = ["net", "user"] }
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
-nix = { version = "0.26", default-features = false, features = ["net", "user"] }
+nix = { version = "0.27", default-features = false, features = ["net", "user"] }
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
 
 [build-dependencies]

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
 ctrlc = "3.2"
 libbpf-rs = { path = "../../libbpf-rs" }
-nix = { version = "0.26", default-features = false, features = ["net", "user"] }
+nix = { version = "0.27", default-features = false, features = ["net", "user"] }
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped minimum Rust version to `1.65`
+
+
 0.21.2
 ------
 - Added `Default` impl for generated `struct` types containing pointers

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.21.2"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 # libbpf-cargo
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -16,6 +16,7 @@ Unreleased
 - Added `AsRawLibbpf` trait as a unified way to retrieve `libbpf` equivalents
   for `libbpf-rs` objects
 - Implemented `Send` for `Link`
+- Bumped minimum Rust version to `1.65`
 - Updated `bitflags` dependency to `2.0`
 
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 version = "0.21.2"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "2.0"
 lazy_static = "1.4"
 libbpf-sys = { version = "1.0.3" }
 libc = "0.2"
-nix = { version = "0.26", default-features = false, features = ["net", "user"] }
+nix = { version = "0.27", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"
 strum_macros = "0.24"
 thiserror = "1.0.10"

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 # libbpf-rs
 


### PR DESCRIPTION
Update the nix dependency that we depend on to 0.27, to prevent copies of multiple versions being pulled in during the build.