### PR TITLE
Adjust Btf Debug impl to start dumping at ID 1

### DIFF
--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -403,7 +403,7 @@ impl Debug for Btf<'_> {
             fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
                 f.debug_list()
                     .entries(
-                        (0..self.0.len())
+                        (1..self.0.len())
                             .map(|i| TypeId::from(i as u32))
                             // SANITY: A type with this ID should always exist
                             //         given that BTF IDs are fully populated up


### PR DESCRIPTION
The type ID 0 is defined to map to void. It doesn't really matter whether or not we include it in the Debug output for the Btf type, as it can be argued that it's always there anyway and that's "common knowledge" (haha...).
Be that as it may, it's confusing to see some iteration starting at ID 0 while most start with ID 1. Stick to what is more commonly done and start with ID 1, for uniformity.