### PR TITLE
libbpf-cargo: Improve panic message for datasec mmap ptr retrieval

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -480,11 +480,10 @@ fn gen_skel_open_map_defs(skel: &mut String, maps: &MapsData, raw_obj_name: &str
                             {name}_data: unsafe {{
                                 config
                                     .map_mmap_ptr({mmap_idx})
-                                    .ok()
-                                    .unwrap_or_else(std::ptr::null_mut)
+                                    .expect(\"BPF map `{name}` does not have mmap pointer\")
                                     .cast::<types::{name}>()
                                     .as_mut()
-                                    .expect(\"BPF map `{name}` does not have mmap pointer\")
+                                    .expect(\"BPF map `{name}` mmap pointer is NULL\")
                             }},
                 ",
                 name = map.name,


### PR DESCRIPTION
Improve the panic message we see when failing datasec mmap pointer retrieval to make it a bit more obvious what went wrong.

Refs: #909