### PR TITLE
Fix default vmlinux.h path

### DIFF
--- a/libbpf-rs/tests/bpf_object_regen.sh
+++ b/libbpf-rs/tests/bpf_object_regen.sh
@@ -49,7 +49,7 @@ function compile() {
 if [[ ! -z $BPFTOOL ]]; then
     bpftool btf dump file /sys/kernel/btf/vmlinux format c > bin/src/vmlinux.h
 else
-    cp ../../examples/vmlinux/x86/vmlinux_601.h bin/src/vmlinux.h
+    cp ../../vmlinux/include/x86/vmlinux_601.h bin/src/vmlinux.h
 fi
 
 for file in $SRC


### PR DESCRIPTION
It seems that the path to the x86 vmlinux.h file as specified in bpf_object_regen.sh is no longer accurate. Adjust it to match reality.