### PR TITLE
libbpf-cargo: Move generated struct_ops type out of types module

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 - Adjusted skeleton creation logic to generate Rust types for types used in BPF
   maps
 - Renamed module for generated Rust types from `<project>_types` to just `types`
+- Renamed generated `struct_ops` type to `StructOps` and moved it out of `types`
+  module
 
 
 0.23.3

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -333,21 +333,21 @@ impl<'btf> GenStructOps<'btf> {
     }
 
     pub fn gen_struct_ops_def(&self, def: &mut String) -> Result<()> {
-        // Emit a single struct_ops definition containing all variables
-        // discovered earlier.
+        // Emit a single struct_ops type definition containing all
+        // variables discovered earlier.
         write!(
             def,
             r#"
 #[derive(Debug, Clone)]
 #[repr(C)]
-pub struct struct_ops {{
+pub struct StructOps {{
 "#
         )?;
 
         for var in self.vars.iter() {
             writeln!(
                 def,
-                r#"    pub {var_name}: *mut {var_type},"#,
+                r#"    pub {var_name}: *mut types::{var_type},"#,
                 var_name = var.name().unwrap().to_string_lossy(),
                 var_type = self.btf.type_declaration(**var)?
             )?;
@@ -358,7 +358,7 @@ pub struct struct_ops {{
         write!(
             def,
             r#"
-impl struct_ops {{
+impl StructOps {{
 "#
         )?;
 
@@ -366,13 +366,13 @@ impl struct_ops {{
             write!(
                 def,
                 r#"
-    pub fn {var_name}(&self) -> &{var_type} {{
+    pub fn {var_name}(&self) -> &types::{var_type} {{
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe {{ self.{var_name}.as_ref() }}.unwrap()
     }}
 
-    pub fn {var_name}_mut(&mut self) -> &mut {var_type} {{
+    pub fn {var_name}_mut(&mut self) -> &mut types::{var_type} {{
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe {{ self.{var_name}.as_mut() }}.unwrap()

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -2999,32 +2999,32 @@ struct bpf_dummy_ops dummy_2 = {
     let expected_output = r#"
 #[derive(Debug, Clone)]
 #[repr(C)]
-pub struct struct_ops {
-    pub dummy_1: *mut bpf_dummy_ops,
-    pub dummy_2: *mut bpf_dummy_ops,
+pub struct StructOps {
+    pub dummy_1: *mut types::bpf_dummy_ops,
+    pub dummy_2: *mut types::bpf_dummy_ops,
 }
 
-impl struct_ops {
+impl StructOps {
 
-    pub fn dummy_1(&self) -> &bpf_dummy_ops {
+    pub fn dummy_1(&self) -> &types::bpf_dummy_ops {
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe { self.dummy_1.as_ref() }.unwrap()
     }
 
-    pub fn dummy_1_mut(&mut self) -> &mut bpf_dummy_ops {
+    pub fn dummy_1_mut(&mut self) -> &mut types::bpf_dummy_ops {
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe { self.dummy_1.as_mut() }.unwrap()
     }
 
-    pub fn dummy_2(&self) -> &bpf_dummy_ops {
+    pub fn dummy_2(&self) -> &types::bpf_dummy_ops {
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe { self.dummy_2.as_ref() }.unwrap()
     }
 
-    pub fn dummy_2_mut(&mut self) -> &mut bpf_dummy_ops {
+    pub fn dummy_2_mut(&mut self) -> &mut types::bpf_dummy_ops {
         // SAFETY: The library ensures that the member is pointing to
         //         valid data.
         unsafe { self.dummy_2.as_mut() }.unwrap()


### PR DESCRIPTION
The struct_ops type is basically a libbpf-cargo construct -- there is no corresponding C type to be found in the BTF information (there is something similar in the C skeleton, but that is entirely orthogonal). However, because we generate this type inside the types module, which is the dumping ground for all Rust types with C equivalents, there is the potential for conflicts. For example, the kernel actually does have a type called struct_ops itself. That is not currently a problem, but it may become one once we generate Rust types for more of the C ones present in BTF.
To fix this issue, move the generated struct_ops type out of the types module and into the "global" (from the skeleton's view) namespace. Also rename it to StructOps as an indication that this is a Rust construct without a C direct equivalent, similar to other generated types such as Open*Maps, Open*Progs, etc.