### PR TITLE
Implement AsRawLibbpf for ObjectBuilder

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -882,8 +882,9 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
         impl<'dat> SkelBuilder<'dat> for {name}SkelBuilder {{
             type Output = Open{name}Skel<'dat>;
             fn open(self) -> libbpf_rs::Result<Open{name}Skel<'dat>> {{
-                let opts = *self.obj_builder.opts();
-                self.open_opts(opts)
+                let opts =
+                    unsafe {{ libbpf_rs::AsRawLibbpf::as_libbpf_object(&self.obj_builder).as_ref() }};
+                self.open_opts(*opts)
             }}
 
             fn open_opts(self, open_opts: libbpf_sys::bpf_object_open_opts) -> libbpf_rs::Result<Open{name}Skel<'dat>> {{

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ----------
-- Added `AsRawLibbpf` impl for `OpenObject`
+- Added `AsRawLibbpf` impl for `OpenObject` and `ObjectBuilder`
 - Decoupled `Map` and `MapHandle` more and introduced `MapCore` trait
   abstracting over common functionality
 - Adjusted `{Open,}Object::from_ptr` constructor to be infallible


### PR DESCRIPTION
ObjectBuilder is really just a thin wrapper around libbpf's bpf_object_open_opts and bpf_object__open_file()/bpf_object__open_mem(). As such, it makes sense for us to make that a bit more obvious by implementing the AsRawLibbpf trait.