### PR TITLE
Implement AsRawLibbpf for ObjectSkeletonConfig

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -728,7 +728,8 @@ fn gen_skel_attach(skel: &mut String, object: &Object, obj_name: &str) -> Result
         skel,
         r#"
         fn attach(&mut self) -> libbpf_rs::Result<()> {{
-            let ret = unsafe {{ libbpf_sys::bpf_object__attach_skeleton(self.skel_config.get()) }};
+            let skel_ptr = libbpf_rs::AsRawLibbpf::as_libbpf_object(&self.skel_config).as_ptr();
+            let ret = unsafe {{ libbpf_sys::bpf_object__attach_skeleton(skel_ptr) }};
             if ret != 0 {{
                 return Err(libbpf_rs::Error::from_raw_os_error(-ret));
             }}
@@ -889,8 +890,9 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
 
             fn open_opts(self, open_opts: libbpf_sys::bpf_object_open_opts) -> libbpf_rs::Result<Open{name}Skel<'dat>> {{
                 let mut skel_config = build_skel_config()?;
+                let skel_ptr = libbpf_rs::AsRawLibbpf::as_libbpf_object(&skel_config).as_ptr();
 
-                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_config.get(), &open_opts) }};
+                let ret = unsafe {{ libbpf_sys::bpf_object__open_skeleton(skel_ptr, &open_opts) }};
                 if ret != 0 {{
                     return Err(libbpf_rs::Error::from_raw_os_error(-ret));
                 }}
@@ -958,8 +960,10 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
 
         impl<'dat> OpenSkel for Open{name}Skel<'dat> {{
             type Output = {name}Skel<'dat>;
-            fn load(mut self) -> libbpf_rs::Result<{name}Skel<'dat>> {{
-                let ret = unsafe {{ libbpf_sys::bpf_object__load_skeleton(self.skel_config.get()) }};
+            fn load(self) -> libbpf_rs::Result<{name}Skel<'dat>> {{
+                let skel_ptr = libbpf_rs::AsRawLibbpf::as_libbpf_object(&self.skel_config).as_ptr();
+
+                let ret = unsafe {{ libbpf_sys::bpf_object__load_skeleton(skel_ptr) }};
                 if ret != 0 {{
                     return Err(libbpf_rs::Error::from_raw_os_error(-ret));
                 }}

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -7,6 +7,7 @@ use std::mem::size_of;
 use std::os::raw::c_char;
 use std::os::raw::c_ulong;
 use std::ptr;
+use std::ptr::addr_of;
 use std::ptr::NonNull;
 
 use libbpf_sys::bpf_link;
@@ -19,6 +20,7 @@ use libbpf_sys::bpf_program;
 
 use crate::error::IntoError as _;
 use crate::util;
+use crate::AsRawLibbpf;
 use crate::Error;
 use crate::Object;
 use crate::ObjectBuilder;
@@ -236,11 +238,6 @@ pub struct ObjectSkeletonConfig<'dat> {
 }
 
 impl ObjectSkeletonConfig<'_> {
-    #[allow(missing_docs)]
-    pub fn get(&mut self) -> &mut bpf_object_skeleton {
-        &mut self.inner
-    }
-
     /// Warning: the returned pointer is only valid while the
     /// `ObjectSkeletonConfig` is alive.
     ///
@@ -292,6 +289,16 @@ impl ObjectSkeletonConfig<'_> {
         }
 
         Ok(*self.progs[index].link)
+    }
+}
+
+impl AsRawLibbpf for ObjectSkeletonConfig<'_> {
+    type LibbpfType = libbpf_sys::bpf_object_skeleton;
+
+    /// Retrieve the underlying [`libbpf_sys::bpf_object_skeleton`].
+    fn as_libbpf_object(&self) -> NonNull<Self::LibbpfType> {
+        // SAFETY: A reference is always a valid pointer.
+        unsafe { NonNull::new_unchecked(addr_of!(self.inner).cast_mut()) }
     }
 }
 


### PR DESCRIPTION
Add an implementation of the AsRawLibbpf trait for ObjectSkeletonConfig, which really is a fairly thin wrapper around libbpf's bpf_object_skeleton type.