### PR TITLE
Overhaul feature set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.65.0
+          toolchain: 1.66.0
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,39 @@ jobs:
     - name: Run root tests
       run: cd libbpf-rs && cargo test --profile=${{ matrix.profile }} --locked --verbose -- test_sudo_
 
+  build-features:
+    name: Build [${{ matrix.args }}]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - args: "features = ['vendored']"
+          - args: "features = ['static']"
+          # TODO: Should build without features, but that requires system
+          #       libbpf and ubuntu 22.04 only has 0.5 (..?)
+          #- args: "default-features = false"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: sudo apt-get install -y libelf-dev autopoint
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build libbpf-rs sample
+        run: |
+          cargo init --bin libbpf-rs-test-project
+          cd libbpf-rs-test-project
+          cat >> Cargo.toml <<EOF
+          libbpf-rs = { version = "*", path = "../libbpf-rs", ${{ matrix.args }} }
+          EOF
+          cat > src/main.rs <<EOF
+          fn main() {
+              // Use *some* libbpf API so that we actually link against the library.
+              let _linker = libbpf_rs::Linker::new("/tmp/foobar").unwrap();
+          }
+          EOF
+          RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build
+
   build-minimum:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "clap",
  "iced-x86",
  "libbpf-rs",
- "nix 0.27.1",
+ "nix",
 ]
 
 [[package]]
@@ -99,9 +99,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -154,7 +157,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
- "nix 0.27.1",
+ "nix",
  "windows-sys",
 ]
 
@@ -268,7 +271,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.27.1",
+ "nix",
  "num_enum",
  "pkg-config",
  "plain",
@@ -283,12 +286,12 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.2.1+v1.2.0"
+version = "1.3.0+v1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adb4021282a72ca63ebbc0e4247750ad74ede68ff062d247691072d709ad8b"
+checksum = "b6e68987fe8f2dd7b76930f800a4e5b958c766171fc3a7c33dd67c06a0f1e801"
 dependencies = [
  "cc",
- "nix 0.26.4",
+ "nix",
  "num_cpus",
  "pkg-config",
 ]
@@ -344,33 +347,11 @@ checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -382,7 +363,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "libc",
- "memoffset 0.9.0",
+ "memoffset",
 ]
 
 [[package]]
@@ -499,16 +480,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "plain"
@@ -801,7 +776,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "nix 0.27.1",
+ "nix",
  "plain",
 ]
 
@@ -887,7 +862,7 @@ dependencies = [
  "ctrlc",
  "libbpf-cargo",
  "libbpf-rs",
- "nix 0.27.1",
+ "nix",
 ]
 
 [[package]]

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped minimum Rust version to `1.66`
+
+
 0.22.0
 ------
 - Adjusted skeleton creation logic to generate shared and exclusive datasec

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.22.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.66"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ novendor = ["libbpf-sys/novendor"]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
 libbpf-sys = { version = "1.0.3" }
-libbpf-rs = { version = "0.22", path = "../libbpf-rs" }
+libbpf-rs = { version = "0.22", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
 num_enum = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.66+-blue.svg)](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)
 
 # libbpf-cargo
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 ----------
+- Overhauled crate feature set:
+  - Removed `novendor` feature
+  - Added `vendored` feature to use vendored copies of all needed libraries
 - Added `replace` functionality to `Xdp` type
 - Fixed examples not building on non-x86 architectures
 - Bumped minimum Rust version to `1.66`

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added `replace` functionality to `Xdp` type
 - Fixed examples not building on non-x86 architectures
+- Bumped minimum Rust version to `1.66`
 
 
 0.22.1

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -15,15 +15,18 @@ keywords = ["bpf", "ebpf", "libbpf"]
 maintenance = { status = "actively-developed" }
 
 [features]
-# When turned on, link against system-installed libbpf instead of building
-# and linking against vendored libbpf sources
-novendor = ["libbpf-sys/novendor"]
+# By default the crate uses a vendored libbpf, but requires other necessary libs
+# to be present on the system.
+default = ["libbpf-sys/vendored-libbpf"]
+# Link all required libraries statically.
 static = ["libbpf-sys/static"]
+# Use vendored versions of all required libraries.
+vendored = ["libbpf-sys/vendored"]
 
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-libbpf-sys = { version = "1.0.3" }
+libbpf-sys = { version = "1.3", default-features = false }
 libc = "0.2"
 nix = { version = "0.27", default-features = false, features = ["net", "user"] }
 num_enum = "0.5"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 version = "0.22.1"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.66"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
-[![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.66+-blue.svg)](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)
 
 # libbpf-rs
 


### PR DESCRIPTION
This change overhauls the crate's feature set. The 'novendor' feature violates Cargo's "features should be additive" rule [0]. It has been made a no-op in libbpf-sys starting with 1.3.0. With this change we remove it from this crate altogether. We introduce the 'vendored' feature, which causes all library dependencies to be built from vendored source code. We preserve the current default, which is using a vendored copy of libbpf but relying on system libelf and zlib, because while it would be great to be self-contained, the additional build tools required to build said libraries makes this a no-go.

[0] https://doc.rust-lang.org/cargo/reference/features.html