### PR TITLE
Add CHANGELOG entry for #776

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added support for user ring buffers
 - Fixed handling of bloom filter type maps
   - Added `Map::lookup_bloom_filter` for looking up elements in a bloom filter
 

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -146,6 +146,7 @@ pub use crate::tc::TC_H_MIN_EGRESS;
 pub use crate::tc::TC_H_MIN_INGRESS;
 pub use crate::tc::TC_INGRESS;
 pub use crate::user_ringbuf::UserRingBuffer;
+pub use crate::user_ringbuf::UserRingBufferSample;
 pub use crate::util::num_possible_cpus;
 pub use crate::xdp::Xdp;
 pub use crate::xdp::XdpFlags;

--- a/libbpf-rs/src/user_ringbuf.rs
+++ b/libbpf-rs/src/user_ringbuf.rs
@@ -147,7 +147,7 @@ impl UserRingBuffer {
 
         // The libbpf API does not return an error code, so we cannot determine
         // if the submission was successful. Return a `Result` to enable future
-        // validation while maintaing backwards compatibility.
+        // validation while maintaining backwards compatibility.
         Ok(())
     }
 }


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #776, which added support for user ring buffers to the library. Also make sure to export UserRingBufferSample publicly to reduce friction when working with it.