### PR TITLE
libbpf-cargo: Allow absolute path usage in generated skeleton

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -811,6 +811,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
            #[allow(dead_code)]
            #[allow(non_snake_case)]
            #[allow(non_camel_case_types)]
+           #[allow(clippy::absolute_paths)]
            #[allow(clippy::transmute_ptr_to_ref)]
            #[allow(clippy::upper_case_acronyms)]
            #[warn(single_use_lifetimes)]


### PR DESCRIPTION
Allow the `clippy::absolute_paths` lint so that references to items specified by absolute path are not flagged, if this lint is enabled in client code.