### PR TITLE
libbpf-cargo: Emit Rust types into 'types' module

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -27,7 +27,7 @@ mod capable {
     ));
 }
 
-use capable::capable_types::uniqueness;
+use capable::types::uniqueness;
 use capable::*;
 
 static CAPS: phf::Map<i32, &'static str> = phf_map! {
@@ -108,7 +108,7 @@ struct Command {
     debug: bool,
 }
 
-unsafe impl Plain for capable_types::event {}
+unsafe impl Plain for capable::types::event {}
 
 fn bump_memlock_rlimit() -> Result<()> {
     let rlimit = libc::rlimit {
@@ -138,7 +138,7 @@ fn print_banner(extra_fields: bool) {
     }
 }
 
-fn _handle_event(opts: Command, event: capable_types::event) {
+fn _handle_event(opts: Command, event: capable::types::event) {
     let now = if let Ok(now) = OffsetDateTime::now_local() {
         let format = format_description!("[hour]:[minute]:[second]");
         now.format(&format)
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
 
     print_banner(opts.extra_fields);
     let handle_event = move |_cpu: i32, data: &[u8]| {
-        let mut event = capable_types::event::default();
+        let mut event = capable::types::event::default();
         plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
         _handle_event(opts, event);
     };

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -41,7 +41,7 @@ struct Command {
     verbose: bool,
 }
 
-unsafe impl Plain for runqslower_types::event {}
+unsafe impl Plain for runqslower::types::event {}
 
 fn bump_memlock_rlimit() -> Result<()> {
     let rlimit = libc::rlimit {
@@ -57,7 +57,7 @@ fn bump_memlock_rlimit() -> Result<()> {
 }
 
 fn handle_event(_cpu: i32, data: &[u8]) {
-    let mut event = runqslower_types::event::default();
+    let mut event = runqslower::types::event::default();
     plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
 
     let now = if let Ok(now) = OffsetDateTime::now_local() {

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   program members, no longer requiring method calls
 - Adjusted skeleton creation logic to generate Rust types for types used in BPF
   maps
+- Renamed module for generated Rust types from `<project>_types` to just `types`
 
 
 0.23.3

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -395,7 +395,7 @@ fn gen_skel_open_map_defs(skel: &mut String, maps: &MapsData, raw_obj_name: &str
             write!(
                 skel,
                 "\
-                    pub {name}_data: &'obj mut {raw_obj_name}_types::{name},
+                    pub {name}_data: &'obj mut types::{name},
                 ",
                 name = map.name,
             )?;
@@ -481,7 +481,7 @@ fn gen_skel_open_map_defs(skel: &mut String, maps: &MapsData, raw_obj_name: &str
                                     .map_mmap_ptr({mmap_idx})
                                     .ok()
                                     .unwrap_or_else(std::ptr::null_mut)
-                                    .cast::<{raw_obj_name}_types::{name}>()
+                                    .cast::<types::{name}>()
                                     .as_mut()
                                     .expect(\"BPF map `{name}` does not have mmap pointer\")
                             }},
@@ -528,7 +528,7 @@ fn gen_skel_map_defs(skel: &mut String, maps: &MapsData, raw_obj_name: &str) -> 
             write!(
                 skel,
                 "\
-                        pub {name}_data: &'obj{ref_mut} {raw_obj_name}_types::{name},
+                        pub {name}_data: &'obj{ref_mut} types::{name},
                 ",
                 name = map.name,
             )?;
@@ -815,7 +815,7 @@ fn gen_skel_map_types(
     Ok(())
 }
 
-fn gen_skel_struct_ops_getters(skel: &mut String, object: &Object, obj_name: &str) -> Result<()> {
+fn gen_skel_struct_ops_getters(skel: &mut String, object: &Object) -> Result<()> {
     if maps(object).next().is_none() {
         return Ok(());
     }
@@ -823,11 +823,11 @@ fn gen_skel_struct_ops_getters(skel: &mut String, object: &Object, obj_name: &st
     write!(
         skel,
         "\
-        pub fn struct_ops_raw(&self) -> *const {obj_name}_types::struct_ops {{
+        pub fn struct_ops_raw(&self) -> *const types::struct_ops {{
             &self.struct_ops
         }}
 
-        pub fn struct_ops(&self) -> &{obj_name}_types::struct_ops {{
+        pub fn struct_ops(&self) -> &types::struct_ops {{
             &self.struct_ops
         }}
         ",
@@ -1079,7 +1079,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     write!(
         skel,
         "\
-            pub mod {raw_obj_name}_types {{
+            pub mod types {{
                 #[allow(unused_imports)]
                 use super::*;
         "
@@ -1100,7 +1100,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
             pub obj: &'obj mut libbpf_rs::OpenObject,
             pub maps: Open{name}Maps<'obj>,
             pub progs: Open{name}Progs<'obj>,
-            pub struct_ops: {raw_obj_name}_types::struct_ops,
+            pub struct_ops: types::struct_ops,
             skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'obj>,
         }}
 
@@ -1167,7 +1167,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
             pub obj: &'obj mut libbpf_rs::Object,
             pub maps: {name}Maps<'obj>,
             pub progs: {name}Progs<'obj>,
-            struct_ops: {raw_obj_name}_types::struct_ops,
+            struct_ops: types::struct_ops,
             skel_config: libbpf_rs::__internal_skel::ObjectSkeletonConfig<'obj>,
         ",
         name = &obj_name,
@@ -1196,7 +1196,7 @@ fn gen_skel_contents(_debug: bool, raw_obj_name: &str, obj_file_path: &Path) -> 
     writeln!(skel, "}}")?;
 
     write!(skel, "impl {name}Skel<'_> {{", name = &obj_name)?;
-    gen_skel_struct_ops_getters(&mut skel, &object, raw_obj_name)?;
+    gen_skel_struct_ops_getters(&mut skel, &object)?;
     writeln!(skel, "}}")?;
 
     // Coerce to &[u8] just to be safe, as we'll be using debug formatting

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -731,7 +731,7 @@ fn test_skeleton_datasec() {
             assert_eq!(skel.maps.rodata_custom_1_data.mycustomrodata, 43);
 
             // Read only for rodata after load
-            let _rodata: &prog_types::rodata = skel.maps.rodata_data;
+            let _rodata: &types::rodata = skel.maps.rodata_data;
         }}
         "#,
     )
@@ -866,7 +866,7 @@ fn test_skeleton_builder_basic() {
             // Check that Option<Link> field is generated
             let _mylink = skel.links.this_is_my_prog.unwrap();
 
-            let _key = prog_types::unique_key::default();
+            let _key = types::unique_key::default();
         }}
         "#,
         skel_path = skel.path().display(),
@@ -1250,7 +1250,7 @@ struct Foo foo;
                 .expect("failed to open skel");
 
             let _skel = open_skel.load().expect("failed to load skel");
-            let _key = prog_types::unique_key::default();
+            let _key = types::unique_key::default();
         }}
         "#,
         skel_path = skel.path().display(),


### PR DESCRIPTION
Instead of calling the module into which Rust types are emitted '<skeleton>_types' just call it 'types'. There isn't really a good reason for the former naming from what I can tell. Client code will always be able to prevent naming conflicts, because it is free to include the generated skeleton inside its own module. In fact, that's what all our examples do:

  > mod capable {
  >     include!(concat!(
  >         env!("CARGO_MANIFEST_DIR"),
  >         "/src/bpf/capable.skel.rs"
  >     ));
  > }
  > use capable::capable_types::uniqueness;

In the above snippet, the usage of capable::capable_types is a needless repetition.