### PR TITLE
Fix potential memory leaks in RingBufferBuilder::build()

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -22,6 +22,7 @@ Unreleased
 - Adjusted `OpenMap::set_inner_map_fd` to return `Result`
 - Adjusted `ProgramInput::context_in` field to be a mutable reference
 - Made inner `query::Tag` contents publicly accessible
+- Fixed potential memory leak in `RingBufferBuilder::build`
 - Removed `Display` implementation of various `enum` types
 
 


### PR DESCRIPTION
When we build up a RingBuffer object via the RingBufferBuilder::build() function, we may leak memory on error paths, because of the usage of raw pointers.
Fix the issue by:
1) stop converting boxes into raw pointers to begin with, which should
   be fine given that libbpf does not actually dereference the sample
   callback pointer in ring_buffer__new() or ring_buffer__add().
2) properly freeing the ring buffer if we return early because we failed
   to successfully add a callback.

Closes: #862