### PR TITLE
libbpf-cargo: Don't clear skeleton object pointer

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -897,8 +897,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
                     return Err(libbpf_rs::Error::from_raw_os_error(-ret));
                 }}
 
-                // We take full "ownership" of the object from the skeleton.
-                let obj_ptr = std::mem::replace(unsafe {{ &mut *skel_ptr.as_ref().obj }}, std::ptr::null_mut());
+                let obj_ptr = unsafe {{ *skel_ptr.as_ref().obj }};
                 // SANITY: `bpf_object__open_skeleton` should have
                 //         allocated the object.
                 let obj_ptr = std::ptr::NonNull::new(obj_ptr).unwrap();


### PR DESCRIPTION
As part of commit a8a4503d9cbb ("Remove
ObjectSkeletonConfig::object_ptr()") we started clearing the object pointer from the C skeleton object. That does not appear to work properly. Revert that part of the change.