### PR TITLE
Add CHANGELOG entry for #843

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
   - Changed `name` and `section` methods to return `&OsStr` and made
     constructors infallible
 - Adjusted `OpenMap::set_inner_map_fd` to return `Result`
+- Made inner `query::Tag` contents publicly accessible
 - Removed `Display` implementation of various `enum` types
 
 


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #843, which made the inner contents of `query::Tag` publicly accessible.