### PR TITLE
Generate Rust types for types used in BPF maps

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Adjusted skeleton creation logic to generate Rust types for types used in BPF
+  maps
+
+
 0.23.3
 ------
 - Fixed generation of `Default` impl in presence of large padding arrays

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -361,10 +361,9 @@ impl<'s> GenBtf<'s> {
             )
         };
 
-        ensure!(
-            !is_terminal(ty),
-            "Tried to print type definition for terminal type"
-        );
+        if is_terminal(ty) {
+            return Ok(String::new());
+        }
 
         // Process dependent types until there are none left.
         //


### PR DESCRIPTION
Generate Rust correspondents for the types used in BPF maps. Having these types generated will eliminate the need for miscellaneous hacks to be employed to get the corresponding Rust types by other means.

Closes: #602