### PR TITLE
Export MapKeyIter in public interface

### DIFF
--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -112,6 +112,7 @@ pub use crate::map::Map;
 pub use crate::map::MapFlags;
 pub use crate::map::MapHandle;
 pub use crate::map::MapInfo;
+pub use crate::map::MapKeyIter;
 pub use crate::map::MapType;
 pub use crate::map::OpenMap;
 pub use crate::object::AsRawLibbpf;

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1108,6 +1108,7 @@ impl From<MapType> for u32 {
     }
 }
 
+/// An iterator over the keys of a [`Map`].
 #[derive(Debug)]
 pub struct MapKeyIter<'a> {
     map: &'a MapHandle,


### PR DESCRIPTION
Export the MapKeyIter type as part of the public interface. The type itself has always been public, it just couldn't be named. Improve ergonomics and documentation by exporting it properly.