### PR TITLE
Removed Result return type from OpenProgram setters

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -15,6 +15,8 @@ Unreleased
   - Changed `name` and `section` methods to return `&OsStr` and made
     constructors infallible
 - Adjusted `OpenObject::name` to return `Option<&OsStr>`
+- Removed `Result` return type from
+  `OpenProgram::{set_log_level,set_autoload,set_flags}`
 - Added `Object::name` method
 - Adjusted `OpenMap::set_inner_map_fd` to return `Result`
 - Made inner `query::Tag` contents publicly accessible

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -192,24 +192,19 @@ impl<'obj> OpenProgramMut<'obj> {
     }
 
     pub fn set_prog_type(&mut self, prog_type: ProgramType) {
-        unsafe {
-            libbpf_sys::bpf_program__set_type(self.ptr.as_ptr(), prog_type as u32);
-        }
+        let rc = unsafe { libbpf_sys::bpf_program__set_type(self.ptr.as_ptr(), prog_type as u32) };
+        debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
     pub fn set_attach_type(&mut self, attach_type: ProgramAttachType) {
-        unsafe {
-            libbpf_sys::bpf_program__set_expected_attach_type(
-                self.ptr.as_ptr(),
-                attach_type as u32,
-            );
-        }
+        let rc = unsafe {
+            libbpf_sys::bpf_program__set_expected_attach_type(self.ptr.as_ptr(), attach_type as u32)
+        };
+        debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
     pub fn set_ifindex(&mut self, idx: u32) {
-        unsafe {
-            libbpf_sys::bpf_program__set_ifindex(self.ptr.as_ptr(), idx);
-        }
+        unsafe { libbpf_sys::bpf_program__set_ifindex(self.ptr.as_ptr(), idx) }
     }
 
     /// Set the log level for the bpf program.
@@ -220,16 +215,16 @@ impl<'obj> OpenProgramMut<'obj> {
     ///
     /// In general, a value of `0` disables logging while values `> 0` enables
     /// it.
-    pub fn set_log_level(&mut self, log_level: u32) -> Result<()> {
-        let ret = unsafe { libbpf_sys::bpf_program__set_log_level(self.ptr.as_ptr(), log_level) };
-        util::parse_ret(ret)
+    pub fn set_log_level(&mut self, log_level: u32) {
+        let rc = unsafe { libbpf_sys::bpf_program__set_log_level(self.ptr.as_ptr(), log_level) };
+        debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
     /// Set whether a bpf program should be automatically loaded by default
     /// when the bpf object is loaded.
-    pub fn set_autoload(&mut self, autoload: bool) -> Result<()> {
-        let ret = unsafe { libbpf_sys::bpf_program__set_autoload(self.ptr.as_ptr(), autoload) };
-        util::parse_ret(ret)
+    pub fn set_autoload(&mut self, autoload: bool) {
+        let rc = unsafe { libbpf_sys::bpf_program__set_autoload(self.ptr.as_ptr(), autoload) };
+        debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
     pub fn set_attach_target(
@@ -259,9 +254,9 @@ impl<'obj> OpenProgramMut<'obj> {
         util::parse_ret(ret)
     }
 
-    pub fn set_flags(&mut self, flags: u32) -> Result<()> {
-        let ret = unsafe { libbpf_sys::bpf_program__set_flags(self.ptr.as_ptr(), flags) };
-        util::parse_ret(ret)
+    pub fn set_flags(&mut self, flags: u32) {
+        let rc = unsafe { libbpf_sys::bpf_program__set_flags(self.ptr.as_ptr(), flags) };
+        debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 }
 


### PR DESCRIPTION
A bunch of the setters on OpenProgram can fail only when the program is loaded already. We encode the fact that a program is loaded via the type system and any OpenProgram should never be loaded. As such, adjust the return types of these setters accordingly, making the methods infallible.