### PR TITLE
Remove a bunch of redundant imports

### DIFF
--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -996,6 +996,8 @@ macro_rules! __btf_type_match {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     // creates a dummy btftype, not it's not safe to use this type, but it is safe to match on it,
     // which is all we need for these tests.
     macro_rules! dummy_type {
@@ -1018,8 +1020,6 @@ mod test {
         "int"
     }
 
-    use super::BtfType;
-    use crate::btf_type_match;
     #[test]
     fn full_switch_case() {
         dummy_type!(ty);


### PR DESCRIPTION
We have some redundant imports in test modules that were not flagged by earlier version of rustc. Remove them so that once we upgrade we don't see any warnings/errors.