### PR TITLE
Adjust OpenObject::name() to return Option<&OsStr>

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
 - Adjusted `{Open,}Program` to lazily retrieve name and section
   - Changed `name` and `section` methods to return `&OsStr` and made
     constructors infallible
+- Adjusted `OpenObject::name` to return `Option<&OsStr>`
+- Added `Object::name` method
 - Adjusted `OpenMap::set_inner_map_fd` to return `Result`
 - Made inner `query::Tag` contents publicly accessible
 - Removed `Display` implementation of various `enum` types

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -32,6 +32,7 @@ use libbpf_rs::MapFlags;
 use libbpf_rs::MapHandle;
 use libbpf_rs::MapInfo;
 use libbpf_rs::MapType;
+use libbpf_rs::Object;
 use libbpf_rs::ObjectBuilder;
 use libbpf_rs::Program;
 use libbpf_rs::ProgramInput;
@@ -100,6 +101,10 @@ fn test_object_build_from_memory() {
         .expect("failed to build object");
     let name = obj.name().expect("failed to get object name");
     assert!(name == "memory name");
+
+    let obj = unsafe { Object::from_ptr(obj.take_ptr()) };
+    let name = obj.name().expect("failed to get object name");
+    assert!(name == "memory name");
 }
 
 #[test]
@@ -112,6 +117,10 @@ fn test_object_build_from_memory_empty_name() {
         .unwrap()
         .open_memory(&contents)
         .expect("failed to build object");
+    let name = obj.name().expect("failed to get object name");
+    assert!(name.is_empty());
+
+    let obj = unsafe { Object::from_ptr(obj.take_ptr()) };
     let name = obj.name().expect("failed to get object name");
     assert!(name.is_empty());
 }


### PR DESCRIPTION
Mirror what map and program APIs do and return an OsStr from OpenObject::name(). Also introduce Object::name() for consistency.