### PR TITLE
Remove CStr usage from API surface

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -13,6 +13,7 @@ use std::ops::Deref;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::ensure;
+use anyhow::Context as _;
 use anyhow::Result;
 use libbpf_rs::btf::types;
 use libbpf_rs::btf::types::Linkage;
@@ -399,7 +400,7 @@ impl<'s> GenBtf<'s> {
         // (and dependent types).
         for ty in self.type_by_kind::<types::DataSec<'_>>() {
             let name = match ty.name() {
-                Some(s) => s.to_str()?,
+                Some(s) => s.to_str().context("datasec has invalid name")?,
                 None => "",
             };
 

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -475,7 +475,7 @@ fn gen_skel_datasec_types(
 
     for ty in btf.type_by_kind::<types::DataSec<'_>>() {
         let name = match ty.name() {
-            Some(s) => s.to_str()?,
+            Some(s) => s.to_str().context("datasec has invalid name")?,
             None => "",
         };
 

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,9 +1,10 @@
 Unreleased
 ----------
 - Added `AsRawLibbpf` impl for `OpenObject`
+- Adjusted various APIs to return/use `OsStr` instead of `CStr`
 - Adjusted `OpenProgram` to lazily retrieve section
-  - Changed `OpenProgram::section` to return `Option<&CStr>` and
-    `OpenProgram::new` to be infallible
+  - Changed `OpenProgram::section` to return `&OsStr` and `OpenProgram::new` to
+    be infallible
 - Removed `Display` implementation of various `enum` types
 
 

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -1,6 +1,6 @@
 //! Wrappers representing concrete btf types.
 
-use std::ffi::CStr;
+use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::Display;
 use std::ops::Deref;
@@ -469,7 +469,7 @@ gen_collection_concrete_type! {
     /// A member of a [Struct]
     struct StructMember<'btf> {
         /// The member's name
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The member's type
         pub ty: TypeId,
         /// The attributes of this member.
@@ -493,7 +493,7 @@ gen_collection_concrete_type! {
     /// A member of an [Union]
     struct UnionMember<'btf> {
         /// The member's name
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The member's type
         pub ty: TypeId,
         /// The attributes of this member.
@@ -586,7 +586,7 @@ gen_collection_members_concrete_type! {
     /// A member of a [Struct]
     struct CompositeMember<'btf> {
         /// The member's name
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The member's type
         pub ty: TypeId,
         /// If this member is a bifield, these are it's attributes.
@@ -610,7 +610,7 @@ gen_collection_concrete_type! {
     /// A member of an [Enum]
     struct EnumMember<'btf> {
         /// The name of this enum variant.
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The numeric value of this enum variant.
         pub value: i32,
     }
@@ -709,7 +709,7 @@ gen_collection_concrete_type! {
     /// A parameter of a [FuncProto].
     struct FuncProtoParam<'btf> {
         /// The parameter's name
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The parameter's type
         pub ty: TypeId,
     }
@@ -810,7 +810,7 @@ gen_collection_concrete_type! {
     /// A member of an [Enum64].
     struct Enum64Member<'btf> {
         /// The name of this enum variant.
-        pub name: Option<&'btf CStr>,
+        pub name: Option<&'btf OsStr>,
         /// The numeric value of this enum variant.
         pub value: u64,
     }

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -184,7 +184,14 @@ impl OpenObject {
             let map_obj = unsafe { OpenMap::new(map_ptr) };
 
             // Add the map to the hashmap
-            obj.maps.insert(map_obj.name()?.into(), map_obj);
+            obj.maps.insert(
+                map_obj
+                    .name()
+                    .to_str()
+                    .ok_or_else(|| Error::with_invalid_data("map has invalid name"))?
+                    .to_string(),
+                map_obj,
+            );
             map = map_ptr.as_ptr();
         }
 
@@ -204,7 +211,14 @@ impl OpenObject {
             let program = unsafe { OpenProgram::new(prog_ptr) };
 
             // Add the program to the hashmap
-            obj.progs.insert(program.name()?.into(), program);
+            obj.progs.insert(
+                program
+                    .name()
+                    .to_str()
+                    .ok_or_else(|| Error::with_invalid_data("program has invalid name"))?
+                    .to_string(),
+                program,
+            );
             prog = prog_ptr.as_ptr();
         }
 


### PR DESCRIPTION
The fact that we are interfacing with C APIs and working with NUL terminated strings is more or less an implementation detail. OsStr is at least somewhat easier to use compared to CStr and so it is both more ergonomic and more flexible to expose it in public APIs. Switch everything over.