### PR TITLE
Remove unneeded IntoError trait methods

### DIFF
--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -516,24 +516,6 @@ where
     {
         self.ok_or_error(io::ErrorKind::InvalidData, f)
     }
-
-    #[inline]
-    fn ok_or_invalid_input<C, F>(self, f: F) -> Result<T, Error>
-    where
-        C: ToString,
-        F: FnOnce() -> C,
-    {
-        self.ok_or_error(io::ErrorKind::InvalidInput, f)
-    }
-
-    #[inline]
-    fn ok_or_unexpected_eof<C, F>(self, f: F) -> Result<T, Error>
-    where
-        C: ToString,
-        F: FnOnce() -> C,
-    {
-        self.ok_or_error(io::ErrorKind::UnexpectedEof, f)
-    }
 }
 
 impl<T> IntoError<T> for Option<T> {


### PR DESCRIPTION
The `ok_or_invalid_input()` and `ok_or_unexpected_eof()` methods of the `IntoError` trait aren't actually used by the crate (anymore). Current versions of Rust lament this fact.
Remove them to make the toolchain happy.