### PR TITLE
Adjust OpenMap::set_inner_map_fd() to return Result

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 - Adjusted `{Open,}Program` to lazily retrieve name and section
   - Changed `name` and `section` methods to return `&OsStr` and made
     constructors infallible
+- Adjusted `OpenMap::set_inner_map_fd` to return `Result`
 - Removed `Display` implementation of various `enum` types
 
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -147,10 +147,11 @@ impl OpenMap {
         util::parse_ret(ret)
     }
 
-    pub fn set_inner_map_fd(&mut self, inner: &Map) {
-        unsafe {
+    pub fn set_inner_map_fd(&mut self, inner: &Map) -> Result<()> {
+        let ret = unsafe {
             libbpf_sys::bpf_map__set_inner_map_fd(self.ptr.as_ptr(), inner.as_fd().as_raw_fd())
         };
+        util::parse_ret(ret)
     }
 
     pub fn set_map_extra(&mut self, map_extra: u64) -> Result<()> {


### PR DESCRIPTION
It appears as if the setting of the inner map file descriptor is a fallible operation. Make sure to check and convey the result.