### PR TITLE
Correctly handle forward declarations in GenBtf::type_declaration()

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -175,12 +175,12 @@ impl<'s> GenBtf<'s> {
             }
             BtfKind::Struct | BtfKind::Union | BtfKind::Enum | BtfKind::Enum64 =>
                 self.get_type_name_handling_anon_types(&ty).into_owned(),
-            // The only way a variable references a function is through a function pointer.
-            // Return c_void here so the final def will look like `*mut c_void`.
+            // The only way a variable references a function or forward declaration is through a
+            // pointer. Return c_void here so the final def will look like `*mut c_void`.
             //
             // It's not like rust code can call a function inside a bpf prog either so we don't
             // really need a full definition. `void *` is totally sufficient for sharing a pointer.
-            BtfKind::Func | BtfKind::FuncProto => "std::ffi::c_void".to_string(),
+            BtfKind::Fwd | BtfKind::Func | BtfKind::FuncProto => "std::ffi::c_void".to_string(),
             BtfKind::Var(t) => self.type_declaration(t.referenced_type())?,
             _ => bail!("Invalid type: {ty:?}"),
         });

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1403,6 +1403,27 @@ impl Default for Foo {
 }
 
 #[test]
+fn test_btf_dump_fwd() {
+    let prog_text = r#"
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct sometypethatdoesnotexist *m;
+"#;
+
+    let mmap = build_btf_mmap(prog_text);
+    let btf = btf_from_mmap(&mmap);
+
+    let m = find_type_in_btf!(btf, types::Var<'_>, "m");
+
+    assert_eq!(
+        "*mut std::ffi::c_void",
+        btf.type_declaration(*m)
+            .expect("Failed to generate foo decl")
+    );
+}
+
+#[test]
 fn test_btf_dump_align() {
     let prog_text = r#"
 #include "vmlinux.h"


### PR DESCRIPTION
Adjust the logic in `GenBtf::type_declaration()` to correctly handle forward declarations. That is generally useful, but will needed particularly for struct_ops shadow type support.
