### PR TITLE
libbpf-cargo: Eliminate direct libbpf-sys dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,6 @@ dependencies = [
  "clap",
  "goblin",
  "libbpf-rs",
- "libbpf-sys",
  "memmap2",
  "num_enum",
  "regex",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -27,12 +27,11 @@ path = "src/lib.rs"
 [features]
 # By default the crate uses a vendored libbpf, but requires other
 # necessary libs to be present on the system.
-default = ["libbpf-sys/vendored-libbpf"]
+default = ["libbpf-rs/default"]
 
 [dependencies]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
-libbpf-sys = { version = "1.4", default-features = false }
 libbpf-rs = { version = "0.23", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
 num_enum = "0.5"

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -54,6 +54,7 @@ fn extract_version(output: &str) -> Result<&str> {
 /// Directory and enclosed contents will be removed when return object is dropped.
 #[cfg(feature = "default")]
 fn extract_libbpf_headers_to_disk(target_dir: &Path) -> Result<Option<PathBuf>> {
+    use libbpf_rs::libbpf_sys;
     use std::fs::OpenOptions;
     use std::io::Write;
 

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -27,8 +27,11 @@ use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
+
 use libbpf_rs::btf::types;
+use libbpf_rs::libbpf_sys;
 use libbpf_rs::Btf;
+
 use memmap2::Mmap;
 
 use crate::metadata;


### PR DESCRIPTION
The crate already depends on libbpf as an integral building block. Yet, it pulls in its own version of libbpf-sys.
Switch to just consuming libbpf-rs's re-export, which reduces the maintenance burden by having a single point of update, while also potentially making it easier to replace/patch the libbpf-sys version in use.
