### PR TITLE
libbpf-cargo: Remove novendor feature

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 ----------
+- Removed `novendor` feature in favor of having disableable default
+  feature
+- Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.66`
 
 

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -25,14 +25,14 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [features]
-# When turned on, link against system-installed libbpf instead of building
-# and linking against vendored libbpf sources
-novendor = ["libbpf-sys/novendor"]
+# By default the crate uses a vendored libbpf, but requires other
+# necessary libs to be present on the system.
+default = ["libbpf-sys/vendored-libbpf"]
 
 [dependencies]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
-libbpf-sys = { version = "1.0.3" }
+libbpf-sys = { version = "1.3", default-features = false }
 libbpf-rs = { version = "0.22", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
 num_enum = "0.5"

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -52,7 +52,7 @@ fn extract_version(output: &str) -> Result<&str> {
 /// Extract vendored libbpf header files to a temporary directory.
 ///
 /// Directory and enclosed contents will be removed when return object is dropped.
-#[cfg(not(feature = "novendor"))]
+#[cfg(feature = "default")]
 fn extract_libbpf_headers_to_disk(target_dir: &Path) -> Result<Option<PathBuf>> {
     use std::fs::OpenOptions;
     use std::io::Write;
@@ -69,9 +69,9 @@ fn extract_libbpf_headers_to_disk(target_dir: &Path) -> Result<Option<PathBuf>> 
     Ok(Some(parent_dir))
 }
 
-#[cfg(feature = "novendor")]
-fn extract_libbpf_headers_to_disk(target_dir: &Path) -> Result<Option<PathBuf>> {
-    return Ok(None);
+#[cfg(not(feature = "default"))]
+fn extract_libbpf_headers_to_disk(_target_dir: &Path) -> Result<Option<PathBuf>> {
+    Ok(None)
 }
 
 fn check_clang(debug: bool, clang: &Path, skip_version_checks: bool) -> Result<()> {

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   - Added `vendored` feature to use vendored copies of all needed libraries
 - Added `replace` functionality to `Xdp` type
 - Fixed examples not building on non-x86 architectures
+- Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.66`
 
 


### PR DESCRIPTION
Similar to what we did for libbpf-rs itself with commit 291c6a4e0368 ("Overhaul feature set"), remove the novendor feature in favor of having a disableable default feature.