### PR TITLE
libbpf-cargo: Add "raw" datasec accessors

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
   having multiple modules for various sections (`.bss`, `.rodata`, etc.)
 - Fixed potential unsoundness issues in generated skeletons by wrapping "unsafe"
   type in `MaybeUninit`
+- Added pointer based ("raw") access to datasec type to generated skeletons
 - Updated `libbpf-sys` dependency to `1.3.0`
 - Bumped minimum Rust version to `1.70`
 

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -548,12 +548,12 @@ fn gen_skel_datasec_getters(
             write!(
                 skel,
                 r#"
+                pub fn {name}{fn_suffix}_raw(&{ref_suffix} self) -> *{ptr_suffix} {struct_name} {{
+                    self.skel_config.map_mmap_ptr{fn_suffix}({idx}).unwrap().cast::<{struct_name}>()
+                }}
+
                 pub fn {name}{fn_suffix}(&{ref_suffix} self) -> &{ref_suffix} {struct_name} {{
-                    unsafe {{
-                        std::mem::transmute::<*{ptr_suffix} std::ffi::c_void, &{ref_suffix} {struct_name}>(
-                            self.skel_config.map_mmap_ptr{fn_suffix}({idx}).unwrap()
-                        )
-                    }}
+                    unsafe {{&{ref_suffix}*self.{name}{fn_suffix}_raw()}}
                 }}
                 "#
             )?;


### PR DESCRIPTION
It's possible to run into borrow checker conflicts with the generated datasec accessor functions. The reason for that is that they all borrow from the very same skeleton object and so once one of the borrows is mutable, no other borrows may exist.
Yet, in reality each datasec object is backed by strictly distinct regions of memory and so there is no actual conflict. However, we haven't found a way to convey this property to the Rust borrow checker given current language features, other than falling back to runtime checking (there are proposals floating around for annotating method signatures with the members they borrow, which would allow the borrow checker to reason correctly, but they are not stable by any means).

With this change we take a way out in the form of exposing the "raw" pointers, effectively opting out of borrow checking altogether and pushing the burden of "proof" to the user. E.g., for the capable example:

```rust
let rodata = open_skel.rodata_raw();
let rodata_mut = open_skel.rodata_mut();
//Pass configuration to BPF
rodata_mut.tool_config.tgid = opts.pid; //tgid in kernel is pid in userland
rodata_mut.tool_config.verbose.write(opts.verbose);
rodata_mut.tool_config.unique_type.write(opts.unique_type);

println!("{:?}", unsafe { (*rodata).tool_config });
```

Closes: #606