### PR TITLE
libbpf-cargo: Fix leakage of bpf_object

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed missing BPF object cleanup after skeleton destruction
+
+
 0.24.0
 ------
 - Reworked generated skeletons to contain publicly accessible maps and


### PR DESCRIPTION
With the switch over to using uninitialized memory that has been provided to the skeleton at open time we ended up leaking the object. The reason is simple: on paper we no longer own it and neither does the MaybeUninit that was passed in. As a result, nobody runs its destructor.