### PR TITLE
Fix Audit workflow

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -167,7 +167,7 @@ exceptions = [
 # published to private registries.
 # To see how to mark a crate as unpublished (to the official registry),
 # visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
-ignore = false
+ignore = true
 # One or more private registries that you might publish crates to, if a crate
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked

--- a/vmlinux/Cargo.toml
+++ b/vmlinux/Cargo.toml
@@ -3,3 +3,8 @@ name = "vmlinux"
 version = "0.0.0"
 edition = "2021"
 authors = ["Daniel Müller <deso@posteo.net>"]
+# Not intended to be published at this point and only meant to be used as a
+# dev-dependency; licensing is not 100% clear but more importantly we can't
+# really version the crate in a way that would be generally useful to downstream
+# users (version by kernel version? "just" semver? none is without problems).
+publish = false


### PR DESCRIPTION
Recent runs of the Audit workflow failed, citing a missing license of the vmlinux crate. At this point we don't intend to publish it or shit it and it really is only meant to be used as a dev-dependency. Mark the crate as unpublishable in its Cargo.toml and instruct cargo-deny to ignore such crates in its evaluation.