### PR TITLE
Adjust remaining examples to produce skeleton in src/bpf/ directory

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -7,9 +7,12 @@ use libbpf_cargo::SkeletonBuilder;
 const SRC: &str = "src/bpf/capable.bpf.c";
 
 fn main() {
-    let mut out =
-        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
-    out.push("capable.skel.rs");
+    let out = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set in build script"),
+    )
+    .join("src")
+    .join("bpf")
+    .join("capable.skel.rs");
 
     let arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH must be set in build script");

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -19,7 +19,7 @@ use time::macros::format_description;
 use time::OffsetDateTime;
 
 mod capable {
-    include!(concat!(env!("OUT_DIR"), "/capable.skel.rs"));
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/capable.skel.rs"));
 }
 
 use capable::capable_types::uniqueness;

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -7,9 +7,12 @@ use libbpf_cargo::SkeletonBuilder;
 const SRC: &str = "src/bpf/runqslower.bpf.c";
 
 fn main() {
-    let mut out =
-        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
-    out.push("runqslower.skel.rs");
+    let out = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set in build script"),
+    )
+    .join("src")
+    .join("bpf")
+    .join("runqslower.skel.rs");
 
     let arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH must be set in build script");

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -14,7 +14,7 @@ use time::macros::format_description;
 use time::OffsetDateTime;
 
 mod runqslower {
-    include!(concat!(env!("OUT_DIR"), "/runqslower.skel.rs"));
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/runqslower.skel.rs"));
 }
 
 use runqslower::*;

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -7,9 +7,12 @@ use libbpf_cargo::SkeletonBuilder;
 const SRC: &str = "src/bpf/tc.bpf.c";
 
 fn main() {
-    let mut out =
-        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
-    out.push("tc.skel.rs");
+    let out = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set in build script"),
+    )
+    .join("src")
+    .join("bpf")
+    .join("tc.skel.rs");
 
     let arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH must be set in build script");

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -19,7 +19,7 @@ use libbpf_rs::TC_H_MIN_INGRESS;
 use libbpf_rs::TC_INGRESS;
 
 mod tc {
-    include!(concat!(env!("OUT_DIR"), "/tc.skel.rs"));
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/tc.skel.rs"));
 }
 use tc::*;
 

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -7,9 +7,12 @@ use libbpf_cargo::SkeletonBuilder;
 const SRC: &str = "src/bpf/tproxy.bpf.c";
 
 fn main() {
-    let mut out =
-        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
-    out.push("tproxy.skel.rs");
+    let out = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set in build script"),
+    )
+    .join("src")
+    .join("bpf")
+    .join("tproxy.skel.rs");
 
     let arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH must be set in build script");

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -16,7 +16,7 @@ use libbpf_rs::TcHookBuilder;
 use libbpf_rs::TC_INGRESS;
 
 mod tproxy {
-    include!(concat!(env!("OUT_DIR"), "/tproxy.skel.rs"));
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/tproxy.skel.rs"));
 }
 
 use tproxy::*;


### PR DESCRIPTION
Do what commit 545c59c006eb ("Adjust tcp_ca example to produce skeleton in example directory") started for all the remaining example and have the skeletons created in the respective src/bpf/ directory to make them easier discoverable.