### PR TITLE
Implement AsRawLibbpf for OpenObject

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `AsRawLibbpf` impl for `OpenObject`
 - Removed `Display` implementation of various `enum` types
 
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -311,6 +311,15 @@ impl OpenObject {
     }
 }
 
+impl AsRawLibbpf for OpenObject {
+    type LibbpfType = libbpf_sys::bpf_object;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_object`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        self.ptr
+    }
+}
+
 impl Drop for OpenObject {
     fn drop(&mut self) {
         // `self.ptr` may be null if `load()` was called. This is ok: libbpf noops


### PR DESCRIPTION
Add an implementation of AsRawLibbpf for OpenObject. We already have one for Object, and both types just encapsulate a bpf_object pointer.