### PR TITLE
libbpf-cargo: Don't generate Rust types for .ksyms contents

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -812,6 +812,13 @@ impl<'s> GenBtf<'s> {
         };
         let sec_name = sec_name.replace('.', "_");
 
+        // Don't generate anything for ksyms. The BTF is patched up by libbpf at
+        // load time and the result can contain multiple variables with the same
+        // name, which is could result in invalid generated code.
+        if sec_name == "ksyms" {
+            return Ok(())
+        }
+
         writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
         writeln!(def, r#"#[repr(C)]"#)?;
         writeln!(def, r#"pub struct {sec_name} {{"#)?;


### PR DESCRIPTION
Contents of the .ksyms section are special in that they can actually lead to invalid code generation in both C and Rust, caused by it containing multiple variables of the same name and type. While the on-disk BTF seems valid and not suffering from this problem, once loaded through libbpf it appears that the contained types get patched up to duplicates.
Work around the issue by not dumping .ksym contents. Yikes.