### PR TITLE
libbpf-cargo: Support on-the-fly vmlinux.h extraction

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 # When turned on, link against system-installed libbpf instead of building
 # and linking against vendored libbpf sources
 novendor = ["libbpf-sys/novendor"]
+bpftool = []
 
 [dependencies]
 anyhow = "1.0.1"


### PR DESCRIPTION
This adds the `extract_vmlinux_header` method to `SkelBuilder`, which lets libbpf-cargo auto-generate the "vmlinux.h" header from the running kernel using bpftool.  This would be particularly useful when packaging a crate with "cargo package", as it doesn't need the header file to be added to the repository.
