### PR TITLE
libbpf-cargo: Correctly generate Default impl for type with pointer a…

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
 - Renamed module for generated Rust types from `<project>_types` to just `types`
 - Renamed generated `struct_ops` type to `StructOps` and moved it out of `types`
   module
+- Fixed Rust code generation logic to properly create `Default` impl for arrays
+  of pointers
 
 
 0.23.3

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -640,6 +640,10 @@ impl<'s> GenBtf<'s> {
                     if ft.capacity() > 32 {
                         gen_impl_default = true
                     }
+
+                    if self.type_by_id::<types::Ptr<'_>>(ft.ty()).is_some() {
+                        gen_impl_default = true
+                    }
                 }
 
                 // Rust does not implement `Default` for pointers, no matter if

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -878,6 +878,42 @@ fn test_skeleton_generate_struct_with_pointer() {
     let () = build_rust_project_from_bpf_c(&bpf_c, &rust);
 }
 
+/// Check that we generate valid Rust code for an array of pointers.
+#[test]
+fn test_skeleton_generate_struct_with_pointer_array() {
+    let bpf_c = r#"
+        #include "vmlinux.h"
+        #include <bpf/bpf_helpers.h>
+
+        struct vm_area_struct;
+
+        struct vmacache {
+            struct vm_area_struct *vmas[4];
+        };
+
+        struct vmacache c;
+    "#
+    .to_string();
+
+    let rust = r#"
+        #![warn(elided_lifetimes_in_paths)]
+        mod bpf;
+        use std::mem::MaybeUninit;
+        use bpf::*;
+        use libbpf_rs::skel::SkelBuilder;
+
+        fn main() {
+            let builder = ProgSkelBuilder::default();
+            let mut open_object = MaybeUninit::uninit();
+            let _open_skel = builder
+                .open(&mut open_object)
+                .expect("failed to open skel");
+        }
+    "#
+    .to_string();
+    let () = build_rust_project_from_bpf_c(&bpf_c, &rust);
+}
+
 /// Generate a skeleton that includes multiple "anon" type definitions.
 #[test]
 fn test_skeleton_builder_multiple_anon() {


### PR DESCRIPTION
…rray

Rust does not provide a Default impl for pointer types. We already take that into consideration for the general case in our skeleton generation logic. However, the case we are lacking correct handling for is when a type embeds an array of pointers. Fix up the logic to explicitly generate a Default impl if that's the case.