### PR TITLE
Introduce MapCore trait

### DIFF
--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::MapCore as _;
 use libbpf_rs::MapFlags;
 use libbpf_rs::TcHookBuilder;
 use libbpf_rs::TC_CUSTOM;

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added `AsRawLibbpf` impl for `OpenObject`
+- Decoupled `Map` and `MapHandle` more and introduced `MapCore` trait
+  abstracting over common functionality
 - Adjusted various APIs to return/use `OsStr` instead of `CStr` or `str`
 - Adjusted `{Open,}Program` to lazily retrieve name and section
   - Changed `name` and `section` methods to return `&OsStr` and made

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -66,7 +66,7 @@
 //!
 //! [See example here](https://github.com/libbpf/libbpf-rs/tree/master/examples/runqslower).
 
-#![allow(clippy::let_unit_value)]
+#![allow(clippy::let_and_return, clippy::let_unit_value)]
 #![warn(
     elided_lifetimes_in_paths,
     missing_debug_implementations,
@@ -109,6 +109,7 @@ pub use crate::iter::Iter;
 pub use crate::link::Link;
 pub use crate::linker::Linker;
 pub use crate::map::Map;
+pub use crate::map::MapCore;
 pub use crate::map::MapFlags;
 pub use crate::map::MapHandle;
 pub use crate::map::MapInfo;

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -13,6 +13,7 @@ use crate::util;
 use crate::Btf;
 use crate::Error;
 use crate::Map;
+use crate::MapCore as _;
 use crate::OpenMap;
 use crate::OpenProgram;
 use crate::PrintLevel;
@@ -389,7 +390,7 @@ impl Object {
             };
 
             if unsafe { libbpf_sys::bpf_map__autocreate(map_ptr.as_ptr()) } {
-                let map_obj = unsafe { Map::new(map_ptr) }?;
+                let map_obj = unsafe { Map::new(map_ptr) };
                 obj.maps.insert(
                     map_obj
                         .name()

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -13,6 +13,7 @@ use crate::util;
 use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Map;
+use crate::MapCore as _;
 use crate::MapType;
 use crate::Result;
 

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -4,7 +4,6 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::ops::Deref as _;
 use std::os::raw::c_ulong;
-use std::os::unix::io::AsFd;
 use std::os::unix::prelude::AsRawFd;
 use std::os::unix::prelude::BorrowedFd;
 use std::ptr::null_mut;
@@ -15,7 +14,7 @@ use std::time::Duration;
 use crate::util;
 use crate::AsRawLibbpf;
 use crate::Error;
-use crate::MapHandle;
+use crate::MapCore;
 use crate::MapType;
 use crate::Result;
 
@@ -69,7 +68,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
     ///
     /// The callback provides a raw byte slice. You may find libraries such as
     /// [`plain`](https://crates.io/crates/plain) helpful.
-    pub fn add<NewF>(&mut self, map: &'slf MapHandle, callback: NewF) -> Result<&mut Self>
+    pub fn add<NewF>(&mut self, map: &'slf dyn MapCore, callback: NewF) -> Result<&mut Self>
     where
         NewF: FnMut(&[u8]) -> i32 + 'cb,
     {

--- a/libbpf-rs/src/user_ringbuf.rs
+++ b/libbpf-rs/src/user_ringbuf.rs
@@ -3,7 +3,6 @@ use libc::ENOSPC;
 use std::io;
 use std::ops::Deref;
 use std::ops::DerefMut;
-use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
 use std::os::raw::c_uint;
 use std::os::raw::c_void;
@@ -14,7 +13,7 @@ use std::slice::from_raw_parts_mut;
 
 use crate::AsRawLibbpf;
 use crate::Error;
-use crate::MapHandle;
+use crate::MapCore;
 use crate::MapType;
 use crate::Result;
 
@@ -80,7 +79,7 @@ impl UserRingBuffer {
     /// # Errors
     /// * If the map is not a user ring buffer.
     /// * If the underlying libbpf function fails.
-    pub fn new(map: &MapHandle) -> Result<Self> {
+    pub fn new(map: &dyn MapCore) -> Result<Self> {
         if map.map_type() != MapType::UserRingBuf {
             return Err(Error::with_invalid_data("must use a UserRingBuf map"));
         }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -24,6 +24,7 @@ use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::Iter;
 use libbpf_rs::Linker;
 use libbpf_rs::Map;
+use libbpf_rs::MapCore;
 use libbpf_rs::MapFlags;
 use libbpf_rs::MapHandle;
 use libbpf_rs::MapInfo;
@@ -1558,13 +1559,13 @@ fn test_object_map_handle_clone() {
 
     let obj = get_test_object("runqslower.bpf.o");
     let map = obj.map("events").expect("failed to find map");
-    let handle1 = MapHandle::try_clone(map).expect("Failed to create handle from Map");
+    let handle1 = MapHandle::try_from(map).expect("Failed to create handle from Map");
     assert_eq!(map.name(), handle1.name());
     assert_eq!(map.map_type(), handle1.map_type());
     assert_eq!(map.key_size(), handle1.key_size());
     assert_eq!(map.value_size(), handle1.value_size());
 
-    let handle2 = MapHandle::try_clone(&handle1).expect("Failed to duplicate existing handle");
+    let handle2 = MapHandle::try_from(&handle1).expect("Failed to duplicate existing handle");
     assert_eq!(handle1.name(), handle2.name());
     assert_eq!(handle1.map_type(), handle2.map_type());
     assert_eq!(handle1.key_size(), handle2.key_size());


### PR DESCRIPTION
This change reworks our BPF map abstractions somewhat. Specifically, we remove the MapHandle part from a Map. These two are more or less separate concepts and having one Deref into the other, while perhaps convenient, is somewhat confusing. Perhaps more importantly, it leads to a bunch of shenanigans, such as:
- Map creation being a fallible operation, despite a properly created bpf_map being provided already
- Map objects effectively carrying heaps of duplicated information: the file descriptor, map type, key size and value size are all already contained in the additionally stored bpf_map object
- the existence of the conceptually unnecessary MapFd enum
- the arbitrary difference in implementation between OpenMap (only bpf_map pointer) and Map (bpf_map pointer + handle) versus OpenProgram (only bpf_program pointer) and Program (only bpf_program pointer)

As a result of this decoupling, we make the Map::new constructor infallible. To keep existing ergonomics, we unite common map related functionality in the newly introduced MapCore trait.