### PR TITLE
libbpf-cargo: fix inference of __TARGET_ARCH_ on ppc64le and s390x

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -174,6 +174,8 @@ fn compile_one(debug: bool, source: &Path, out: &Path, clang: &Path, options: &s
         let arch = match ARCH {
             "x86_64" => "x86",
             "aarch64" => "arm64",
+            "powerpc64" => "powerpc",
+            "s390x" => "s390",
             _ => ARCH,
         };
         cmd.arg(format!("-D__TARGET_ARCH_{arch}"));


### PR DESCRIPTION
On those architectures, libbpf expects different values than reported by std::env::const::ARCH, causing a build failure as follows:

```console
0: Command `clang -I/builddir/build/BUILD/crypto-auditing-agent-0.2.1/target/rpm/build/crypto-auditing-agent-b76cca1d0cfd3630/out -fno-stack-protector -D__TARGET_ARCH_powerpc64 -g -O2 -target bpf -c /builddir/build/BUILD/crypto-auditing-agent-0.2.1/src/bpf/audit.bpf.c -o /tmp/.tmpwsWurL/audit.o` failed (exit status: 1)
1: In file included from /builddir/build/BUILD/crypto-auditing-agent-0.2.1/src/bpf/audit.bpf.c:6:
   /usr/include/bpf/usdt.bpf.h:83:13: error: Must specify a BPF target arch via __TARGET_ARCH_xxx
      83 |                 long ip = PT_REGS_IP(ctx);
         |                           ^
   /usr/include/bpf/bpf_tracing.h:576:26: note: expanded from macro 'PT_REGS_IP'
     576 | #define PT_REGS_IP(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
         |                          ^
   <scratch space>:14:6: note: expanded from here
      14 |  GCC error "Must specify a BPF target arch via __TARGET_ARCH_xxx"
         |      ^
   1 error generated.
   )
```
