### PR TITLE
Flag absolute path usage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --locked --no-deps --all-targets --tests -- -D warnings
+      - run: cargo clippy --locked --no-deps --all-targets --tests -- -D warnings -D clippy::absolute_paths
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -4,6 +4,7 @@
 //
 // Based on capable(8) by Brendan Gregg
 use core::time::Duration;
+use std::str;
 use std::str::FromStr;
 
 use anyhow::bail;
@@ -145,7 +146,7 @@ fn _handle_event(opts: Command, event: capable_types::event) {
         "00:00:00".to_string()
     };
 
-    let comm_str = std::str::from_utf8(&event.comm)
+    let comm_str = str::from_utf8(&event.comm)
         .unwrap()
         .trim_end_matches(char::from(0));
     let cap_name = match CAPS.get(&event.cap) {

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
-use core::time::Duration;
+use std::str;
+use std::time::Duration;
 
 use anyhow::bail;
 use anyhow::Result;
@@ -66,7 +67,7 @@ fn handle_event(_cpu: i32, data: &[u8]) {
         "00:00:00".to_string()
     };
 
-    let task = std::str::from_utf8(&event.task).unwrap();
+    let task = str::from_utf8(&event.task).unwrap();
 
     println!(
         "{:8} {:16} {:<7} {:<14}",

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -18,6 +18,8 @@ use libbpf_rs::TC_H_CLSACT;
 use libbpf_rs::TC_H_MIN_INGRESS;
 use libbpf_rs::TC_INGRESS;
 
+use nix::net::if_::if_nametoindex;
+
 mod tc {
     include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/tc.skel.rs"));
 }
@@ -71,7 +73,7 @@ fn main() -> Result<()> {
     let open = builder.open()?;
     let mut skel = open.load()?;
     let progs = skel.progs();
-    let ifidx = nix::net::if_::if_nametoindex(opts.iface.as_str())? as i32;
+    let ifidx = if_nametoindex(opts.iface.as_str())? as i32;
 
     let mut tc_builder = TcHookBuilder::new(progs.handle_tc().as_fd());
     tc_builder


### PR DESCRIPTION
Deny the `absolute_paths` Clippy lint project wide in CI, to enforce a more coherent style in an automated fashion.