### PR TITLE
Make MapHandle::name an OsString

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased
 ----------
 - Added `AsRawLibbpf` impl for `OpenObject`
-- Adjusted various APIs to return/use `OsStr` instead of `CStr`
+- Adjusted various APIs to return/use `OsStr` instead of `CStr` or `str`
 - Adjusted `{Open,}Program` to lazily retrieve name and section
   - Changed `name` and `section` methods to return `&OsStr` and made
     constructors infallible

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -390,7 +390,14 @@ impl Object {
 
             if unsafe { libbpf_sys::bpf_map__autocreate(map_ptr.as_ptr()) } {
                 let map_obj = unsafe { Map::new(map_ptr) }?;
-                obj.maps.insert(map_obj.name().into(), map_obj);
+                obj.maps.insert(
+                    map_obj
+                        .name()
+                        .to_str()
+                        .ok_or_invalid_data(|| "map has invalid name")?
+                        .to_string(),
+                    map_obj,
+                );
             }
 
             map = map_ptr.as_ptr();

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -187,7 +187,7 @@ fn test_object_maps_iter() {
 
     let obj = get_test_object("runqslower.bpf.o");
     for map in obj.maps_iter() {
-        eprintln!("{}", map.name());
+        eprintln!("{:?}", map.name());
     }
     // This will include .rodata and .bss, so our expected count is 4, not 2
     assert!(obj.maps_iter().count() == 4);


### PR DESCRIPTION
The constraint that a MapHandle's name is a String is overly strong: we have decided earlier that OpenMap, for example, works with OsStr. Switch MapHandle's name to an OsString to mirror this contract.