### PR TITLE
Limit Depandabot Cargo lock file updates to one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "cargo"
+    # Limited to 1 to eliminate risk of accidental merge conflicts.
+    open-pull-requests-limit: 1
     versioning-strategy: "lockfile-only"
     directory: "/"
     schedule:


### PR DESCRIPTION
In the past we have hit a case where two Rust package update PRs were merged and that resulted in a merge conflict that wasn't detected by either change. Since then we have done some "@dependabot rebase; @dependabot merge" dance.
Let's just limit the number of outstanding PRs to a single one, to serialize creation completely.