### PR TITLE
Remove dependency on `num_enum`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,6 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "num_enum",
  "pkg-config",
  "plain",
  "probe",
@@ -422,27 +421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,17 +523,6 @@ name = "probe"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216e81fcf486280f0b8b18ca43ceafd32739eb0eb703eb024a8d00814eeba556"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
-dependencies = [
- "once_cell",
- "thiserror",
- "toml",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -924,15 +891,6 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,10 +293,7 @@ dependencies = [
  "goblin",
  "libbpf-rs",
  "memmap2",
- "num_enum",
  "regex",
- "scroll",
- "scroll_derive",
  "semver",
  "serde",
  "serde_json",
@@ -322,7 +319,6 @@ dependencies = [
  "serial_test",
  "strum_macros",
  "tempfile",
- "thiserror",
  "vsprintf",
 ]
 
@@ -838,7 +834,6 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "nix 0.28.0",
- "plain",
  "vmlinux",
 ]
 

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -13,6 +13,5 @@ vmlinux = { path = "../../vmlinux" }
 anyhow = "1.0"
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
-plain = "0.2"
 nix = { version = "0.28", default-features = false, features = ["net", "user"] }
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -34,10 +34,7 @@ anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
 libbpf-rs = { version = "0.23", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
-num_enum = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }
-scroll = "0.11"
-scroll_derive = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -29,7 +29,6 @@ libbpf-sys = { version = "1.4.1", default-features = false }
 libc = "0.2"
 num_enum = "0.5"
 strum_macros = "0.24"
-thiserror = "1.0.10"
 vsprintf = "2.0"
 
 [dev-dependencies]

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -27,7 +27,6 @@ vendored = ["libbpf-sys/vendored"]
 bitflags = "2.0"
 libbpf-sys = { version = "1.4.1", default-features = false }
 libc = "0.2"
-num_enum = "0.5"
 strum_macros = "0.24"
 vsprintf = "2.0"
 

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -732,7 +732,7 @@ impl Var<'_> {
     /// The kind of linkage this variable has.
     #[inline]
     pub fn linkage(&self) -> Linkage {
-        self.ptr.linkage.try_into().unwrap_or(Linkage::Unknown)
+        self.ptr.linkage.into()
     }
 }
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1175,10 +1175,7 @@ impl MapInfo {
     /// Get the map type
     #[inline]
     pub fn map_type(&self) -> MapType {
-        match MapType::try_from(self.info.type_) {
-            Ok(t) => t,
-            Err(_) => MapType::Unknown,
-        }
+        MapType::from(self.info.type_)
     }
 
     /// Get the name of this map.

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -554,10 +554,7 @@ impl Program {
 
     /// Retrieve the type of the program.
     pub fn prog_type(&self) -> ProgramType {
-        match ProgramType::try_from(unsafe { libbpf_sys::bpf_program__type(self.ptr.as_ptr()) }) {
-            Ok(ty) => ty,
-            Err(_) => ProgramType::Unknown,
-        }
+        ProgramType::from(unsafe { libbpf_sys::bpf_program__type(self.ptr.as_ptr()) })
     }
 
     /// Returns program fd by id

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -14,7 +14,6 @@ use std::ptr::NonNull;
 use std::slice;
 
 use libbpf_sys::bpf_func_id;
-use num_enum::TryFromPrimitive;
 use strum_macros::Display;
 
 use crate::util;
@@ -361,7 +360,7 @@ impl From<u32> for ProgramType {
 /// Attach type of a [`Program`]. Maps to `enum bpf_attach_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, TryFromPrimitive, Display, Debug)]
+#[derive(Clone, Display, Debug)]
 // TODO: Document variants.
 #[allow(missing_docs)]
 pub enum ProgramAttachType {
@@ -409,6 +408,58 @@ pub enum ProgramAttachType {
     PerfEvent,
     /// See [`MapType::Unknown`][crate::MapType::Unknown]
     Unknown = u32::MAX,
+}
+
+impl From<u32> for ProgramAttachType {
+    fn from(value: u32) -> Self {
+        use ProgramAttachType::*;
+
+        match value {
+            x if x == CgroupInetIngress as u32 => CgroupInetIngress,
+            x if x == CgroupInetEgress as u32 => CgroupInetEgress,
+            x if x == CgroupInetSockCreate as u32 => CgroupInetSockCreate,
+            x if x == CgroupSockOps as u32 => CgroupSockOps,
+            x if x == SkSkbStreamParser as u32 => SkSkbStreamParser,
+            x if x == SkSkbStreamVerdict as u32 => SkSkbStreamVerdict,
+            x if x == CgroupDevice as u32 => CgroupDevice,
+            x if x == SkMsgVerdict as u32 => SkMsgVerdict,
+            x if x == CgroupInet4Bind as u32 => CgroupInet4Bind,
+            x if x == CgroupInet6Bind as u32 => CgroupInet6Bind,
+            x if x == CgroupInet4Connect as u32 => CgroupInet4Connect,
+            x if x == CgroupInet6Connect as u32 => CgroupInet6Connect,
+            x if x == CgroupInet4PostBind as u32 => CgroupInet4PostBind,
+            x if x == CgroupInet6PostBind as u32 => CgroupInet6PostBind,
+            x if x == CgroupUdp4Sendmsg as u32 => CgroupUdp4Sendmsg,
+            x if x == CgroupUdp6Sendmsg as u32 => CgroupUdp6Sendmsg,
+            x if x == LircMode2 as u32 => LircMode2,
+            x if x == FlowDissector as u32 => FlowDissector,
+            x if x == CgroupSysctl as u32 => CgroupSysctl,
+            x if x == CgroupUdp4Recvmsg as u32 => CgroupUdp4Recvmsg,
+            x if x == CgroupUdp6Recvmsg as u32 => CgroupUdp6Recvmsg,
+            x if x == CgroupGetsockopt as u32 => CgroupGetsockopt,
+            x if x == CgroupSetsockopt as u32 => CgroupSetsockopt,
+            x if x == TraceRawTp as u32 => TraceRawTp,
+            x if x == TraceFentry as u32 => TraceFentry,
+            x if x == TraceFexit as u32 => TraceFexit,
+            x if x == ModifyReturn as u32 => ModifyReturn,
+            x if x == LsmMac as u32 => LsmMac,
+            x if x == TraceIter as u32 => TraceIter,
+            x if x == CgroupInet4Getpeername as u32 => CgroupInet4Getpeername,
+            x if x == CgroupInet6Getpeername as u32 => CgroupInet6Getpeername,
+            x if x == CgroupInet4Getsockname as u32 => CgroupInet4Getsockname,
+            x if x == CgroupInet6Getsockname as u32 => CgroupInet6Getsockname,
+            x if x == XdpDevmap as u32 => XdpDevmap,
+            x if x == CgroupInetSockRelease as u32 => CgroupInetSockRelease,
+            x if x == XdpCpumap as u32 => XdpCpumap,
+            x if x == SkLookup as u32 => SkLookup,
+            x if x == Xdp as u32 => Xdp,
+            x if x == SkSkbVerdict as u32 => SkSkbVerdict,
+            x if x == SkReuseportSelect as u32 => SkReuseportSelect,
+            x if x == SkReuseportSelectOrMigrate as u32 => SkReuseportSelectOrMigrate,
+            x if x == PerfEvent as u32 => PerfEvent,
+            _ => Unknown,
+        }
+    }
 }
 
 /// The input a program accepts.
@@ -542,12 +593,9 @@ impl Program {
 
     /// Retrieve the attach type of the program.
     pub fn attach_type(&self) -> ProgramAttachType {
-        match ProgramAttachType::try_from(unsafe {
+        ProgramAttachType::from(unsafe {
             libbpf_sys::bpf_program__expected_attach_type(self.ptr.as_ptr())
-        }) {
-            Ok(ty) => ty,
-            Err(_) => ProgramAttachType::Unknown,
-        }
+        })
     }
 
     /// Return `true` if the bpf program is set to autoload, `false` otherwise.
@@ -1088,6 +1136,63 @@ mod tests {
         ] {
             // check if discriminants match after a roundtrip conversion
             assert_eq!(discriminant(&t), discriminant(&ProgramType::from(t as u32)));
+        }
+    }
+
+    #[test]
+    fn program_attach_type() {
+        use ProgramAttachType::*;
+
+        for t in [
+            CgroupInetIngress,
+            CgroupInetEgress,
+            CgroupInetSockCreate,
+            CgroupSockOps,
+            SkSkbStreamParser,
+            SkSkbStreamVerdict,
+            CgroupDevice,
+            SkMsgVerdict,
+            CgroupInet4Bind,
+            CgroupInet6Bind,
+            CgroupInet4Connect,
+            CgroupInet6Connect,
+            CgroupInet4PostBind,
+            CgroupInet6PostBind,
+            CgroupUdp4Sendmsg,
+            CgroupUdp6Sendmsg,
+            LircMode2,
+            FlowDissector,
+            CgroupSysctl,
+            CgroupUdp4Recvmsg,
+            CgroupUdp6Recvmsg,
+            CgroupGetsockopt,
+            CgroupSetsockopt,
+            TraceRawTp,
+            TraceFentry,
+            TraceFexit,
+            ModifyReturn,
+            LsmMac,
+            TraceIter,
+            CgroupInet4Getpeername,
+            CgroupInet6Getpeername,
+            CgroupInet4Getsockname,
+            CgroupInet6Getsockname,
+            XdpDevmap,
+            CgroupInetSockRelease,
+            XdpCpumap,
+            SkLookup,
+            Xdp,
+            SkSkbVerdict,
+            SkReuseportSelect,
+            SkReuseportSelectOrMigrate,
+            PerfEvent,
+            Unknown,
+        ] {
+            // check if discriminants match after a roundtrip conversion
+            assert_eq!(
+                discriminant(&t),
+                discriminant(&ProgramAttachType::from(t as u32))
+            );
         }
     }
 }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -292,10 +292,7 @@ impl ProgramInfo {
 
         // SANITY: `libbpf` should guarantee NUL termination.
         let name = util::c_char_slice_to_cstr(&item.name).unwrap();
-        let ty = match ProgramType::try_from(item.type_) {
-            Ok(ty) => ty,
-            Err(_) => ProgramType::Unknown,
-        };
+        let ty = ProgramType::from(item.type_);
 
         if opts.include_xlated_prog_insns {
             xlated_prog_insns.resize(item.xlated_prog_len as usize, 0u8);
@@ -464,10 +461,7 @@ impl MapInfo {
     fn from_uapi(_fd: BorrowedFd<'_>, s: libbpf_sys::bpf_map_info) -> Option<Self> {
         // SANITY: `libbpf` should guarantee NUL termination.
         let name = util::c_char_slice_to_cstr(&s.name).unwrap();
-        let ty = match MapType::try_from(s.type_) {
-            Ok(ty) => ty,
-            Err(_) => MapType::Unknown,
-        };
+        let ty = MapType::from(s.type_);
 
         Some(Self {
             name: name.to_owned(),
@@ -673,25 +667,22 @@ impl LinkInfo {
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_TRACING => LinkTypeInfo::Tracing(TracingLinkInfo {
-                attach_type: ProgramAttachType::try_from(unsafe {
+                attach_type: ProgramAttachType::from(unsafe {
                     s.__bindgen_anon_1.tracing.attach_type
-                })
-                .unwrap_or(ProgramAttachType::Unknown),
+                }),
             }),
             libbpf_sys::BPF_LINK_TYPE_CGROUP => LinkTypeInfo::Cgroup(CgroupLinkInfo {
                 cgroup_id: unsafe { s.__bindgen_anon_1.cgroup.cgroup_id },
-                attach_type: ProgramAttachType::try_from(unsafe {
+                attach_type: ProgramAttachType::from(unsafe {
                     s.__bindgen_anon_1.cgroup.attach_type
-                })
-                .unwrap_or(ProgramAttachType::Unknown),
+                }),
             }),
             libbpf_sys::BPF_LINK_TYPE_ITER => LinkTypeInfo::Iter,
             libbpf_sys::BPF_LINK_TYPE_NETNS => LinkTypeInfo::NetNs(NetNsLinkInfo {
                 ino: unsafe { s.__bindgen_anon_1.netns.netns_ino },
-                attach_type: ProgramAttachType::try_from(unsafe {
+                attach_type: ProgramAttachType::from(unsafe {
                     s.__bindgen_anon_1.netns.attach_type
-                })
-                .unwrap_or(ProgramAttachType::Unknown),
+                }),
             }),
             _ => LinkTypeInfo::Unknown,
         };


### PR DESCRIPTION
Hello! 

I am using `libbpf-rs` in one of my personal projects and I noticed that I was pulling in `toml-edit` via `libbpf-rs` which accounted for 1.3 seconds of my total build time. With the help of `cargo tree` I realized that `num_enum` is pulling in that dependency (and many others!) and I decided to try to remove it from `libbpf-rs` completely. Let me know what you think!

`cargo udeps` also noticed some extra things that can be removed, so I went ahead and removed those.