### PR TITLE
Use different target names in USDT tests

### DIFF
--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1625,7 +1625,7 @@ fn test_object_usdt_cookie() {
             unsafe { libc::getpid() },
             &path,
             "test_provider",
-            "test_function",
+            "test_function2",
             UsdtOpts {
                 cookie: cookie_val.into(),
                 ..UsdtOpts::default()
@@ -1636,7 +1636,7 @@ fn test_object_usdt_cookie() {
     let map = obj.map("ringbuf").expect("Failed to get ringbuf map");
     let action = || {
         // Define a USDT probe point and exercise it as we are attaching to self.
-        probe!(test_provider, test_function, 1);
+        probe!(test_provider, test_function2, 1);
     };
     let result = with_ringbuffer(map, action);
 


### PR DESCRIPTION
We probably shouldn't be sharing the same target name for the static probes created in the USDT tests, if for no other reason than it being stupidly confusing. Rename one of them.