### PR TITLE
Bump minimum supported Rust version to 1.65

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           profile: minimal
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.64.0
+          toolchain: 1.65.0
           components: rustfmt
           default: true
       - uses: Swatinem/rust-cache@v2

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped minimum Rust version to `1.65`
+
+
 0.21.2
 ------
 - Added `Default` impl for generated `struct` types containing pointers

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.21.2"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 # libbpf-cargo
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -16,6 +16,7 @@ Unreleased
 - Added `AsRawLibbpf` trait as a unified way to retrieve `libbpf` equivalents
   for `libbpf-rs` objects
 - Implemented `Send` for `Link`
+- Bumped minimum Rust version to `1.65`
 - Updated `bitflags` dependency to `2.0`
 
 

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 version = "0.21.2"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.64+-blue.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 # libbpf-rs
 


### PR DESCRIPTION
Bump the minimum supported Rust version to 1.65. This version is what nix 0.27 requires, and we wish to update to it.
