### PR TITLE
Enable clippy::absolute_paths lint in test module

### DIFF
--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::let_unit_value)]
+#![warn(clippy::absolute_paths)]
 
 use std::collections::HashSet;
+use std::env::current_exe;
 use std::ffi::c_void;
 use std::fs;
 use std::hint;
@@ -1386,7 +1388,7 @@ fn test_sudo_object_usdt() {
         .prog_mut("handle__usdt")
         .expect("Failed to find program");
 
-    let path = std::env::current_exe().expect("Failed to find executable name");
+    let path = current_exe().expect("Failed to find executable name");
     let _link = prog
         .attach_usdt(
             unsafe { libc::getpid() },
@@ -1416,7 +1418,7 @@ fn test_sudo_object_usdt_cookie() {
         .prog_mut("handle__usdt_with_cookie")
         .expect("Failed to find program");
 
-    let path = std::env::current_exe().expect("Failed to find executable name");
+    let path = current_exe().expect("Failed to find executable name");
     let _link = prog
         .attach_usdt_with_opts(
             unsafe { libc::getpid() },
@@ -1575,7 +1577,7 @@ fn test_sudo_object_uprobe_with_opts() {
         .expect("Failed to find program");
 
     let pid = unsafe { libc::getpid() };
-    let path = std::env::current_exe().expect("Failed to find executable name");
+    let path = current_exe().expect("Failed to find executable name");
     let func_offset = 0;
     let opts = UprobeOpts {
         func_name: "uprobe_target".to_string(),
@@ -1607,7 +1609,7 @@ fn test_sudo_object_uprobe_with_cookie() {
         .expect("Failed to find program");
 
     let pid = unsafe { libc::getpid() };
-    let path = std::env::current_exe().expect("Failed to find executable name");
+    let path = current_exe().expect("Failed to find executable name");
     let func_offset = 0;
     let opts = UprobeOpts {
         func_name: "uprobe_target".to_string(),


### PR DESCRIPTION
Enable the `clippy::absolute_paths` lint in the test module.