### PR TITLE
Remove strum_macros dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,10 +186,10 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -252,12 +252,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -316,7 +310,6 @@ dependencies = [
  "probe",
  "scopeguard",
  "serial_test",
- "strum_macros",
  "tempfile",
  "vsprintf",
 ]
@@ -488,7 +481,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -623,12 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +653,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -701,7 +688,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -735,7 +722,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -755,30 +742,6 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.107"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -857,7 +820,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]

--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -27,7 +27,7 @@ fn prog(args: ProgArgs) {
     let opts = query::ProgInfoQueryOptions::default().include_all();
     for prog in query::ProgInfoIter::with_query_opts(opts) {
         println!(
-            "name={:<16} type={:<15} run_count={:<2} runtime_ns={} recursion_misses={:<2}",
+            "name={:<16} type={:<15?} run_count={:<2} runtime_ns={} recursion_misses={:<2}",
             prog.name.to_string_lossy(),
             prog.ty,
             prog.run_cnt,
@@ -60,7 +60,7 @@ fn prog(args: ProgArgs) {
 
 fn map() {
     for map in query::MapInfoIter::default() {
-        println!("name={:<16} type={}", map.name.to_string_lossy(), map.ty);
+        println!("name={:<16} type={:?}", map.name.to_string_lossy(), map.ty);
     }
 }
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Removed `Display` implementation of various `enum` types
+
+
 0.23.2
 ------
 - Fixed build failure on Android platforms

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -27,7 +27,6 @@ vendored = ["libbpf-sys/vendored"]
 bitflags = "2.0"
 libbpf-sys = { version = "1.4.1", default-features = false }
 libc = "0.2"
-strum_macros = "0.24"
 vsprintf = "2.0"
 
 [dev-dependencies]

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -23,7 +23,6 @@ use std::slice::from_raw_parts;
 use bitflags::bitflags;
 use libbpf_sys::bpf_map_info;
 use libbpf_sys::bpf_obj_get_info_by_fd;
-use strum_macros::Display;
 
 use crate::util;
 use crate::util::parse_ret_i32;
@@ -316,7 +315,7 @@ impl Map {
     pub fn attach_struct_ops(&self) -> Result<Link> {
         if self.map_type() != MapType::StructOps {
             return Err(Error::with_invalid_data(format!(
-                "Invalid map type ({}) for attach_struct_ops()",
+                "Invalid map type ({:?}) for attach_struct_ops()",
                 self.map_type(),
             )));
         }
@@ -635,7 +634,7 @@ impl MapHandle {
         }
         if self.map_type().is_percpu() {
             return Err(Error::with_invalid_data(format!(
-                "lookup_percpu() must be used for per-cpu maps (type of the map is {})",
+                "lookup_percpu() must be used for per-cpu maps (type of the map is {:?})",
                 self.map_type(),
             )));
         }
@@ -674,7 +673,7 @@ impl MapHandle {
     pub fn lookup_percpu(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<Vec<u8>>>> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
-                "lookup() must be used for maps that are not per-cpu (type of the map is {})",
+                "lookup() must be used for maps that are not per-cpu (type of the map is {:?})",
                 self.map_type(),
             )));
         }
@@ -802,7 +801,7 @@ impl MapHandle {
     pub fn update(&self, key: &[u8], value: &[u8], flags: MapFlags) -> Result<()> {
         if self.map_type().is_percpu() {
             return Err(Error::with_invalid_data(format!(
-                "update_percpu() must be used for per-cpu maps (type of the map is {})",
+                "update_percpu() must be used for per-cpu maps (type of the map is {:?})",
                 self.map_type(),
             )));
         }
@@ -881,7 +880,7 @@ impl MapHandle {
     pub fn update_percpu(&self, key: &[u8], values: &[Vec<u8>], flags: MapFlags) -> Result<()> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
-                "update() must be used for maps that are not per-cpu (type of the map is {})",
+                "update() must be used for maps that are not per-cpu (type of the map is {:?})",
                 self.map_type(),
             )));
         }
@@ -981,7 +980,7 @@ bitflags! {
 // If you add a new per-cpu map, also update `is_percpu`.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Display, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 // TODO: Document members.
 #[allow(missing_docs)]
 pub enum MapType {

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -14,7 +14,6 @@ use std::ptr::NonNull;
 use std::slice;
 
 use libbpf_sys::bpf_func_id;
-use strum_macros::Display;
 
 use crate::util;
 use crate::AsRawLibbpf;
@@ -245,7 +244,7 @@ impl AsRawLibbpf for OpenProgram {
 /// Type of a [`Program`]. Maps to `enum bpf_prog_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Copy, Clone, Display, Debug)]
+#[derive(Copy, Clone, Debug)]
 // TODO: Document variants.
 #[allow(missing_docs)]
 pub enum ProgramType {
@@ -360,7 +359,7 @@ impl From<u32> for ProgramType {
 /// Attach type of a [`Program`]. Maps to `enum bpf_attach_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, Display, Debug)]
+#[derive(Clone, Debug)]
 // TODO: Document variants.
 #[allow(missing_docs)]
 pub enum ProgramAttachType {


### PR DESCRIPTION
Remove the strum_macros dependency. Having arbitrary Display implementations for enum types makes very little sense and is generally not recommended practice. Drop the derive and just use the Debug representation where needed.