### PR TITLE
Exclude Dependabot created branches from CI testing on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
   pull_request:
     branches: [ master ]
   workflow_call:


### PR DESCRIPTION
When Dependabot creates a pull request we always end up with two CI runs -- one for the pull request and one for the push of the commit to a branch.
Exclude pushes to branches for Dependabot created pull requests, to prevent this duplication of work.