### PR TITLE
Specify truncation behavior when "creating" files

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -62,7 +62,11 @@ fn extract_libbpf_headers_to_disk(target_dir: &Path) -> Result<Option<PathBuf>> 
     fs::create_dir_all(&dir)?;
     for (filename, contents) in libbpf_sys::API_HEADERS.iter() {
         let path = dir.as_path().join(filename);
-        let mut file = OpenOptions::new().write(true).create(true).open(path)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
         file.write_all(contents.as_bytes())?;
     }
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -87,6 +87,7 @@ fn setup_temp_workspace() -> (TempDir, PathBuf, PathBuf, PathBuf, PathBuf) {
     let mut cargo_toml_file = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&workspace_cargo_toml)
         .expect("failed to open workspace Cargo.toml");
     writeln!(cargo_toml_file, r#"[workspace]"#).expect("write to workspace Cargo.toml failed");
@@ -125,6 +126,7 @@ fn get_libbpf_rs_path() -> PathBuf {
 fn add_vmlinux_header(project: &Path) {
     let mut vmlinux = OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(project.join("src/bpf/vmlinux.h"))
         .expect("failed to open vmlinux.h");
@@ -461,6 +463,7 @@ fn test_skeleton_basic() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -586,6 +589,7 @@ fn test_skeleton_generate_datasec_static() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -632,6 +636,7 @@ fn test_skeleton_datasec() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -746,6 +751,7 @@ fn test_skeleton_builder_basic() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -869,6 +875,7 @@ fn test_skeleton_builder_clang_opts() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -913,6 +920,7 @@ fn test_skeleton_builder_arrays_ptrs() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -1023,6 +1031,7 @@ fn test_skeleton_generate_struct_with_pointer() {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 
@@ -1245,6 +1254,7 @@ fn build_btf_mmap(prog_text: &str) -> Mmap {
     let mut prog = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(proj_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to open prog.bpf.c");
 


### PR DESCRIPTION
Recent versions of clippy warn about the lack of specification of the truncation behavior when open a file for writing with create(true) [0]. With this change we make sure to call truncate(true) alongside to silence the resulting warning.

[0] https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options