### PR TITLE
Add CHANGELOG entry for #890

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased
 - Added `Object::name` method
 - Added `Copy` and `Clone` impls for types inside `btf::types` module
 - Adjusted `OpenMap::set_inner_map_fd` to return `Result`
+- Adjusted `ProgramInput::context_in` field to be a mutable reference
 - Made inner `query::Tag` contents publicly accessible
 - Removed `Display` implementation of various `enum` types
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -104,6 +104,7 @@ impl From<TracepointOpts> for libbpf_sys::bpf_tracepoint_opts {
     }
 }
 
+
 /// An immutable parsed but not yet loaded BPF program.
 pub type OpenProgram<'obj> = OpenProgramImpl<'obj>;
 /// A mutable parsed but not yet loaded BPF program.
@@ -505,6 +506,8 @@ impl From<u32> for ProgramAttachType {
 #[derive(Debug, Default)]
 pub struct Input<'dat> {
     /// The input context to provide.
+    ///
+    /// The input is mutable because the kernel may modify it.
     pub context_in: Option<&'dat mut [u8]>,
     /// The output context buffer provided to the program.
     pub context_out: Option<&'dat mut [u8]>,
@@ -542,6 +545,7 @@ pub struct Output<'dat> {
 pub type Program<'obj> = ProgramImpl<'obj>;
 /// A mutable loaded BPF program.
 pub type ProgramMut<'obj> = ProgramImpl<'obj, Mut>;
+
 
 /// Represents a loaded [`Program`].
 ///

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -56,6 +56,7 @@ use crate::common::get_test_object;
 use crate::common::get_test_object_path;
 use crate::common::open_test_object;
 
+
 /// A helper function for instantiating a `RingBuffer` with a callback meant to
 /// be invoked when `action` is executed and that is intended to trigger a write
 /// to said `RingBuffer` from kernel space, which then reads a single `i32` from


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #890, which adjust the ProgramInput's context_in field to a mutable reference.