### PR TITLE
libbpf-cargo: Don't populate datasec contents for kconfig map

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed panic on "open" of skeleton with `kconfig` map
+
+
 0.24.1
 ------
 - Fixed missing BPF object cleanup after skeleton destruction


### PR DESCRIPTION
The .kconfig section is special in that libbpf sets its values as part of the load procedure. That means that until then, i.e., during open, contents are invalid. To that end the library doesn't even set the mmap pointer to anything but NULL, despite all heuristics pointing at it being mmapable and whatnot.
That's a problem for us, because we generate section contents and attempt to have them reference this nonexistent mmap area, which will fail.
Work around the issue by special casing this section and not permitting direct datasec access. If users require this access they have to manually iterate maps, retrieve initial value, and cast it to types::kconfig.

Closes: #909