### PR TITLE
Use `CARGO_CFG_TARGET_ARCH` environment variable in example build scripts

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -12,11 +11,15 @@ fn main() {
     let mut out =
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("capable.skel.rs");
+
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args([
             OsStr::new("-I"),
-            Path::new("../vmlinux").join(ARCH).as_os_str(),
+            Path::new("../vmlinux").join(arch).as_os_str(),
         ])
         .build_and_generate(&out)
         .unwrap();

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -12,11 +11,15 @@ fn main() {
     let mut out =
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("runqslower.skel.rs");
+
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args([
             OsStr::new("-I"),
-            Path::new("../vmlinux").join(ARCH).as_os_str(),
+            Path::new("../vmlinux").join(arch).as_os_str(),
         ])
         .build_and_generate(&out)
         .unwrap();

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -12,11 +11,15 @@ fn main() {
     let mut out =
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("tc.skel.rs");
+
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args([
             OsStr::new("-I"),
-            Path::new("../vmlinux").join(ARCH).as_os_str(),
+            Path::new("../vmlinux").join(arch).as_os_str(),
         ])
         .build_and_generate(&out)
         .unwrap();

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -12,12 +11,16 @@ fn main() {
     let mut out =
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("tproxy.skel.rs");
+
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args([
             OsStr::new("-Wno-compare-distinct-pointer-types"),
             OsStr::new("-I"),
-            Path::new("../vmlinux").join(ARCH).as_os_str(),
+            Path::new("../vmlinux").join(arch).as_os_str(),
         ])
         .build_and_generate(&out)
         .unwrap();


### PR DESCRIPTION
It appears as if `std::env::consts::ARCH` does not get updated to the target architecture in a cross-compilation context. Switch to using the `CARGO_CFG_TARGET_ARCH` environment variable in the hopes that we get the desired behavior.