### PR TITLE
Use parse_ret_i32() helper in one more location

### DIFF
--- a/examples/capable/README.md
+++ b/examples/capable/README.md
@@ -96,7 +96,7 @@ used both at the same time to include user and kernel stack).
 
 -->
 Some processes can do a lot of security capability checks, generating a lot of
-ouput. In this case, the --unique option is useful to only print once the same
+output. In this case, the --unique option is useful to only print once the same
 set of capability, pid(1) or cgroup (2) <!-- and kernel/user
 stacks (if -K or -U are used). -->
 ```

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -236,9 +236,7 @@ impl Map {
 
         // Get the map fd
         let fd = unsafe { libbpf_sys::bpf_map__fd(ptr.as_ptr()) };
-        if fd < 0 {
-            return Err(Error::from_raw_os_error(-fd));
-        }
+        let fd = util::parse_ret_i32(fd)?;
 
         let ty = MapType::try_from(unsafe { libbpf_sys::bpf_map__type(ptr.as_ptr()) })
             .unwrap_or(MapType::Unknown);


### PR DESCRIPTION
Switch to using the parse_ret_i32() helper in one more location, instead of having to hard code the condition evaluation there "by hand".