### PR TITLE
libbpf-cargo: Warn on clippy::absolute_paths

### DIFF
--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::absolute_paths, clippy::let_unit_value)]
+#![allow(clippy::let_unit_value)]
+#![warn(clippy::absolute_paths)]
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
Commit 4ef150551dbb ("Enable clippy::absolute_paths lint") wrongly added the clippy::absolute_paths lint to the allow list in libbpf-cargo. Warn about it instead, as had been the intention.