### PR TITLE
libbpf-cargo: Treat special identifiers...specially

### DIFF
--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1196,6 +1196,7 @@ fn test_btf_dump_reserved_keyword_escaping() {
 struct Foo {
     u64 type;
     void* mod;
+    void* self;
 };
 
 struct Foo foo = {{0}};
@@ -1207,12 +1208,14 @@ struct Foo foo = {{0}};
 pub struct Foo {
     pub r#type: u64,
     pub r#mod: *mut std::ffi::c_void,
+    pub slf: *mut std::ffi::c_void,
 }
 impl Default for Foo {
     fn default() -> Self {
         Self {
             r#type: u64::default(),
             r#mod: std::ptr::null_mut(),
+            slf: std::ptr::null_mut(),
         }
     }
 }


### PR DESCRIPTION
It turns out just rawifying reserved identifiers as done commit 77cc68cc5684 ("libbpf-cargo: Make sure to escape reserve keywords used for identifiers") is not enough. Some of those identifiers are not allowed to be used, even in raw form.
For those, modify them instead of "escaping". Yes, that can result in a collision, but it seems rather unlikely and it's unclear what else we can do.