### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,6 @@ version = "0.22.1"
 dependencies = [
  "bitflags 2.4.2",
  "cc",
- "lazy_static",
  "libbpf-sys",
  "libc",
  "log",

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -25,7 +25,6 @@ vendored = ["libbpf-sys/vendored"]
 
 [dependencies]
 bitflags = "2.0"
-lazy_static = "1.4"
 libbpf-sys = { version = "1.3", default-features = false }
 libc = "0.2"
 nix = { version = "0.27", default-features = false, features = ["net", "user"] }

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::os::raw::c_char;
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
+use crate::util::LazyLock;
 
 /// An enum representing the different supported print levels.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -48,10 +48,8 @@ fn default_callback(_lvl: PrintLevel, msg: String) {
 // locking the mutex.
 //
 // Note that default print behavior ignores debug messages.
-lazy_static! {
-    static ref PRINT_CB: Mutex<Option<(PrintLevel, PrintCallback)>> =
-        Mutex::new(Some((PrintLevel::Info, default_callback)));
-}
+static PRINT_CB: LazyLock<Mutex<Option<(PrintLevel, PrintCallback)>>> =
+    LazyLock::new(|| Mutex::new(Some((PrintLevel::Info, default_callback))));
 
 extern "C" fn outer_print_cb(
     level: libbpf_sys::libbpf_print_level,


### PR DESCRIPTION
std::sync::OnceLock has been stabilized in rust version 1.70.  [std::sync::LazyLock](https://github.com/rust-lang/rust/issues/109736) is not stable yet. Implement LazyLock with std::sync::OnceLock as an alternative to std::sync::LazyLock. 

