### PR TITLE
libbpf-cargo: Generate Rust types for all BTF types

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -2,8 +2,8 @@ Unreleased
 ----------
 - Reworked generated skeletons to contain publicly accessible maps and
   program members, no longer requiring method calls
-- Adjusted skeleton creation logic to generate Rust types for types used in BPF
-  maps
+- Adjusted skeleton creation logic to generate Rust types for all types
+  available in BPF
 - Renamed module for generated Rust types from `<project>_types` to just `types`
 - Renamed generated `struct_ops` type to `StructOps` and moved it out of `types`
   module

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -802,12 +802,14 @@ impl<'s> GenBtf<'s> {
         dependent_types: &mut Vec<BtfType<'a>>,
         t: types::DataSec<'_>,
     ) -> Result<()> {
-        let mut sec_name = match t.name().map(|s| s.to_string_lossy()) {
+        let sec_name = match t.name().map(|s| s.to_string_lossy().into_owned()) {
             None => bail!("Datasec name is empty"),
-            Some(s) if !s.starts_with('.') => bail!("Datasec name is invalid: {s}"),
-            Some(s) => s.into_owned(),
+            Some(mut s) if s.starts_with('.') => {
+                s.remove(0);
+                s
+            }
+            Some(s) => s,
         };
-        sec_name.remove(0);
         let sec_name = sec_name.replace('.', "_");
 
         writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;


### PR DESCRIPTION
Adjust the skeleton code to just generate Rust types for types present in the BTF of the object file being used. There is no real reason to artificially restrict types, as the BTF itself is already heavily trimmed down by the generation infrastructure. Yet, making all types present in it available to Rust users can reduce friction in usage, as everything that is available in C will be available in Rust as well.

Closes: #603 