### PR TITLE
Fix CI badges in README

### DIFF
--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
+[![CI](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml)
 [![rustc](https://img.shields.io/badge/rustc-1.71+-blue.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
 
 # libbpf-cargo

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/libbpf/libbpf-rs/workflows/Rust/badge.svg?branch=master)
+[![CI](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml)
 [![rustc](https://img.shields.io/badge/rustc-1.71+-blue.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
 
 # libbpf-rs


### PR DESCRIPTION
The CI badges we have in the README files no longer point to valid data. Update them as per the latest.