### PR TITLE
libbpf-cargo: Use "contains" for checking existence of __TARGET_ARCH_…

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -179,7 +179,7 @@ fn compile_one(
 
     if !clang_args
         .iter()
-        .any(|arg| arg.as_os_str() == OsStr::new("-D__TARGET_ARCH_"))
+        .any(|arg| arg.to_string_lossy().contains("__TARGET_ARCH_"))
     {
         let arch = match ARCH {
             "x86_64" => "x86",


### PR DESCRIPTION
…<xxx>

When we added logic for passing through clang arguments in a more structured fashion, we switched to using an equality check for the presence of the __TARGET_ARCH_<xxx> define. However, that does not work, because the define contains the architecture as a suffix. Switch to just checking for a substring.