### PR TITLE
libbpf-cargo: escape map names

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -366,7 +366,7 @@ fn gen_skel_map_defs(
 
         for map in MapIter::new(object.as_mut_ptr()) {
             let map_name = match get_map_name(map)? {
-                Some(n) => n,
+                Some(n) => n.replace('.', "_"),
                 None => continue,
             };
 


### PR DESCRIPTION
commit 51ffd0f added support for custom sections.

this broke skeleton generation when bpf_printk() was used along with BPF_NO_GLOBAL_DATA, as e.g. the map '.rodata.str1.1' contains invalid chars. add simple escaping to the map name as well (similar to the one used for the section name)
