### PR TITLE
Enable clippy::absolute_paths lint

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
@@ -170,10 +171,10 @@ fn compile_one(debug: bool, source: &Path, out: &Path, clang: &Path, options: &s
     }
 
     if !options.contains("-D__TARGET_ARCH_") {
-        let arch = match std::env::consts::ARCH {
+        let arch = match ARCH {
             "x86_64" => "x86",
             "aarch64" => "arm64",
-            _ => std::env::consts::ARCH,
+            _ => ARCH,
         };
         cmd.arg(format!("-D__TARGET_ARCH_{arch}"));
     }

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::io::stdout;
 use std::io::ErrorKind;
 use std::io::Write;
+use std::mem::size_of;
 use std::os::raw::c_ulong;
 use std::path::Path;
 use std::path::PathBuf;
@@ -606,7 +607,7 @@ fn gen_skel_link_getter(skel: &mut String, object: &mut BpfObj, obj_name: &str) 
 fn open_bpf_object(name: &str, data: &[u8]) -> Result<BpfObj> {
     let cname = CString::new(name)?;
     let obj_opts = libbpf_sys::bpf_object_open_opts {
-        sz: std::mem::size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
+        sz: size_of::<libbpf_sys::bpf_object_open_opts>() as libbpf_sys::size_t,
         object_name: cname.as_ptr(),
         ..Default::default()
     };

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -59,6 +59,7 @@
 #![warn(
     elided_lifetimes_in_paths,
     single_use_lifetimes,
+    clippy::absolute_paths,
     clippy::wildcard_imports
 )]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+#![allow(clippy::absolute_paths, clippy::let_unit_value)]
 
 use std::path::PathBuf;
 

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -339,7 +339,7 @@ pub enum IntEncoding {
 impl<'btf> TryFrom<BtfType<'btf>> for Int<'btf> {
     type Error = BtfType<'btf>;
 
-    fn try_from(t: BtfType<'btf>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(t: BtfType<'btf>) -> Result<Self, Self::Error> {
         if t.kind() == BtfKind::Int {
             let int = {
                 let base_ptr = t.ty as *const libbpf_sys::btf_type;

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -72,6 +72,7 @@
     missing_debug_implementations,
     missing_docs,
     single_use_lifetimes,
+    clippy::absolute_paths,
     clippy::wildcard_imports,
     rustdoc::broken_intra_doc_links
 )]

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -16,7 +16,6 @@ use std::os::unix::io::OwnedFd;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::ptr;
-use std::ptr::null;
 use std::ptr::NonNull;
 use std::slice::from_raw_parts;
 
@@ -83,7 +82,7 @@ impl OpenMap {
         let ret = unsafe {
             libbpf_sys::bpf_map__set_initial_value(
                 self.ptr.as_ptr(),
-                data.as_ptr() as *const std::ffi::c_void,
+                data.as_ptr() as *const c_void,
                 data.len() as libbpf_sys::size_t,
             )
         };
@@ -393,7 +392,7 @@ impl MapHandle {
 
         let map_name_ptr = {
             if map_name_str.as_bytes().is_empty() {
-                null()
+                ptr::null()
             } else {
                 map_name_str.as_ptr()
             }
@@ -934,7 +933,7 @@ impl MapType {
     /// Make sure the process has required set of CAP_* permissions (or runs as
     /// root) when performing feature checking.
     pub fn is_supported(&self) -> Result<bool> {
-        let ret = unsafe { libbpf_sys::libbpf_probe_bpf_map_type(*self as u32, std::ptr::null()) };
+        let ret = unsafe { libbpf_sys::libbpf_probe_bpf_map_type(*self as u32, ptr::null()) };
         match ret {
             0 => Ok(false),
             1 => Ok(true),

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -171,7 +171,7 @@ impl OpenObject {
         };
 
         // Populate obj.maps
-        let mut map: *mut libbpf_sys::bpf_map = std::ptr::null_mut();
+        let mut map: *mut libbpf_sys::bpf_map = ptr::null_mut();
         loop {
             // Get the pointer to the next BPF map
             let map_ptr = {
@@ -190,7 +190,7 @@ impl OpenObject {
         }
 
         // Populate obj.progs
-        let mut prog: *mut libbpf_sys::bpf_program = std::ptr::null_mut();
+        let mut prog: *mut libbpf_sys::bpf_program = ptr::null_mut();
         loop {
             // Get the pointer to the next BPF program
             let prog_ptr = {
@@ -233,12 +233,12 @@ impl OpenObject {
             // using destructuring we make sure we'll get a compiler error if anything in
             // Self changes, which will alert us to change this function as well
             let Self { ptr, maps, progs } = &mut self;
-            std::mem::take(maps);
-            std::mem::take(progs);
+            mem::take(maps);
+            mem::take(progs);
             *ptr
         };
         // avoid double free of self.ptr
-        std::mem::forget(self);
+        mem::forget(self);
         ptr
     }
 
@@ -354,7 +354,7 @@ impl Object {
         };
 
         // Populate obj.maps
-        let mut map: *mut libbpf_sys::bpf_map = std::ptr::null_mut();
+        let mut map: *mut libbpf_sys::bpf_map = ptr::null_mut();
         loop {
             // Get the pointer to the next BPF map
             let map_ptr = {
@@ -373,7 +373,7 @@ impl Object {
         }
 
         // Populate obj.progs
-        let mut prog: *mut libbpf_sys::bpf_program = std::ptr::null_mut();
+        let mut prog: *mut libbpf_sys::bpf_program = ptr::null_mut();
         loop {
             // Get the pointer to the next BPF program
             let prog_ptr = {

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -5,6 +5,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::os::unix::io::AsFd;
 use std::os::unix::prelude::AsRawFd;
+use std::ptr;
 use std::ptr::NonNull;
 use std::slice;
 use std::time::Duration;
@@ -133,7 +134,7 @@ impl<'a, 'b> PerfBufferBuilder<'a, 'b> {
                 c_sample_cb,
                 c_lost_cb,
                 callback_struct_ptr as *mut _,
-                std::ptr::null(),
+                ptr::null(),
             )
         })
         .map(|ptr| PerfBuffer {

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -2,6 +2,7 @@ use crate::libbpf_sys;
 use lazy_static::lazy_static;
 use std::io;
 use std::io::Write;
+use std::mem;
 use std::os::raw::c_char;
 use std::sync::Mutex;
 
@@ -117,7 +118,7 @@ pub fn set_print(
     mut callback: Option<(PrintLevel, PrintCallback)>,
 ) -> Option<(PrintLevel, PrintCallback)> {
     let real_cb: libbpf_sys::libbpf_print_fn_t = callback.as_ref().and(Some(outer_print_cb));
-    std::mem::swap(&mut callback, &mut *PRINT_CB.lock().unwrap());
+    mem::swap(&mut callback, &mut *PRINT_CB.lock().unwrap());
     unsafe { libbpf_sys::libbpf_set_print(real_cb) };
     callback
 }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -15,6 +15,7 @@ use std::ffi::c_void;
 use std::ffi::CString;
 use std::mem::size_of_val;
 use std::os::raw::c_char;
+use std::ptr;
 use std::time::Duration;
 
 use nix::errno;
@@ -337,7 +338,7 @@ impl ProgramInfo {
         }
 
         if opts.include_jited_line_info {
-            jited_line_info.resize(item.nr_jited_line_info as usize, std::ptr::null());
+            jited_line_info.resize(item.nr_jited_line_info as usize, ptr::null());
             item.jited_line_info = jited_line_info.as_mut_ptr() as *mut c_void as u64;
         } else {
             item.nr_jited_line_info = 0;
@@ -358,7 +359,7 @@ impl ProgramInfo {
         }
 
         if opts.include_jited_ksyms {
-            jited_ksyms.resize(item.nr_jited_ksyms as usize, std::ptr::null());
+            jited_ksyms.resize(item.nr_jited_ksyms as usize, ptr::null());
             item.jited_ksyms = jited_ksyms.as_mut_ptr() as *mut c_void as u64;
         } else {
             item.nr_jited_ksyms = 0;

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -8,6 +8,7 @@ use std::os::raw::c_ulong;
 use std::os::unix::io::AsFd;
 use std::os::unix::prelude::AsRawFd;
 use std::os::unix::prelude::BorrowedFd;
+use std::ptr::null_mut;
 use std::ptr::NonNull;
 use std::slice;
 use std::time::Duration;
@@ -98,7 +99,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
                             fd.as_raw_fd(),
                             c_sample_cb,
                             sample_cb_ptr as *mut _,
-                            std::ptr::null_mut(),
+                            null_mut(),
                         )
                     })?);
                 }

--- a/libbpf-rs/src/tc.rs
+++ b/libbpf-rs/src/tc.rs
@@ -1,3 +1,4 @@
+use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::BorrowedFd;
 
@@ -64,8 +65,8 @@ impl TcHook {
             opts: libbpf_sys::bpf_tc_opts::default(),
         };
 
-        tc_hook.hook.sz = std::mem::size_of::<libbpf_sys::bpf_tc_hook>() as libbpf_sys::size_t;
-        tc_hook.opts.sz = std::mem::size_of::<libbpf_sys::bpf_tc_opts>() as libbpf_sys::size_t;
+        tc_hook.hook.sz = size_of::<libbpf_sys::bpf_tc_hook>() as libbpf_sys::size_t;
+        tc_hook.opts.sz = size_of::<libbpf_sys::bpf_tc_opts>() as libbpf_sys::size_t;
         tc_hook.opts.prog_fd = fd.as_raw_fd();
 
         tc_hook

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -1,3 +1,4 @@
+use std::any::type_name;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::io;
@@ -95,12 +96,12 @@ pub fn create_bpf_entity_checked<B: 'static, F: FnOnce() -> *mut B>(f: F) -> Res
                 io::ErrorKind::Other,
                 format!(
                     "bpf call {:?} returned NULL",
-                    std::any::type_name::<F>() // this is usually a library bug, hopefully this will
-                                               // help diagnose the bug.
-                                               //
-                                               // One way to fix the bug might be to change to calling
-                                               // create_bpf_entity_checked_opt and handling Ok(None)
-                                               // as a meaningful value.
+                    type_name::<F>() // this is usually a library bug, hopefully this will
+                                     // help diagnose the bug.
+                                     //
+                                     // One way to fix the bug might be to change to calling
+                                     // create_bpf_entity_checked_opt and handling Ok(None)
+                                     // as a meaningful value.
                 ),
             )
         })


### PR DESCRIPTION
In the past we had many submissions that, for one reason or another, were using absolute paths to functions/constants in a very inconsistent manner. It is not particularly great use of anybody's time pointing these out and it's certainly a job that computers can do better. Clippy folks seem to concur that this can be a useful lint [0] and we got blessed with clippy::absolute_paths.
Enable it throughout libbpf-rs and libbpf-cargo and fix all violations.

[0] https://github.com/rust-lang/rust-clippy/issues/10568