### PR TITLE
libbpf-cargo: Add support for custom .data sections

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Removed `novendor` feature in favor of having disableable default
   feature
 - Added support for `struct_ops` shadow objects for generated skeletons
+- Added support for handling custom data sections in generated skeletons
 - Adjusted `SkeletonBuilder::clang_args` to accept an iterator of
   arguments instead of a string
 - Added `--clang-args` argument to `make` and `build` sub-commands

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -772,6 +772,7 @@ impl struct_ops {{
             Some(s) => s.into_owned(),
         };
         sec_name.remove(0);
+        let sec_name = sec_name.replace('.', "_");
 
         writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
         writeln!(def, r#"#[repr(C)]"#)?;


### PR DESCRIPTION
This change adds support for handling of custom .data sections, declared via SEC(".data.xxxx") in the BPF C code. It makes sure that we generate the corresponding Rust types as well as the proper maps getters.