### PR TITLE
libbpf-cargo: Improve error for GenBtf::required_padding() method

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -231,7 +231,7 @@ impl<'s> GenBtf<'s> {
     ) -> Result<usize> {
         ensure!(
             current_offset <= required_offset,
-            "Current offset ahead of required offset"
+            "current offset ({current_offset}) ahead of required offset ({required_offset})"
         );
 
         let align = if packed {


### PR DESCRIPTION
Improve the fidelity of errors reported by `GenBtf::required_padding()` by including current and required offset in message.