### PR TITLE
libbpf-cargo: Stop treating clang arguments as a string

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::env::consts::ARCH;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -13,10 +14,10 @@ fn main() {
     out.push("capable.skel.rs");
     SkeletonBuilder::new()
         .source(SRC)
-        .clang_args(format!(
-            "-I{}",
-            Path::new("../vmlinux").join(ARCH).display()
-        ))
+        .clang_args([
+            OsStr::new("-I"),
+            Path::new("../vmlinux").join(ARCH).as_os_str(),
+        ])
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::env::consts::ARCH;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -13,10 +14,10 @@ fn main() {
     out.push("runqslower.skel.rs");
     SkeletonBuilder::new()
         .source(SRC)
-        .clang_args(format!(
-            "-I{}",
-            Path::new("../vmlinux").join(ARCH).display()
-        ))
+        .clang_args([
+            OsStr::new("-I"),
+            Path::new("../vmlinux").join(ARCH).as_os_str(),
+        ])
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::env::consts::ARCH;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -13,10 +14,10 @@ fn main() {
     out.push("tc.skel.rs");
     SkeletonBuilder::new()
         .source(SRC)
-        .clang_args(format!(
-            "-I{}",
-            Path::new("../vmlinux").join(ARCH).display()
-        ))
+        .clang_args([
+            OsStr::new("-I"),
+            Path::new("../vmlinux").join(ARCH).as_os_str(),
+        ])
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::env::consts::ARCH;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -13,10 +14,11 @@ fn main() {
     out.push("tproxy.skel.rs");
     SkeletonBuilder::new()
         .source(SRC)
-        .clang_args(format!(
-            "-Wno-compare-distinct-pointer-types -I{}",
-            Path::new("../vmlinux").join(ARCH).display()
-        ))
+        .clang_args([
+            OsStr::new("-Wno-compare-distinct-pointer-types"),
+            OsStr::new("-I"),
+            Path::new("../vmlinux").join(ARCH).as_os_str(),
+        ])
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Removed `novendor` feature in favor of having disableable default
   feature
+- Adjusted `SkeletonBuilder::clang_args` to accept an iterator of
+  arguments instead of a string
 - Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.66`
 

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   feature
 - Adjusted `SkeletonBuilder::clang_args` to accept an iterator of
   arguments instead of a string
+- Added `--clang-args` argument to `make` and `build` sub-commands
 - Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.66`
 

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -20,6 +20,9 @@ mod metadata;
 struct Opt {
     #[command(subcommand)]
     wrapper: Wrapper,
+    /// Enable debug output.
+    #[clap(short, long, global = true)]
+    debug: bool,
 }
 
 // cargo invokes subcommands with the first argument as
@@ -45,8 +48,6 @@ enum Wrapper {
 enum Command {
     /// Build bpf programs
     Build {
-        #[arg(short, long)]
-        debug: bool,
         #[arg(long, value_parser)]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
@@ -59,8 +60,6 @@ enum Command {
     },
     /// Generate skeleton files
     Gen {
-        #[arg(short, long)]
-        debug: bool,
         #[arg(long, value_parser)]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
@@ -75,8 +74,6 @@ enum Command {
     },
     /// Build project
     Make {
-        #[arg(short, long)]
-        debug: bool,
         #[arg(long, value_parser)]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
@@ -102,11 +99,11 @@ enum Command {
 #[doc(hidden)]
 fn main() -> Result<()> {
     let opts = Opt::parse();
+    let Opt { wrapper, debug } = opts;
 
-    match opts.wrapper {
+    match wrapper {
         Wrapper::Libbpf(cmd) => match cmd {
             Command::Build {
-                debug,
                 manifest_path,
                 clang_path,
                 skip_clang_version_checks,
@@ -117,7 +114,6 @@ fn main() -> Result<()> {
                 skip_clang_version_checks,
             ),
             Command::Gen {
-                debug,
                 manifest_path,
                 rustfmt_path,
                 object,
@@ -128,7 +124,6 @@ fn main() -> Result<()> {
                 object.as_ref(),
             ),
             Command::Make {
-                debug,
                 manifest_path,
                 clang_path,
                 skip_clang_version_checks,

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 
@@ -42,6 +43,17 @@ enum Wrapper {
     Libbpf(Command),
 }
 
+/// A grouping of clang specific options.
+#[derive(Debug, Args)]
+pub struct ClangOpts {
+    /// Path to clang binary
+    #[arg(long, value_parser)]
+    clang_path: Option<PathBuf>,
+    /// Skip clang version checks
+    #[arg(long)]
+    skip_clang_version_checks: bool,
+}
+
 /// cargo-libbpf is a cargo subcommand that helps develop and build eBPF (BPF) programs.
 #[doc(hidden)]
 #[derive(Debug, Subcommand)]
@@ -51,12 +63,8 @@ enum Command {
         #[arg(long, value_parser)]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
-        #[arg(long, value_parser)]
-        /// Path to clang binary
-        clang_path: Option<PathBuf>,
-        #[arg(long)]
-        /// Skip clang version checks
-        skip_clang_version_checks: bool,
+        #[command(flatten)]
+        clang_opts: ClangOpts,
     },
     /// Generate skeleton files
     Gen {
@@ -77,12 +85,8 @@ enum Command {
         #[arg(long, value_parser)]
         /// Path to top level Cargo.toml
         manifest_path: Option<PathBuf>,
-        #[arg(long, value_parser)]
-        /// Path to clang binary
-        clang_path: Option<PathBuf>,
-        #[arg(long)]
-        /// Skip clang version checks
-        skip_clang_version_checks: bool,
+        #[command(flatten)]
+        clang_opts: ClangOpts,
         #[arg(short, long)]
         /// Quiet output
         quiet: bool,
@@ -105,8 +109,11 @@ fn main() -> Result<()> {
         Wrapper::Libbpf(cmd) => match cmd {
             Command::Build {
                 manifest_path,
-                clang_path,
-                skip_clang_version_checks,
+                clang_opts:
+                    ClangOpts {
+                        clang_path,
+                        skip_clang_version_checks,
+                    },
             } => build::build(
                 debug,
                 manifest_path.as_ref(),
@@ -125,8 +132,11 @@ fn main() -> Result<()> {
             ),
             Command::Make {
                 manifest_path,
-                clang_path,
-                skip_clang_version_checks,
+                clang_opts:
+                    ClangOpts {
+                        clang_path,
+                        skip_clang_version_checks,
+                    },
                 quiet,
                 cargo_build_args,
                 rustfmt_path,

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::let_unit_value)]
 #![warn(clippy::absolute_paths)]
 
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -49,6 +50,9 @@ pub struct ClangOpts {
     /// Path to clang binary
     #[arg(long, value_parser)]
     clang_path: Option<PathBuf>,
+    /// Additional arguments to pass to `clang`.
+    #[arg(long, value_parser)]
+    clang_args: Vec<OsString>,
     /// Skip clang version checks
     #[arg(long)]
     skip_clang_version_checks: bool,
@@ -112,12 +116,14 @@ fn main() -> Result<()> {
                 clang_opts:
                     ClangOpts {
                         clang_path,
+                        clang_args,
                         skip_clang_version_checks,
                     },
             } => build::build(
                 debug,
                 manifest_path.as_ref(),
                 clang_path.as_ref(),
+                clang_args,
                 skip_clang_version_checks,
             ),
             Command::Gen {
@@ -135,6 +141,7 @@ fn main() -> Result<()> {
                 clang_opts:
                     ClangOpts {
                         clang_path,
+                        clang_args,
                         skip_clang_version_checks,
                     },
                 quiet,
@@ -144,6 +151,7 @@ fn main() -> Result<()> {
                 debug,
                 manifest_path.as_ref(),
                 clang_path.as_ref(),
+                clang_args,
                 skip_clang_version_checks,
                 quiet,
                 cargo_build_args,

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -8,10 +9,12 @@ use anyhow::Result;
 use crate::build;
 use crate::gen;
 
+#[allow(clippy::too_many_arguments)]
 pub fn make(
     debug: bool,
     manifest_path: Option<&PathBuf>,
     clang: Option<&PathBuf>,
+    clang_args: Vec<OsString>,
     skip_clang_version_checks: bool,
     quiet: bool,
     cargo_build_args: Vec<String>,
@@ -20,8 +23,14 @@ pub fn make(
     if !quiet {
         println!("Compiling BPF objects");
     }
-    build::build(debug, manifest_path, clang, skip_clang_version_checks)
-        .context("Failed to compile BPF objects")?;
+    build::build(
+        debug,
+        manifest_path,
+        clang,
+        clang_args,
+        skip_clang_version_checks,
+    )
+    .context("Failed to compile BPF objects")?;
 
     if !quiet {
         println!("Generating skeletons");

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -135,17 +135,17 @@ fn test_build_default() {
     let (_dir, proj_dir, cargo_toml) = setup_temp_project();
 
     // No bpf progs yet
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     // Add a prog
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -163,7 +163,7 @@ fn test_build_invalid_prog() {
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
     writeln!(prog_file, "1").expect("write to prog file failed");
 
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 }
 
 #[test]
@@ -182,14 +182,14 @@ fn test_build_custom() {
         .expect("write to Cargo.toml failed");
 
     // No bpf progs yet
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     // Add a prog
     create_dir(proj_dir.join("src/other_bpf_dir")).expect("failed to create prog dir");
     let _prog_file = File::create(proj_dir.join("src/other_bpf_dir/prog.bpf.c"))
         .expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
 
     // Validate generated object file
     validate_bpf_o(
@@ -219,13 +219,13 @@ fn test_unknown_metadata_section() {
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     // Add a prog
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -237,15 +237,15 @@ fn test_enforce_file_extension() {
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     let _prog_file = File::create(proj_dir.join("src/bpf/prog_BAD_EXTENSION.c"))
         .expect("failed to create prog file");
-    build(true, Some(&cargo_toml), None, true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
 
     let _prog_file_again = File::create(proj_dir.join("src/bpf/prog_GOOD_EXTENSION.bpf.c"))
         .expect("failed to create prog file");
-    build(true, Some(&cargo_toml), None, true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
 }
 
 #[test]
@@ -253,7 +253,7 @@ fn test_build_workspace() {
     let (_dir, _, workspace_cargo_toml, proj_one_dir, proj_two_dir) = setup_temp_workspace();
 
     // No bpf progs yet
-    build(true, Some(&workspace_cargo_toml), None, true).unwrap_err();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap_err();
 
     // Create bpf prog for project one
     create_dir(proj_one_dir.join("src/bpf")).expect("failed to create prog dir");
@@ -265,7 +265,7 @@ fn test_build_workspace() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog2.bpf.c"))
         .expect("failed to create prog file 2");
 
-    build(true, Some(&workspace_cargo_toml), None, true).unwrap();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap();
 }
 
 #[test]
@@ -282,7 +282,7 @@ fn test_build_workspace_collision() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to create prog file 2");
 
-    build(true, Some(&workspace_cargo_toml), None, true).unwrap_err();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap_err();
 }
 
 #[test]
@@ -296,7 +296,17 @@ fn test_make_basic() {
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -328,6 +338,7 @@ fn test_make_workspace() {
         true,
         Some(&workspace_cargo_toml),
         None,
+        Vec::new(),
         true,
         true,
         Vec::new(),
@@ -373,7 +384,17 @@ fn test_skeleton_empty_source() {
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -467,7 +488,17 @@ fn test_skeleton_basic() {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -576,7 +607,17 @@ fn test_skeleton_generate_datasec_static() {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -614,7 +655,17 @@ fn test_skeleton_datasec() {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -891,7 +942,17 @@ fn test_skeleton_builder_arrays_ptrs() {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -982,7 +1043,17 @@ fn test_skeleton_generate_struct_with_pointer() {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(true, Some(&cargo_toml), None, true, true, Vec::new(), None).unwrap();
+    make(
+        true,
+        Some(&cargo_toml),
+        None,
+        Vec::new(),
+        true,
+        true,
+        Vec::new(),
+        None,
+    )
+    .unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)
@@ -1182,7 +1253,7 @@ fn build_btf_mmap(prog_text: &str) -> Mmap {
     add_vmlinux_header(&proj_dir);
 
     // Build the .bpf.o
-    build(true, Some(&cargo_toml), None, true).expect("failed to compile");
+    build(true, Some(&cargo_toml), None, Vec::new(), true).expect("failed to compile");
 
     let obj = OpenOptions::new()
         .read(true)

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -845,7 +845,7 @@ fn test_skeleton_builder_clang_opts() {
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
         .debug(true)
         .clang("clang")
-        .clang_args("-DPURPOSE=you_pass_the_butter")
+        .clang_args(["-DPURPOSE=you_pass_the_butter"])
         .build_and_generate(skel.path())
         .unwrap();
 }


### PR DESCRIPTION
Please see individual commits for descriptions.