### PR TITLE
Introduce a proper test utility module

### DIFF
--- a/libbpf-rs/tests/common/mod.rs
+++ b/libbpf-rs/tests/common/mod.rs
@@ -1,0 +1,46 @@
+use std::io;
+use std::path::PathBuf;
+
+use libbpf_rs::Object;
+use libbpf_rs::ObjectBuilder;
+use libbpf_rs::OpenObject;
+
+
+pub fn get_test_object_path(filename: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    // env!() macro fails at compile time if var not found
+    path.push(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/bin");
+    path.push(filename);
+    path
+}
+
+pub fn open_test_object(filename: &str) -> OpenObject {
+    let obj_path = get_test_object_path(filename);
+    let obj = ObjectBuilder::default()
+        .debug(true)
+        .open_file(obj_path)
+        .expect("failed to open object");
+    obj
+}
+
+pub fn bump_rlimit_mlock() {
+    let rlimit = libc::rlimit {
+        rlim_cur: 128 << 20,
+        rlim_max: 128 << 20,
+    };
+
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) };
+    assert_eq!(
+        ret,
+        0,
+        "Setting RLIMIT_MEMLOCK failed with errno: {}",
+        io::Error::last_os_error()
+    );
+}
+
+pub fn get_test_object(filename: &str) -> Object {
+    open_test_object(filename)
+        .load()
+        .expect("failed to load object")
+}

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,13 +1,11 @@
+mod common;
+
 use std::ffi::OsStr;
 use std::os::unix::io::AsFd as _;
 use std::os::unix::io::BorrowedFd;
 
 use serial_test::serial;
 use test_tag::tag;
-
-mod test;
-use test::bump_rlimit_mlock;
-use test::get_test_object;
 
 use libbpf_rs::ErrorKind;
 use libbpf_rs::Result;
@@ -20,8 +18,12 @@ use libbpf_rs::TC_H_MIN_EGRESS;
 use libbpf_rs::TC_H_MIN_INGRESS;
 use libbpf_rs::TC_INGRESS;
 
+use crate::common::bump_rlimit_mlock;
+use crate::common::get_test_object;
+
 // do all TC tests on the lo network interface
 const LO_IFINDEX: i32 = 1;
+
 
 fn clear_clsact(fd: BorrowedFd) -> Result<()> {
     // Ensure clean clsact tc qdisc

--- a/libbpf-rs/tests/test_xdp.rs
+++ b/libbpf-rs/tests/test_xdp.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::ffi::OsStr;
 use std::os::fd::AsFd;
 
@@ -5,14 +7,15 @@ use scopeguard::defer;
 
 use test_tag::tag;
 
-mod test;
-use test::bump_rlimit_mlock;
-use test::get_test_object;
-
 use libbpf_rs::Xdp;
 use libbpf_rs::XdpFlags;
 
+use crate::common::bump_rlimit_mlock;
+use crate::common::get_test_object;
+
+
 const LO_IFINDEX: i32 = 1;
+
 
 #[tag(root)]
 #[test]


### PR DESCRIPTION
Heaps of our tests run multiple times, because test_tc and test_xdp use the test module, and with that pull in the tests it defines. Introduce a proper module with common functionality to fix this.