### PR TITLE
libbpf-cargo: Wrap generated "unsafe" type in MaybeUninit

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -187,8 +187,16 @@ fn main() -> Result<()> {
     let mut open_skel = skel_builder.open()?;
     //Pass configuration to BPF
     open_skel.rodata_mut().tool_config.tgid = opts.pid; //tgid in kernel is pid in userland
-    open_skel.rodata_mut().tool_config.verbose = opts.verbose;
-    open_skel.rodata_mut().tool_config.unique_type = opts.unique_type;
+    open_skel
+        .rodata_mut()
+        .tool_config
+        .verbose
+        .write(opts.verbose);
+    open_skel
+        .rodata_mut()
+        .tool_config
+        .unique_type
+        .write(opts.unique_type);
 
     let mut skel = open_skel.load()?;
     skel.attach()?;

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 - Adjusted `SkeletonBuilder::clang_args` to accept an iterator of
   arguments instead of a string
 - Added `--clang-args` argument to `make` and `build` sub-commands
+- Fixed potential unsoundness issues in generated skeletons by wrapping "unsafe"
+  type in `MaybeUninit`
 - Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.70`
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -2375,10 +2375,17 @@ struct Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
-    pub test: __anon_1,
+    pub test: std::mem::MaybeUninit<__anon_1>,
+}
+impl Default for Foo {
+    fn default() -> Self {
+        Foo {
+            test: std::mem::MaybeUninit::new(__anon_1::default()),
+        }
+    }
 }
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 #[repr(u32)]
@@ -2414,14 +2421,25 @@ struct Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
     pub a: i32,
     pub b: u16,
     pub c: i16,
-    pub d: bool,
+    pub d: std::mem::MaybeUninit<bool>,
     pub e: i8,
+}
+impl Default for Foo {
+    fn default() -> Self {
+        Foo {
+            a: i32::default(),
+            b: u16::default(),
+            c: i16::default(),
+            d: std::mem::MaybeUninit::new(bool::default()),
+            e: i8::default(),
+        }
+    }
 }
 "#;
 


### PR DESCRIPTION
Certain Rust types that we use in our generated skeleton are not valid for all bit patterns. Bools, for example, are defined to be one byte in size, but their representation allows only for 0 and 1 values to be used in said byte -- everything else is undefined behavior. Enums have similar problems, in that not the entire space of the backing type is necessarily used by variants.
The result is an unsoundness issue in our generated skeletons, because C code could accidentally set an enum to an invalid value and Rust code would exhibit undefined behavior.
This change fixes this problem by wrapping the corresponding attributes in MaybeUninit. In so doing users have to be explicit when accessing them and make sure that the current representation is indeed valid.

Closes: #589