### PR TITLE
Mark `Tag`'s inner data as `pub`

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -120,7 +120,7 @@ impl From<&libbpf_sys::bpf_line_info> for LineInfo {
 /// Bpf identifier tag
 #[derive(Debug, Clone, Default)]
 #[repr(C)]
-pub struct Tag([u8; 8]);
+pub struct Tag(pub [u8; 8]);
 
 /// Information about a BPF program
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This data was previously accessible, but was maybe inadvertently made private when be857ed landed. This patch makes the data accessible again by marking `Tag`s inner field as `pub`.

Closes #842 