### PR TITLE
Rename 'a lifetime

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -879,14 +879,14 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
             }}
         }}
 
-        impl<'a> SkelBuilder<'a> for {name}SkelBuilder {{
-            type Output = Open{name}Skel<'a>;
-            fn open(self) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
+        impl<'dat> SkelBuilder<'dat> for {name}SkelBuilder {{
+            type Output = Open{name}Skel<'dat>;
+            fn open(self) -> libbpf_rs::Result<Open{name}Skel<'dat>> {{
                 let opts = *self.obj_builder.opts();
                 self.open_opts(opts)
             }}
 
-            fn open_opts(self, open_opts: libbpf_sys::bpf_object_open_opts) -> libbpf_rs::Result<Open{name}Skel<'a>> {{
+            fn open_opts(self, open_opts: libbpf_sys::bpf_object_open_opts) -> libbpf_rs::Result<Open{name}Skel<'dat>> {{
                 let mut skel_config = build_skel_config()?;
 
                 let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), &open_opts) }};
@@ -947,17 +947,17 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     write!(
         skel,
         r#"
-        pub struct Open{name}Skel<'a> {{
+        pub struct Open{name}Skel<'dat> {{
             pub obj: libbpf_rs::OpenObject,
             progs: std::collections::HashMap<std::string::String, libbpf_rs::OpenProgram>,
             maps: std::collections::HashMap<std::string::String, libbpf_rs::OpenMap>,
             pub struct_ops: {raw_obj_name}_types::struct_ops,
-            skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'a>,
+            skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'dat>,
         }}
 
-        impl<'a> OpenSkel for Open{name}Skel<'a> {{
-            type Output = {name}Skel<'a>;
-            fn load(mut self) -> libbpf_rs::Result<{name}Skel<'a>> {{
+        impl<'dat> OpenSkel for Open{name}Skel<'dat> {{
+            type Output = {name}Skel<'dat>;
+            fn load(mut self) -> libbpf_rs::Result<{name}Skel<'dat>> {{
                 let ret = unsafe {{ libbpf_sys::bpf_object__load_skeleton(self.skel_config.get()) }};
                 if ret != 0 {{
                     return Err(libbpf_rs::Error::from_raw_os_error(-ret));
@@ -1019,12 +1019,12 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     write!(
         skel,
         r#"
-        pub struct {name}Skel<'a> {{
+        pub struct {name}Skel<'dat> {{
             pub obj: libbpf_rs::Object,
             progs: std::collections::HashMap<std::string::String, libbpf_rs::Program>,
             maps: std::collections::HashMap<std::string::String, libbpf_rs::Map>,
             struct_ops: {raw_obj_name}_types::struct_ops,
-            skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'a>,
+            skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'dat>,
         "#,
         name = &obj_name,
     )?;

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -41,8 +41,8 @@ struct ProgSkelConfig {
 
 #[allow(missing_docs)]
 #[derive(Debug)]
-pub struct ObjectSkeletonConfigBuilder<'a> {
-    data: &'a [u8],
+pub struct ObjectSkeletonConfigBuilder<'dat> {
+    data: &'dat [u8],
     p: Box<*mut bpf_object>,
     name: Option<String>,
     maps: Vec<MapSkelConfig>,
@@ -57,14 +57,14 @@ fn str_to_cstring_and_pool(s: &str, pool: &mut Vec<CString>) -> Result<*const c_
     Ok(p)
 }
 
-impl<'a> ObjectSkeletonConfigBuilder<'a> {
+impl<'dat> ObjectSkeletonConfigBuilder<'dat> {
     /// Construct a new instance
     ///
     /// `object_data` is the contents of the `.o` from clang
     ///
     /// `p` is a reference to the pointer where `libbpf_sys::bpf_object` should be
     /// stored/retrieved
-    pub fn new(object_data: &'a [u8]) -> Self {
+    pub fn new(object_data: &'dat [u8]) -> Self {
         Self {
             data: object_data,
             p: Box::new(ptr::null_mut()),
@@ -178,7 +178,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
     }
 
     #[allow(missing_docs)]
-    pub fn build(mut self) -> Result<ObjectSkeletonConfig<'a>> {
+    pub fn build(mut self) -> Result<ObjectSkeletonConfig<'dat>> {
         // Holds `CString`s alive so pointers to them stay valid
         let mut string_pool = Vec::new();
 
@@ -221,7 +221,7 @@ impl<'a> ObjectSkeletonConfigBuilder<'a> {
 ///
 /// This struct can be moved around at will. Upon drop, all allocated resources will be freed
 #[derive(Debug)]
-pub struct ObjectSkeletonConfig<'a> {
+pub struct ObjectSkeletonConfig<'dat> {
     inner: bpf_object_skeleton,
     maps: Vec<MapSkelConfig>,
     progs: Vec<ProgSkelConfig>,
@@ -230,7 +230,7 @@ pub struct ObjectSkeletonConfig<'a> {
     /// Same as above
     progs_layout: Option<Layout>,
     /// Hold this reference so that compiler guarantees buffer lives as long as us
-    _data: &'a [u8],
+    _data: &'dat [u8],
     /// Hold strings alive so pointers to them stay valid
     _string_pool: Vec<CString>,
 }
@@ -338,7 +338,7 @@ impl Drop for ObjectSkeletonConfig<'_> {
 }
 
 /// A trait for skeleton builder.
-pub trait SkelBuilder<'a> {
+pub trait SkelBuilder<'dat> {
     /// Define that when BPF object is opened, the returned type should implement the [`OpenSkel`]
     /// trait
     type Output: OpenSkel;


### PR DESCRIPTION
Rename the 'a lifetime used extensively in the skeleton logic to something at least a tad more meaningful.