### PR TITLE
Enable default features for clap dependency of tcp-ca example

### DIFF
--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 libbpf-cargo = { path = "../../libbpf-cargo" }
 
 [dependencies]
-clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
+clap = { version = "4.0.32", features = ["derive"] }
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"


### PR DESCRIPTION
Enable default features for the clap dependency of the tcp-ca example. See commit 20fd30cb8b8f ("libbpf-cargo: Enable default features of clap") for reasoning.