### PR TITLE
Implement AsRawLibbpf for OpenProgram

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - Added `replace` functionality to `Xdp` type
 - Added low-level `consume_raw` and `poll_raw` methods to `RingBuffer` type
 - Added `recursion_misses` attribute to `query::ProgramInfo` type
+- Added `AsRawLibbpf` impl for `OpenProgram`
 - Fixed incorrect inference of `btf::types::MemberAttr::Bitfield` variant
 - Fixed examples not building on non-x86 architectures
 - Fixed potentially missing padding byte initialization on some target

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -237,7 +237,7 @@ impl OpenProgram {
     }
 }
 
-impl AsRawLibbpf for Program {
+impl AsRawLibbpf for OpenProgram {
     type LibbpfType = libbpf_sys::bpf_program;
 
     /// Retrieve the underlying [`libbpf_sys::bpf_program`].
@@ -990,5 +990,14 @@ impl Program {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
         unsafe { slice::from_raw_parts(ptr, count) }
+    }
+}
+
+impl AsRawLibbpf for Program {
+    type LibbpfType = libbpf_sys::bpf_program;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_program`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
     }
 }


### PR DESCRIPTION
OpenProgram is not really different from Program and so it should implement the AsRawLibbpf trait just the same.