### PR TITLE
libbpf-cargo: Generate Default impl on overly large padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,10 +186,10 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -252,6 +252,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -310,6 +316,7 @@ dependencies = [
  "probe",
  "scopeguard",
  "serial_test",
+ "strum_macros",
  "tempfile",
  "test-tag",
  "vsprintf",
@@ -471,7 +478,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -606,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +656,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -678,7 +691,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -712,7 +725,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -732,6 +745,30 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -801,7 +838,7 @@ checksum = "f3166bd55ee7b5cc0543b3dcf0ecc099c371443c5515cbe83720db96243aa45a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -821,7 +858,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.46",
 ]
 
 [[package]]

--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -27,7 +27,7 @@ fn prog(args: ProgArgs) {
     let opts = query::ProgInfoQueryOptions::default().include_all();
     for prog in query::ProgInfoIter::with_query_opts(opts) {
         println!(
-            "name={:<16} type={:<15?} run_count={:<2} runtime_ns={} recursion_misses={:<2}",
+            "name={:<16} type={:<15} run_count={:<2} runtime_ns={} recursion_misses={:<2}",
             prog.name.to_string_lossy(),
             prog.ty,
             prog.run_cnt,
@@ -60,7 +60,7 @@ fn prog(args: ProgArgs) {
 
 fn map() {
     for map in query::MapInfoIter::default() {
-        println!("name={:<16} type={:?}", map.name.to_string_lossy(), map.ty);
+        println!("name={:<16} type={}", map.name.to_string_lossy(), map.ty);
     }
 }
 

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed generation of `Default` impl in presence of large padding arrays
+
+
 0.23.1
 ------
 - Added "import injection" escape hatch to generated skeletons

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -575,6 +575,10 @@ impl struct_ops {{
                     impl_default.push(format!(
                         r#"            __pad_{offset}: [u8::default(); {padding}]"#,
                     ));
+
+                    if padding > 32 {
+                        gen_impl_default = true;
+                    }
                 }
 
                 if let Some(ft) = self.type_by_id::<types::Array<'_>>(field_ty.type_id()) {
@@ -634,6 +638,10 @@ impl struct_ops {{
                 impl_default.push(format!(
                     r#"            __pad_{offset}: [u8::default(); {padding}]"#,
                 ));
+
+                if padding > 32 {
+                    gen_impl_default = true;
+                }
             }
         }
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,8 +1,3 @@
-Unreleased
-----------
-- Removed `Display` implementation of various `enum` types
-
-
 0.23.2
 ------
 - Fixed build failure on Android platforms

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -27,6 +27,7 @@ vendored = ["libbpf-sys/vendored"]
 bitflags = "2.0"
 libbpf-sys = { version = "1.4.1", default-features = false }
 libc = "0.2"
+strum_macros = "0.24"
 vsprintf = "2.0"
 
 [dev-dependencies]

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -23,6 +23,7 @@ use std::slice::from_raw_parts;
 use bitflags::bitflags;
 use libbpf_sys::bpf_map_info;
 use libbpf_sys::bpf_obj_get_info_by_fd;
+use strum_macros::Display;
 
 use crate::util;
 use crate::util::parse_ret_i32;
@@ -315,7 +316,7 @@ impl Map {
     pub fn attach_struct_ops(&self) -> Result<Link> {
         if self.map_type() != MapType::StructOps {
             return Err(Error::with_invalid_data(format!(
-                "Invalid map type ({:?}) for attach_struct_ops()",
+                "Invalid map type ({}) for attach_struct_ops()",
                 self.map_type(),
             )));
         }
@@ -634,7 +635,7 @@ impl MapHandle {
         }
         if self.map_type().is_percpu() {
             return Err(Error::with_invalid_data(format!(
-                "lookup_percpu() must be used for per-cpu maps (type of the map is {:?})",
+                "lookup_percpu() must be used for per-cpu maps (type of the map is {})",
                 self.map_type(),
             )));
         }
@@ -673,7 +674,7 @@ impl MapHandle {
     pub fn lookup_percpu(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<Vec<u8>>>> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
-                "lookup() must be used for maps that are not per-cpu (type of the map is {:?})",
+                "lookup() must be used for maps that are not per-cpu (type of the map is {})",
                 self.map_type(),
             )));
         }
@@ -801,7 +802,7 @@ impl MapHandle {
     pub fn update(&self, key: &[u8], value: &[u8], flags: MapFlags) -> Result<()> {
         if self.map_type().is_percpu() {
             return Err(Error::with_invalid_data(format!(
-                "update_percpu() must be used for per-cpu maps (type of the map is {:?})",
+                "update_percpu() must be used for per-cpu maps (type of the map is {})",
                 self.map_type(),
             )));
         }
@@ -880,7 +881,7 @@ impl MapHandle {
     pub fn update_percpu(&self, key: &[u8], values: &[Vec<u8>], flags: MapFlags) -> Result<()> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
-                "update() must be used for maps that are not per-cpu (type of the map is {:?})",
+                "update() must be used for maps that are not per-cpu (type of the map is {})",
                 self.map_type(),
             )));
         }
@@ -980,7 +981,7 @@ bitflags! {
 // If you add a new per-cpu map, also update `is_percpu`.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Display, Debug)]
 // TODO: Document members.
 #[allow(missing_docs)]
 pub enum MapType {

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -14,6 +14,7 @@ use std::ptr::NonNull;
 use std::slice;
 
 use libbpf_sys::bpf_func_id;
+use strum_macros::Display;
 
 use crate::util;
 use crate::AsRawLibbpf;
@@ -244,7 +245,7 @@ impl AsRawLibbpf for OpenProgram {
 /// Type of a [`Program`]. Maps to `enum bpf_prog_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Display, Debug)]
 // TODO: Document variants.
 #[allow(missing_docs)]
 pub enum ProgramType {
@@ -359,7 +360,7 @@ impl From<u32> for ProgramType {
 /// Attach type of a [`Program`]. Maps to `enum bpf_attach_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Display, Debug)]
 // TODO: Document variants.
 #[allow(missing_docs)]
 pub enum ProgramAttachType {


### PR DESCRIPTION
When we pad structs to ensure proper alignment, we may end up generating
padding arrays of more than 32 byte when alignment is large. In such
cases, Rust would not be able to derive a Default and we'd need to make
sure to generate one ourselves, or a compilation error will ensue.
With this change we make sure to switch over to generating a Default
impl ourselves in those cases.