### PR TITLE
Adjust OpenSkel::load() to reuse earlier BPF object storage

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -206,8 +206,7 @@ fn main() -> Result<()> {
         .unique_type
         .write(opts.unique_type);
 
-    let mut object = MaybeUninit::uninit();
-    let mut skel = open_skel.load(&mut object)?;
+    let mut skel = open_skel.load()?;
     skel.attach()?;
 
     print_banner(opts.extra_fields);

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -101,8 +101,7 @@ fn main() -> Result<()> {
     open_skel.maps.rodata_data.targ_tgid = opts.tid;
 
     // Begin tracing
-    let mut object = MaybeUninit::uninit();
-    let mut skel = open_skel.load(&mut object)?;
+    let mut skel = open_skel.load()?;
     skel.attach()?;
     println!("Tracing run queue latency higher than {} us", opts.latency);
     println!("{:8} {:16} {:7} {:14}", "TIME", "COMM", "TID", "LAT(us)");

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -74,8 +74,7 @@ fn main() -> Result<()> {
     let builder = TcSkelBuilder::default();
     let mut open_object = MaybeUninit::uninit();
     let open = builder.open(&mut open_object)?;
-    let mut object = MaybeUninit::uninit();
-    let skel = open.load(&mut object)?;
+    let skel = open.load()?;
     let ifidx = if_nametoindex(opts.iface.as_str())? as i32;
 
     let mut tc_builder = TcHookBuilder::new(skel.progs.handle_tc.as_fd());

--- a/examples/tcp_ca/src/main.rs
+++ b/examples/tcp_ca/src/main.rs
@@ -151,8 +151,7 @@ fn test(name_to_register: Option<&OsStr>, name_to_use: &OsStr, verbose: bool) ->
     let ca_update = open_skel.struct_ops.ca_update_mut();
     ca_update.cong_control = ca_update_cong_control2;
 
-    let mut object = MaybeUninit::uninit();
-    let mut skel = open_skel.load(&mut object)?;
+    let mut skel = open_skel.load()?;
     let _link = skel.maps.ca_update.attach_struct_ops()?;
 
     println!(

--- a/examples/tcp_option/src/main.rs
+++ b/examples/tcp_option/src/main.rs
@@ -106,8 +106,7 @@ fn main() -> Result<()> {
     open.maps.rodata_data.targ_ip = u32::from_be_bytes(ip.octets()).to_be();
     open.maps.rodata_data.data_such_as_trace_id = opts.trace_id;
 
-    let mut object = MaybeUninit::uninit();
-    let mut skel = open.load(&mut object)?;
+    let mut skel = open.load()?;
 
     let cgroup_fd = OpenOptions::new()
         .read(true)

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -74,8 +74,7 @@ fn main() -> Result<()> {
     open_skel.maps.rodata_data.proxy_port = opts.proxy_port.to_be();
 
     // Load into kernel
-    let mut object = MaybeUninit::uninit();
-    let skel = open_skel.load(&mut object)?;
+    let skel = open_skel.load()?;
     // Set up and attach ingress TC hook
     let mut ingress = TcHookBuilder::new(skel.progs.tproxy.as_fd())
         .ifindex(opts.ifindex)

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -433,11 +433,10 @@ fn test_skeleton_empty_source() {
         fn main() {{
             let builder = ProgSkelBuilder::default();
             let mut open_object = MaybeUninit::uninit();
-            let mut object = MaybeUninit::uninit();
             let _skel = builder
                 .open(&mut open_object)
                 .expect("failed to open skel")
-                .load(&mut object)
+                .load()
                 .expect("failed to load skel");
         }}
         "#,
@@ -550,10 +549,7 @@ fn test_skeleton_basic() {
             let _open_map = &open_skel.maps.mymap;
             let _open_prog = &open_skel.progs.this_is_my_prog;
 
-            let mut object = MaybeUninit::uninit();
-            let mut skel = open_skel
-                .load(&mut object)
-                .expect("failed to load skel");
+            let mut skel = open_skel.load().expect("failed to load skel");
 
             // Check that we can grab handles to loaded maps/progs
             let _map = &skel.maps.mymap;
@@ -726,10 +722,7 @@ fn test_skeleton_datasec() {
             open_skel.maps.bss_custom_data.mycustombss = 12;
             assert_eq!(open_skel.maps.rodata_custom_1_data.mycustomrodata, 43);
 
-            let mut object = MaybeUninit::uninit();
-            let skel = open_skel
-                .load(&mut object)
-                .expect("failed to load skel");
+            let skel = open_skel.load().expect("failed to load skel");
 
             // We can always set bss vars
             skel.maps.bss_data.myglobal = 24;
@@ -860,10 +853,7 @@ fn test_skeleton_builder_basic() {
             let _open_map2 = &open_skel.maps.mymap2;
             let _open_prog = &open_skel.progs.this_is_my_prog;
 
-            let mut object = MaybeUninit::uninit();
-            let mut skel = open_skel
-                .load(&mut object)
-                .expect("failed to load skel");
+            let mut skel = open_skel.load().expect("failed to load skel");
 
             // Check that we can grab handles to loaded maps/progs
             let _map = &skel.maps.mymap;

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -5,8 +5,8 @@ Unreleased
 - Added `AsRawLibbpf` impl for `OpenObject` and `ObjectBuilder`
 - Decoupled `Map` and `MapHandle` more and introduced `MapCore` trait
   abstracting over common functionality
-- Adjusted `SkelBuilder::open` and `OpenSkel::load` methods to require mutable
-  reference to storage space for BPF object
+- Adjusted `SkelBuilder::open` method to require mutable reference to
+  storage space for BPF object
 - Adjusted `{Open,}Object::from_ptr` constructor to be infallible
 - Added `{Open,}Object::maps{_mut,}` and `{Open,}Object::progs{_mut,}`
   for BPF map and program iteration

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -212,6 +212,7 @@ impl AsRawLibbpf for ObjectBuilder {
 ///
 /// Use this object to access [`OpenMap`]s and [`OpenProgram`]s.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct OpenObject {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }
@@ -318,6 +319,7 @@ impl Drop for OpenObject {
 /// Note that this is an explanation of the motivation -- Rust's lifetime system should already be
 /// enforcing this invariant.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct Object {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -376,7 +376,7 @@ pub trait OpenSkel<'obj> {
     type Output: Skel<'obj>;
 
     /// Load BPF object and return [`Skel`].
-    fn load(self, object: &'obj mut MaybeUninit<Object>) -> Result<Self::Output>;
+    fn load(self) -> Result<Self::Output>;
 
     /// Get a reference to [`OpenObject`].
     fn open_object(&self) -> &OpenObject;


### PR DESCRIPTION
We strictly speaking only need storage for a single BPF object for use with a skeleton, but currently we pass in such space to both the SkelBuilder::open() and OpenSkel::load() methods. The main reason for this decision was that we didn't want to make the assumption that OpenObject and Object have the same size. However, we are already doing something similar for the {Open,}{Program,Map} types. As such, this change adjusts OpenSkel::load() to no longer require an object reference to be passed in and modifies the skeleton generation logic to just reuse the already provided storage space instead.