### PR TITLE
Let rustfmt take care of wrapping comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,5 @@
+blank_lines_upper_bound = 2
 imports_granularity = "item"
+trailing_semicolon = false
+wrap_comments = true
+comment_width = 100

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -37,8 +37,8 @@
 //!
 //! * source file names must be in the `<NAME>.bpf.c` format
 //! * object file names will be generated in `<NAME>.bpf.o` format
-//! * there may not be any two identical `<NAME>.bpf.c` file names in any two projects in a
-//!   cargo workspace
+//! * there may not be any two identical `<NAME>.bpf.c` file names in any two projects in a cargo
+//!   workspace
 //!
 //! ## gen
 //!

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -458,7 +458,6 @@ pub struct BtfType<'btf> {
     ///      type_: u32,
     ///  }
     ///  ```
-    ///
     ty: &'btf libbpf_sys::btf_type,
 }
 

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -16,8 +16,8 @@
 //! 2. Create directory `$PROJ_PATH/src/bpf`
 //! 3. Write CO-RE bpf code in `$PROJ_PATH/src/bpf/${MYFILE}.bpf.c`, where `$MYFILE` may be any
 //!    valid filename. Note the `.bpf.c` extension is required.
-//! 4. Create a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
-//!    that builds and generates a skeleton module using `libbpf_cargo::SkeletonBuilder`
+//! 4. Create a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) that
+//!    builds and generates a skeleton module using `libbpf_cargo::SkeletonBuilder`
 //! 5. Write your userspace code by importing and using the generated module. Import the
 //!    module by using the [path
 //!    attribute](https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute).

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -229,8 +229,9 @@ where
     Ok(ncpu * aligned_val_size)
 }
 
-/// Apply a key check and return a null pointer in case of dealing with queue/stack/bloom-filter map,
-/// before passing the key to the bpf functions that support the map of type queue/stack/bloom-filter.
+/// Apply a key check and return a null pointer in case of dealing with queue/stack/bloom-filter
+/// map, before passing the key to the bpf functions that support the map of type
+/// queue/stack/bloom-filter.
 fn map_key<M>(map: &M, key: &[u8]) -> *const c_void
 where
     M: MapCore + ?Sized,

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -213,7 +213,6 @@ impl OpenProgram {
     /// Note: Keep in mind, libbpf can modify the program's instructions
     /// and consequently its instruction count, as it processes the BPF object file.
     /// So [`OpenProgram::insn_cnt`] and [`Program::insn_cnt`] may return different values.
-    ///
     pub fn insn_cnt(&self) -> usize {
         unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr.as_ptr()) as usize }
     }
@@ -1067,7 +1066,6 @@ impl Program {
     /// Gives read-only access to BPF program's underlying BPF instructions.
     ///
     /// Please see note in [`OpenProgram::insns`].
-    ///
     pub fn insns(&self) -> &[libbpf_sys::bpf_insn] {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -339,7 +339,8 @@ impl Drop for ObjectSkeletonConfig<'_> {
 
 /// A trait for skeleton builder.
 pub trait SkelBuilder<'a> {
-    /// Define that when BPF object is opened, the returned type should implement the [`OpenSkel`] trait
+    /// Define that when BPF object is opened, the returned type should implement the [`OpenSkel`]
+    /// trait
     type Output: OpenSkel;
 
     /// Open eBPF object and return [`OpenSkel`]

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -83,12 +83,12 @@ pub fn create_bpf_entity_checked<B: 'static, F: FnOnce() -> *mut B>(f: F) -> Res
                 io::ErrorKind::Other,
                 format!(
                     "bpf call {:?} returned NULL",
-                    type_name::<F>() // this is usually a library bug, hopefully this will
-                                     // help diagnose the bug.
-                                     //
-                                     // One way to fix the bug might be to change to calling
-                                     // create_bpf_entity_checked_opt and handling Ok(None)
-                                     // as a meaningful value.
+                    type_name::<F>() /* this is usually a library bug, hopefully this will
+                                      * help diagnose the bug.
+                                      *
+                                      * One way to fix the bug might be to change to calling
+                                      * create_bpf_entity_checked_opt and handling Ok(None)
+                                      * as a meaningful value. */
                 ),
             )
         })


### PR DESCRIPTION
It turns out `rustfmt` can ensure a consistent comment length by applying automatic wrapping. Let's enable the functionality to get some more consistency into the code base and ensure that pull requests adhere to a basic standard in the process.
Also set a two other options that don't exactly change anything at this point but are nice to have and give us more flexibility in the future.