### PR TITLE
Fix a couple of formatting glitches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --package libbpf-cargo libbpf-rs -- --check
+      - run: cargo fmt -- --check
   cargo-doc:
     name: Check documentation
     runs-on: ubuntu-latest

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -19,7 +19,10 @@ use time::macros::format_description;
 use time::OffsetDateTime;
 
 mod capable {
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/capable.skel.rs"));
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/capable.skel.rs"
+    ));
 }
 
 use capable::capable_types::uniqueness;

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -14,7 +14,10 @@ use time::macros::format_description;
 use time::OffsetDateTime;
 
 mod runqslower {
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/runqslower.skel.rs"));
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/runqslower.skel.rs"
+    ));
 }
 
 use runqslower::*;

--- a/examples/tcp_ca/src/main.rs
+++ b/examples/tcp_ca/src/main.rs
@@ -18,16 +18,16 @@ use std::thread;
 
 use clap::Parser;
 
-use libc::setsockopt;
-use libc::IPPROTO_TCP;
-use libc::TCP_CONGESTION;
-
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::AsRawLibbpf as _;
 use libbpf_rs::ErrorExt as _;
 use libbpf_rs::ErrorKind;
 use libbpf_rs::Result;
+
+use libc::setsockopt;
+use libc::IPPROTO_TCP;
+use libc::TCP_CONGESTION;
 
 use crate::tcp_ca::TcpCaSkelBuilder;
 

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -16,7 +16,10 @@ use libbpf_rs::TcHookBuilder;
 use libbpf_rs::TC_INGRESS;
 
 mod tproxy {
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/tproxy.skel.rs"));
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/tproxy.skel.rs"
+    ));
 }
 
 use tproxy::*;

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -1,5 +1,10 @@
 //! Wrappers representing concrete btf types.
 
+use std::ffi::CStr;
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Deref;
+
 use num_enum::IntoPrimitive;
 use num_enum::TryFromPrimitive;
 
@@ -8,10 +13,6 @@ use super::BtfType;
 use super::HasSize;
 use super::ReferencesType;
 use super::TypeId;
-use std::ffi::CStr;
-use std::fmt;
-use std::fmt::Display;
-use std::ops::Deref;
 
 // Generate a btf type that doesn't have any fields, i.e. there is no data after the BtfType
 // pointer.

--- a/libbpf-rs/src/xdp.rs
+++ b/libbpf-rs/src/xdp.rs
@@ -1,7 +1,8 @@
-use bitflags::bitflags;
 use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::BorrowedFd;
+
+use bitflags::bitflags;
 
 use crate::util;
 use crate::Result;

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -13,16 +13,11 @@ use std::mem::size_of;
 use std::os::unix::io::AsFd;
 use std::path::Path;
 use std::path::PathBuf;
+use std::ptr;
 use std::ptr::addr_of;
 use std::slice;
 use std::sync::mpsc::channel;
 use std::time::Duration;
-
-use plain::Plain;
-use probe::probe;
-use scopeguard::defer;
-use std::ptr;
-use tempfile::NamedTempFile;
 
 use libbpf_rs::num_possible_cpus;
 use libbpf_rs::AsRawLibbpf;
@@ -42,6 +37,10 @@ use libbpf_rs::ProgramType;
 use libbpf_rs::TracepointOpts;
 use libbpf_rs::UprobeOpts;
 use libbpf_rs::UsdtOpts;
+use plain::Plain;
+use probe::probe;
+use scopeguard::defer;
+use tempfile::NamedTempFile;
 
 fn get_test_object_path(filename: &str) -> PathBuf {
     let mut path = PathBuf::new();

--- a/libbpf-rs/tests/test_print.rs
+++ b/libbpf-rs/tests/test_print.rs
@@ -5,14 +5,15 @@
 //!
 //! For the same reason, all tests here must run serially.
 
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
 use libbpf_rs::get_print;
 use libbpf_rs::set_print;
 use libbpf_rs::ObjectBuilder;
 use libbpf_rs::PrintCallback;
 use libbpf_rs::PrintLevel;
 use serial_test::serial;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 
 #[test]
 #[serial]


### PR DESCRIPTION
I tried setting the "StdExternalCrate" 'group_imports' rustfmt configuration. It works, but it has some not-so-great impacts as well. Nevertheless, there are some uncontroversial suggestions in there, so keep them. Also make sure to not exclusively run rustfmt on only libbpf-rs and libbpf-cargo, but also also examples in CI.