### PR TITLE
libbpf-rs: handle maps that were autocreate(false)

### DIFF
--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -365,10 +365,11 @@ impl Object {
                 }
             };
 
-            let map_obj = unsafe { Map::new(map_ptr) }?;
+            if unsafe { libbpf_sys::bpf_map__autocreate(map_ptr.as_ptr()) } {
+                let map_obj = unsafe { Map::new(map_ptr) }?;
+                obj.maps.insert(map_obj.name().into(), map_obj);
+            }
 
-            // Add the map to the hashmap
-            obj.maps.insert(map_obj.name().into(), map_obj);
             map = map_ptr.as_ptr();
         }
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1636,3 +1636,19 @@ fn test_sudo_program_get_fd_and_id() {
     let owned_prog_fd = Program::get_fd_by_id(prog_id).expect("failed to get program fd by id");
     close(owned_prog_fd.as_raw_fd()).expect("failed to close owned program fd");
 }
+
+/// Check that autocreate disabled maps don't prevent object loading
+#[test]
+fn test_sudo_map_autocreate_disable() {
+    bump_rlimit_mlock();
+
+    let mut open_obj = open_test_object("map_auto_pin.bpf.o");
+
+    open_obj
+        .map_mut("auto_pin_map")
+        .expect("map wasn't found")
+        .set_autocreate(false)
+        .expect("set_autocreate() failed");
+
+    open_obj.load().expect("failed to load object");
+}


### PR DESCRIPTION
If map auto creation was disabled, the Object would fail to load since the map's underlying fd will be -1.

This checks the if the map autocreate flag was disabled and skips creating a Map for it.
