### PR TITLE
Remove 'name' and 'section' member of Program

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,9 +2,9 @@ Unreleased
 ----------
 - Added `AsRawLibbpf` impl for `OpenObject`
 - Adjusted various APIs to return/use `OsStr` instead of `CStr`
-- Adjusted `OpenProgram` to lazily retrieve section
-  - Changed `OpenProgram::section` to return `&OsStr` and `OpenProgram::new` to
-    be infallible
+- Adjusted `{Open,}Program` to lazily retrieve name and section
+  - Changed `name` and `section` methods to return `&OsStr` and made
+    constructors infallible
 - Removed `Display` implementation of various `enum` types
 
 

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::ptr;
 use std::ptr::NonNull;
 
+use crate::error::IntoError as _;
 use crate::set_print;
 use crate::util;
 use crate::Btf;
@@ -408,10 +409,17 @@ impl Object {
                 }
             };
 
-            let program = unsafe { Program::new(prog_ptr) }?;
+            let program = unsafe { Program::new(prog_ptr) };
 
             // Add the program to the hashmap
-            obj.progs.insert(program.name().into(), program);
+            obj.progs.insert(
+                program
+                    .name()
+                    .to_str()
+                    .ok_or_invalid_data(|| "program has invalid name")?
+                    .to_string(),
+                program,
+            );
             prog = prog_ptr.as_ptr();
         }
 


### PR DESCRIPTION
Remove the 'name' and 'section' members of the Program type, replacing them with methods that directly inquire the data in a lossless fashion.