### PR TITLE
libbpf-cargo: Introduce GenStructOps helper type

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -44,6 +44,7 @@ use crate::metadata;
 use crate::metadata::UnprocessedObj;
 
 use self::btf::GenBtf;
+use self::btf::GenStructOps;
 
 /// Escape certain characters in a "raw" name of a section, for example.
 fn escape_raw_name(name: &str) -> String {
@@ -735,8 +736,9 @@ fn gen_skel_struct_ops_types(
     processed: &mut HashSet<TypeId>,
 ) -> Result<()> {
     if let Some(btf) = btf {
-        let def = btf.struct_ops_type_definition(processed)?;
-        write!(skel, "{def}")?;
+        let gen = GenStructOps::new(btf)?;
+        let () = gen.gen_struct_ops_def(skel)?;
+        let () = gen.gen_dependent_types(processed, skel)?;
     } else {
         write!(
             skel,

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -21,6 +21,7 @@ use tempfile::TempDir;
 
 use crate::build::build;
 use crate::gen::btf::GenBtf;
+use crate::gen::btf::GenStructOps;
 use crate::make::make;
 use crate::SkeletonBuilder;
 
@@ -3048,7 +3049,10 @@ impl Default for bpf_dummy_ops {
     let mmap = build_btf_mmap(prog_text);
     let btf = btf_from_mmap(&mmap);
     let mut processed = HashSet::new();
-    let def = btf.struct_ops_type_definition(&mut processed).unwrap();
+    let mut def = String::new();
+    let gen = GenStructOps::new(&btf).unwrap();
+    let () = gen.gen_struct_ops_def(&mut def).unwrap();
+    let () = gen.gen_dependent_types(&mut processed, &mut def).unwrap();
 
     assert_output(&def, expected_output);
 }


### PR DESCRIPTION
Introduce the GenStructOps helper type, taking over parts of the GenBtf::struct_ops_type_definition() method.