### PR TITLE
libbpf-cargo: Add support for "import injection" to generated skeletons

### DIFF
--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -11,5 +11,7 @@ vmlinux = { path = "../../vmlinux" }
 
 [dependencies]
 clap = { version = "4.0.32", features = ["derive"] }
-libbpf-rs = { path = "../../libbpf-rs" }
+# We rename the `libbpf-rs` dependency here to illustrate how skeleton creation
+# works with that.
+the-original-libbpf-rs = { path = "../../libbpf-rs", package = "libbpf-rs" }
 libc = "0.2"

--- a/examples/tcp_ca/src/main.rs
+++ b/examples/tcp_ca/src/main.rs
@@ -18,12 +18,12 @@ use std::thread;
 
 use clap::Parser;
 
-use libbpf_rs::skel::OpenSkel;
-use libbpf_rs::skel::SkelBuilder;
-use libbpf_rs::AsRawLibbpf as _;
-use libbpf_rs::ErrorExt as _;
-use libbpf_rs::ErrorKind;
-use libbpf_rs::Result;
+use the_original_libbpf_rs::skel::OpenSkel;
+use the_original_libbpf_rs::skel::SkelBuilder;
+use the_original_libbpf_rs::AsRawLibbpf as _;
+use the_original_libbpf_rs::ErrorExt as _;
+use the_original_libbpf_rs::ErrorKind;
+use the_original_libbpf_rs::Result;
 
 use libc::setsockopt;
 use libc::IPPROTO_TCP;
@@ -32,6 +32,12 @@ use libc::TCP_CONGESTION;
 use crate::tcp_ca::TcpCaSkelBuilder;
 
 mod tcp_ca {
+    // Skeleton rely on `libbpf_rs` being present in their "namespace". Because
+    // we renamed the libbpf-rs dependency, we have to make it available under
+    // the expected name here for the skeleton itself to work. None of this is
+    // generally necessary, but it enables some niche use cases.
+    use the_original_libbpf_rs as libbpf_rs;
+
     include!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/src/bpf/tcp_ca.skel.rs"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added "import injection" escape hatch to generated skeletons
+
+
 0.23.0
 ------
 - Removed `novendor` feature in favor of having disableable default

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -815,6 +815,8 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
            #[allow(clippy::upper_case_acronyms)]
            #[warn(single_use_lifetimes)]
            mod imp {{
+           #[allow(unused_imports)]
+           use super::*;
            use libbpf_rs::libbpf_sys;
            use libbpf_rs::skel::OpenSkel;
            use libbpf_rs::skel::Skel;
@@ -896,6 +898,8 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
         skel,
         r#"
             pub mod {raw_obj_name}_types {{
+                #[allow(unused_imports)]
+                use super::*;
             "#
     )?;
 


### PR DESCRIPTION
Our generated skeletons hardcode the libbpf-rs dependency to use. That is fine in principle, but it can be limiting for users. For example, a user may legitimately want to import libbpf-rs under a different name, in which case skeletons simply won't work. Or, instead of having a direct dependency on libbpf-rs they may want to rely on a re-export through a different dependency.
Currently there is no way to cater to these cases. With this change we introduce an escape hatch that allows for such usage. Specifically, we generate a super::* import that optionally pulls in items defined in the outer module. It should be extremely unlikely that this pulls in any conflicting items, because this should only honor 'pub'. In any event, conflicts can always be mitigated by introducing an intermediary module that has a clean slate environment. What this hatch provides users with, is the ability to inject a "prelude" of sorts into the generated skeleton. E.g., in the case of a re-export as mentioned before, that could be a 'use <renamed-libbpf-rs> as libbpf_rs;' statement.