### PR TITLE
Use get_*() helper functions in other test modules

### DIFF
--- a/libbpf-rs/tests/common/mod.rs
+++ b/libbpf-rs/tests/common/mod.rs
@@ -1,9 +1,12 @@
 use std::io;
 use std::path::PathBuf;
 
+use libbpf_rs::Map;
+use libbpf_rs::MapCore;
 use libbpf_rs::Object;
 use libbpf_rs::ObjectBuilder;
 use libbpf_rs::OpenObject;
+use libbpf_rs::Program;
 
 
 pub fn get_test_object_path(filename: &str) -> PathBuf {
@@ -43,4 +46,23 @@ pub fn get_test_object(filename: &str) -> Object {
     open_test_object(filename)
         .load()
         .expect("failed to load object")
+}
+
+
+/// Find the BPF map with the given name, panic if it does not exist.
+#[track_caller]
+pub fn get_map(object: &Object, name: &str) -> Map {
+    object
+        .maps()
+        .find(|map| map.name() == name)
+        .unwrap_or_else(|| panic!("failed to find map `{name}`"))
+}
+
+/// Find the BPF program with the given name, panic if it does not exist.
+#[track_caller]
+pub fn get_prog(object: &Object, name: &str) -> Program {
+    object
+        .progs()
+        .find(|map| map.name() == name)
+        .unwrap_or_else(|| panic!("failed to find program `{name}`"))
 }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -32,7 +32,6 @@ use libbpf_rs::MapFlags;
 use libbpf_rs::MapHandle;
 use libbpf_rs::MapInfo;
 use libbpf_rs::MapType;
-use libbpf_rs::Object;
 use libbpf_rs::ObjectBuilder;
 use libbpf_rs::Program;
 use libbpf_rs::ProgramInput;
@@ -48,28 +47,11 @@ use tempfile::NamedTempFile;
 use test_tag::tag;
 
 use crate::common::bump_rlimit_mlock;
+use crate::common::get_map;
+use crate::common::get_prog;
 use crate::common::get_test_object;
 use crate::common::get_test_object_path;
 use crate::common::open_test_object;
-
-
-/// Find the BPF map with the given name, panic if it does not exist.
-#[track_caller]
-fn get_map(object: &Object, name: &str) -> Map {
-    object
-        .maps()
-        .find(|map| map.name() == name)
-        .unwrap_or_else(|| panic!("failed to find map `{name}`"))
-}
-
-/// Find the BPF program with the given name, panic if it does not exist.
-#[track_caller]
-fn get_prog(object: &Object, name: &str) -> Program {
-    object
-        .progs()
-        .find(|map| map.name() == name)
-        .unwrap_or_else(|| panic!("failed to find program `{name}`"))
-}
 
 
 /// A helper function for instantiating a `RingBuffer` with a callback meant to

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,6 +1,6 @@
+#[allow(dead_code)]
 mod common;
 
-use std::ffi::OsStr;
 use std::os::unix::io::AsFd as _;
 use std::os::unix::io::BorrowedFd;
 
@@ -19,6 +19,7 @@ use libbpf_rs::TC_H_MIN_INGRESS;
 use libbpf_rs::TC_INGRESS;
 
 use crate::common::bump_rlimit_mlock;
+use crate::common::get_prog;
 use crate::common::get_test_object;
 
 // do all TC tests on the lo network interface
@@ -49,10 +50,7 @@ fn test_tc_basic_cycle() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -96,10 +94,7 @@ fn test_tc_attach_no_qdisc() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -126,10 +121,7 @@ fn test_tc_attach_basic() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -160,10 +152,7 @@ fn test_tc_attach_repeat() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -204,10 +193,7 @@ fn test_tc_attach_repeat() {
 fn test_tc_attach_custom() {
     bump_rlimit_mlock();
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -262,10 +248,7 @@ fn test_tc_attach_custom() {
 fn test_tc_detach_basic() {
     bump_rlimit_mlock();
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -314,10 +297,7 @@ fn test_tc_query() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);
@@ -391,10 +371,7 @@ fn test_tc_double_create() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("tc-unit.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("handle_tc"))
-        .unwrap();
+    let prog = get_prog(&obj, "handle_tc");
     let fd = prog.as_fd();
 
     let mut tc_builder = TcHookBuilder::new(fd);

--- a/libbpf-rs/tests/test_xdp.rs
+++ b/libbpf-rs/tests/test_xdp.rs
@@ -1,6 +1,6 @@
+#[allow(dead_code)]
 mod common;
 
-use std::ffi::OsStr;
 use std::os::fd::AsFd;
 
 use scopeguard::defer;
@@ -11,6 +11,7 @@ use libbpf_rs::Xdp;
 use libbpf_rs::XdpFlags;
 
 use crate::common::bump_rlimit_mlock;
+use crate::common::get_prog;
 use crate::common::get_test_object;
 
 
@@ -23,17 +24,11 @@ fn test_xdp() {
     bump_rlimit_mlock();
 
     let obj = get_test_object("xdp.bpf.o");
-    let prog = obj
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("xdp_filter"))
-        .unwrap();
+    let prog = get_prog(&obj, "xdp_filter");
     let fd = prog.as_fd();
 
     let obj1 = get_test_object("xdp.bpf.o");
-    let prog1 = obj1
-        .progs()
-        .find(|prog| prog.name() == OsStr::new("xdp_filter"))
-        .unwrap();
+    let prog1 = get_prog(&obj1, "xdp_filter");
     let fd1 = prog1.as_fd();
 
     let xdp_prog = Xdp::new(fd);


### PR DESCRIPTION
Now that we have a module for sharing test helper functionality, move the get_map() and get_prog() helper into it and use them from more places.