### PR TITLE
Retrieve OpenProgram::section lazily

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 - Added `AsRawLibbpf` impl for `OpenObject`
+- Adjusted `OpenProgram` to lazily retrieve section
+  - Changed `OpenProgram::section` to return `Option<&CStr>` and
+    `OpenProgram::new` to be infallible
 - Removed `Display` implementation of various `enum` types
 
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -201,7 +201,7 @@ impl OpenObject {
                 }
             };
 
-            let program = unsafe { OpenProgram::new(prog_ptr) }?;
+            let program = unsafe { OpenProgram::new(prog_ptr) };
 
             // Add the program to the hashmap
             obj.progs.insert(program.name()?.into(), program);


### PR DESCRIPTION
It seems questionable for the OpenProgram type to eagerly retrieve the program's section. For one, that member seems useful in only very niche situations, meaning that we may perform unnecessary work. Handling is also different from other similar members such as the program's name, which is retrieve on-demand only. Lastly, initializing this member eagerly (i.e., in the constructor), means that we add an unnecessary fallible path to every call site using an object of the type. Just move the section retrieval into the OpenProgram::section() member function.