### PR TITLE
Add recursion_misses field to ProgramInfo struct

### DIFF
--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -27,11 +27,12 @@ fn prog(args: ProgArgs) {
     let opts = query::ProgInfoQueryOptions::default().include_all();
     for prog in query::ProgInfoIter::with_query_opts(opts) {
         println!(
-            "name={:<16} type={:<15} run_count={:<2} runtime_ns={}",
+            "name={:<16} type={:<15} run_count={:<2} runtime_ns={} recursion_misses={:<2}",
             prog.name.to_string_lossy(),
             prog.ty,
             prog.run_cnt,
-            prog.run_time_ns
+            prog.run_time_ns,
+            prog.recursion_misses,
         );
         if args.disassemble {
             #[cfg(target_arch = "x86_64")]

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -153,6 +153,7 @@ pub struct ProgramInfo {
     pub prog_tags: Vec<Tag>,
     pub run_time_ns: u64,
     pub run_cnt: u64,
+    pub recursion_misses: u64,
 }
 
 /// An iterator for the information of loaded bpf programs
@@ -393,6 +394,7 @@ impl ProgramInfo {
             prog_tags,
             run_time_ns: item.run_time_ns,
             run_cnt: item.run_cnt,
+            recursion_misses: item.recursion_misses,
         });
     }
 }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -153,6 +153,7 @@ pub struct ProgramInfo {
     pub prog_tags: Vec<Tag>,
     pub run_time_ns: u64,
     pub run_cnt: u64,
+    /// Skipped BPF executions due to recursion or concurrent execution prevention.
     pub recursion_misses: u64,
 }
 


### PR DESCRIPTION
The `recursion_misses` statistic is incremented under two scenarios when BPF stats are enabled:

1. When recursion is detected within a BPF program execution. In such a case, the recursive execution is prevented, thus incrementing the recursion_misses counter.
2. When a kprobe handler tries to execute a BPF program and the kernel finds that another program is already running on the CPU. 

These increments help track instances where BPF program execution is skipped due to recursion or concurrent execution prevention mechanisms.

This PR exposes this counter in the ProgramInfo struct. I'd like to add it to [bpftop](https://github.com/Netflix/bpftop)