### PR TITLE
Introduce ErrorKind::Interrupted variant

### DIFF
--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -124,6 +124,7 @@ impl ErrorImpl {
                 io::ErrorKind::InvalidData => ErrorKind::InvalidData,
                 io::ErrorKind::TimedOut => ErrorKind::TimedOut,
                 io::ErrorKind::WriteZero => ErrorKind::WriteZero,
+                io::ErrorKind::Interrupted => ErrorKind::Interrupted,
                 io::ErrorKind::Unsupported => ErrorKind::Unsupported,
                 io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
                 io::ErrorKind::OutOfMemory => ErrorKind::OutOfMemory,
@@ -242,6 +243,10 @@ pub enum ErrorKind {
     /// An error returned when an operation could not be completed
     /// because a call to [`write`] returned [`Ok(0)`].
     WriteZero,
+    /// This operation was interrupted.
+    ///
+    /// Interrupted operations can typically be retried.
+    Interrupted,
     /// This operation is unsupported on this platform.
     Unsupported,
     /// An error returned when an operation could not be completed


### PR DESCRIPTION
For (better? or) worse the EINTR error is typically treated somewhat specially by clients. As such, it seems reasonable for us to expose it properly as opposed to just capturing it as "other".
Introduce the `ErrorKind::Interrupted` variant to allow for that.