### PR TITLE
libbpf-cargo: Suppress some Clippy warnings

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Silenced possible `clippy` reported warnings in generated skeleton
+  when BPF object file does not contain any maps
+
+
 0.24.2
 ------
 - Fixed panic on "open" of skeleton with `kconfig` map

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -458,6 +458,7 @@ fn gen_skel_map_defs(
                         let object = unsafe {{
                             std::mem::transmute::<&mut libbpf_rs::{prefix}Object, &'obj mut libbpf_rs::{prefix}Object>(object)
                         }};
+                        #[allow(clippy::never_loop)]
                         for map in object.maps_mut() {{
                             let name = map
                                 .name()
@@ -468,6 +469,7 @@ fn gen_skel_map_defs(
                                         \"map has invalid name\",
                                     ))
                                 }})?;
+                            #[allow(clippy::match_single_binding)]
                             match name {{
         ",
     )?;


### PR DESCRIPTION
With the changes to initialize maps inline during skeleton open/load, we may end up with Clippy complaining that a loop never loops or a match never matches, if there are no maps present.
Silence the warnings. Such patterns are to be expected in generated code like this.