### PR TITLE
Init padding fields in libbpf_sys types

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -707,10 +707,13 @@ impl MapHandle {
             )));
         };
 
+        #[allow(clippy::needless_update)]
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
             elem_flags: elem_flags.bits(),
             flags: flags.bits(),
+            // bpf_map_batch_opts might have padding fields on some platform
+            ..Default::default()
         };
 
         let mut count = count;
@@ -820,10 +823,13 @@ impl MapHandle {
             )));
         }
 
+        #[allow(clippy::needless_update)]
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
             elem_flags: elem_flags.bits(),
             flags: flags.bits(),
+            // bpf_map_batch_opts might have padding fields on some platform
+            ..Default::default()
         };
 
         let mut count = count;

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -60,9 +60,12 @@ impl From<UsdtOpts> for libbpf_sys::bpf_usdt_opts {
             cookie,
             _non_exhaustive,
         } = opts;
+        #[allow(clippy::needless_update)]
         libbpf_sys::bpf_usdt_opts {
             sz: size_of::<Self>() as _,
             usdt_cookie: cookie,
+            // bpf_usdt_opts might have padding fields on some platform
+            ..Default::default()
         }
     }
 }
@@ -83,9 +86,12 @@ impl From<TracepointOpts> for libbpf_sys::bpf_tracepoint_opts {
             _non_exhaustive,
         } = opts;
 
+        #[allow(clippy::needless_update)]
         libbpf_sys::bpf_tracepoint_opts {
             sz: size_of::<Self>() as _,
             bpf_cookie: cookie,
+            // bpf_tracepoint_opts might have padding fields on some platform
+            ..Default::default()
         }
     }
 }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -339,6 +339,7 @@ fn test_sudo_object_map_delete_batch() {
 /// Test whether `MapInfo` works properly
 #[test]
 pub fn test_sudo_map_info() {
+    #[allow(clippy::needless_update)]
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
         map_flags: libbpf_sys::BPF_ANY,
@@ -350,6 +351,8 @@ pub fn test_sudo_map_info() {
         map_extra: 0,
         numa_node: 0,
         map_ifindex: 0,
+        // bpf_map_create_opts might have padding fields on some platform
+        ..Default::default()
     };
 
     let map = MapHandle::create(MapType::Hash, Some("simple_map"), 8, 64, 1024, &opts).unwrap();
@@ -1324,6 +1327,7 @@ fn test_sudo_object_map_create_and_pin() {
 fn test_sudo_object_map_create_without_name() {
     bump_rlimit_mlock();
 
+    #[allow(clippy::needless_update)]
     let opts = libbpf_sys::bpf_map_create_opts {
         sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
         map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
@@ -1335,6 +1339,8 @@ fn test_sudo_object_map_create_without_name() {
         map_extra: 0,
         numa_node: 0,
         map_ifindex: 0,
+        // bpf_map_create_opts might have padding fields on some platform
+        ..Default::default()
     };
 
     let map = MapHandle::create(MapType::Hash, Option::<&str>::None, 4, 8, 8, &opts)


### PR DESCRIPTION
libbpf-sys structs might have additional padding fields on some 32-bit platform(like arm32, mips32) when using bindgen, initialize all fileds of libbpf structs with `...Default.default()`.
