### PR TITLE
Simplify ObjectSkeletonConfig pointer accessor methods

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -644,7 +644,7 @@ fn gen_skel_datasec_getters(
                 skel,
                 r#"
                 pub fn {name}{fn_suffix}_raw(&{ref_suffix} self) -> *{ptr_suffix} {struct_name} {{
-                    self.skel_config.map_mmap_ptr{fn_suffix}({idx}).unwrap().cast::<{struct_name}>()
+                    self.skel_config.map_mmap_ptr({idx}).unwrap().cast::<{struct_name}>()
                 }}
 
                 pub fn {name}{fn_suffix}(&{ref_suffix} self) -> &{ref_suffix} {struct_name} {{

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -264,7 +264,7 @@ impl ObjectSkeletonConfig<'_> {
     /// `ObjectSkeletonConfigBuilder::map`. Index starts at 0.
     ///
     /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
-    pub fn map_mmap_ptr(&self, index: usize) -> Result<*const c_void> {
+    pub fn map_mmap_ptr(&self, index: usize) -> Result<*mut c_void> {
         if index >= self.maps.len() {
             return Err(Error::with_invalid_data(format!(
                 "Invalid map index: {index}"
@@ -278,23 +278,13 @@ impl ObjectSkeletonConfig<'_> {
         Ok(**p)
     }
 
-    /// Returns the `mmaped` pointer for a map at the specified `index`.
-    ///
-    /// The index is determined by the order in which the map was passed to
-    /// `ObjectSkeletonConfigBuilder::map`. Index starts at 0.
-    ///
-    /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
-    pub fn map_mmap_ptr_mut(&mut self, index: usize) -> Result<*mut c_void> {
-        self.map_mmap_ptr(index).map(|p| p.cast_mut())
-    }
-
     /// Returns the link pointer for a prog at the specified `index`.
     ///
     /// The index is determined by the order in which the prog was passed to
     /// `ObjectSkeletonConfigBuilder::prog`. Index starts at 0.
     ///
     /// Warning: the returned pointer is only valid while the `ObjectSkeletonConfig` is alive.
-    pub fn prog_link_ptr(&mut self, index: usize) -> Result<*mut bpf_link> {
+    pub fn prog_link_ptr(&self, index: usize) -> Result<*mut bpf_link> {
         if index >= self.progs.len() {
             return Err(Error::with_invalid_data(format!(
                 "Invalid prog index: {index}"


### PR DESCRIPTION
There isn't really a point in having a method that does nothing more than return a pointer require a mutable receiver -- ultimately it is up to the caller what is being done with the pointer anyway, and casting pointer mutability is a trivial (and safe) operation. Hence, adjust ObjectSkeletonConfig::prog_link_ptr() to work on a shared receiver and remove ObjectSkeletonConfig::map_mmap_ptr_mut() in favor of map_mmap_ptr(), which now returns a mutable pointer.