### PR TITLE
Stop generation of duplicate types

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -22,7 +22,7 @@ mod capable {
     include!(concat!(env!("OUT_DIR"), "/capable.skel.rs"));
 }
 
-use capable::capable_rodata_types::uniqueness;
+use capable::capable_types::uniqueness;
 use capable::*;
 
 static CAPS: phf::Map<i32, &'static str> = phf_map! {
@@ -103,7 +103,7 @@ struct Command {
     debug: bool,
 }
 
-unsafe impl Plain for capable_bss_types::event {}
+unsafe impl Plain for capable_types::event {}
 
 fn bump_memlock_rlimit() -> Result<()> {
     let rlimit = libc::rlimit {
@@ -133,7 +133,7 @@ fn print_banner(extra_fields: bool) {
     }
 }
 
-fn _handle_event(opts: Command, event: capable_bss_types::event) {
+fn _handle_event(opts: Command, event: capable_types::event) {
     let now = if let Ok(now) = OffsetDateTime::now_local() {
         let format = format_description!("[hour]:[minute]:[second]");
         now.format(&format)
@@ -203,7 +203,7 @@ fn main() -> Result<()> {
 
     print_banner(opts.extra_fields);
     let handle_event = move |_cpu: i32, data: &[u8]| {
-        let mut event = capable_bss_types::event::default();
+        let mut event = capable_types::event::default();
         plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
         _handle_event(opts, event);
     };

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -36,7 +36,7 @@ struct Command {
     verbose: bool,
 }
 
-unsafe impl Plain for runqslower_bss_types::event {}
+unsafe impl Plain for runqslower_types::event {}
 
 fn bump_memlock_rlimit() -> Result<()> {
     let rlimit = libc::rlimit {
@@ -52,7 +52,7 @@ fn bump_memlock_rlimit() -> Result<()> {
 }
 
 fn handle_event(_cpu: i32, data: &[u8]) {
-    let mut event = runqslower_bss_types::event::default();
+    let mut event = runqslower_types::event::default();
     plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
 
     let now = if let Ok(now) = OffsetDateTime::now_local() {

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 - Adjusted `SkeletonBuilder::clang_args` to accept an iterator of
   arguments instead of a string
 - Added `--clang-args` argument to `make` and `build` sub-commands
+- Put all generated types into single `<project>_types` module as opposed to
+  having multiple modules for various sections (`.bss`, `.rodata`, etc.)
 - Fixed potential unsoundness issues in generated skeletons by wrapping "unsafe"
   type in `MaybeUninit`
 - Updated `libbpf-sys` dependency to `1.3.0`

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -2,6 +2,7 @@ pub mod btf;
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -422,7 +423,8 @@ fn gen_skel_datasec_defs(skel: &mut String, obj_name: &str, object: &[u8]) -> Re
                 "#
         )?;
 
-        let sec_def = btf.type_definition(*ty)?;
+        let mut processed = HashSet::new();
+        let sec_def = btf.type_definition(*ty, &mut processed)?;
         write!(skel, "{sec_def}")?;
 
         writeln!(skel, "}}")?;

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::create_dir;
 use std::fs::read;
 use std::fs::read_to_string;
@@ -1279,7 +1280,7 @@ fn btf_from_mmap(mmap: &Mmap) -> GenBtf<'_> {
 #[track_caller]
 fn assert_definition(btf: &GenBtf<'_>, btf_item: &BtfType<'_>, expected_output: &str) {
     let actual_output = btf
-        .type_definition(*btf_item)
+        .type_definition(*btf_item, &mut HashSet::new())
         .expect("Failed to generate struct Foo defn");
     let ao = actual_output.trim_end().trim_start();
     let eo = expected_output.trim_end().trim_start();
@@ -1722,7 +1723,9 @@ struct Foo foo;
     // Find our struct
     let struct_foo = find_type_in_btf!(btf, types::Struct<'_>, "Foo");
 
-    assert!(btf.type_definition(*struct_foo).is_err());
+    assert!(btf
+        .type_definition(*struct_foo, &mut HashSet::new())
+        .is_err());
 }
 
 #[test]

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -718,7 +718,7 @@ fn test_skeleton_datasec() {
             skel.bss_mut().myglobal = 24;
 
             // Read only for rodata after load
-            let _rodata: &prog_rodata_types::rodata = skel.rodata();
+            let _rodata: &prog_types::rodata = skel.rodata();
         }}
         "#,
     )

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -366,20 +366,19 @@ pub trait SkelBuilder<'a> {
 ///
 /// The type of the value returned by each of these methods will be specific to your BPF program.
 /// A common convention is to define a single global variable in the BPF program with a struct type
-/// containing a field for each configuration parameter <sup>\[[source]\]</sup>.  libbpf-rs
+/// containing a field for each configuration parameter <sup>\[[source]\]</sup>. libbpf-rs
 /// auto-generates this pattern for you without you having to define such a struct type in your BPF
 /// program. It does this by examining each of the global variables in your BPF program's `.bss`,
-/// `.data`, and `.rodata` sections and then creating rust struct types `<yourprogram>_bss_types`,
-/// `<yourprogram>_data_types`, and `<yourprogram>_rodata_types`. Since these struct types are
-/// specific to the layout of your BPF program, they are not documented in this crate. However you
-/// can see documentation for them by running `cargo doc` in your own project and looking at the
-/// `imp` module. You can also view their implementation by looking at the generated skeleton rust
-/// source file. The use of these methods can also be seen in the examples 'capable', 'runqslower',
-/// and 'tproxy'.
+/// `.data`, and `.rodata` sections and then creating Rust struct types. Since these struct types
+/// are specific to the layout of your BPF program, they are not documented in this crate. However
+/// you can see documentation for them by running `cargo doc` in your own project and looking at
+/// the `imp` module. You can also view their implementation by looking at the generated skeleton
+/// rust source file. The use of these methods can also be seen in the examples 'capable',
+/// 'runqslower', and 'tproxy'.
 ///
 /// If you ever doubt whether libbpf-rs has placed a particular variable in the correct struct
-/// type, you can see which section each global variable is stored in by examing the output of the
-/// following command (after a successful build):
+/// type, you can see which section each global variable is stored in by examining the output of
+/// the following command (after a successful build):
 ///
 /// ```sh
 /// bpf-objdump --syms ./target/bpf/*.bpf.o


### PR DESCRIPTION
When a type is present in more than one section in the ELF binary (e.g., in .bss as well as .rodata), the generation code ends up generating multiple Rust correspondents as well. That is horrible for interoperability, because there is no language-level connection between these types and so the corresponding objects are not interchangeable in any way.

This change fixes this problem by putting all generated types in a single Rust module, '<project>_types', as opposed to having them be emitted into modules for each of the "data sections".
