### PR TITLE
Use workspace-wide definitions for various meta-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
+[workspace.package]
+version = "0.24.3"
+edition = "2021"
+rust-version = "1.71"
+license = "LGPL-2.1-only OR BSD-2-Clause"
+repository = "https://github.com/libbpf/libbpf-rs"
+homepage = "https://github.com/libbpf/libbpf-rs"
+
 [workspace]
 members = [
   "vmlinux",

--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "bpf_query"
 version = "0.1.0"
+edition.workspace = true
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }

--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "capable"
 version = "0.1.0"
+edition.workspace = true
 authors = ["Devasia Thomas <https://www.linkedin.com/in/devasiathomas>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "runqslower"
 version = "0.1.0"
+edition.workspace = true
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tc_whitelist_ports"
 version = "0.1.0"
+edition.workspace = true
 authors = ["Michael Mullin <mimullin@blackberry.com>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tcp_ca"
 version = "0.0.0"
+edition.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }

--- a/examples/tcp_option/Cargo.toml
+++ b/examples/tcp_option/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tcp_option"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tproxy"
 version = "0.1.0"
+edition.workspace = true
 authors = ["Daniel Xu <dxu@dxuuu.xyz>"]
 license = "LGPL-2.1-only OR BSD-2-Clause"
-edition = "2021"
 
 [[bin]]
 name = "proxy"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "libbpf-cargo"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 description = "Cargo plugin to build bpf programs"
-repository = "https://github.com/libbpf/libbpf-rs"
-homepage = "https://github.com/libbpf/libbpf-rs"
-documentation = "https://docs.rs/crate/libbpf-cargo"
 readme = "README.md"
-version = "0.24.3"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
-edition = "2021"
-rust-version = "1.71"
-license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 
 [badges]

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "libbpf-rs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 description = "libbpf-rs is a safe, idiomatic, and opinionated wrapper around libbpf-sys"
-repository = "https://github.com/libbpf/libbpf-rs"
-homepage = "https://github.com/libbpf/libbpf-rs"
 readme = "README.md"
-version = "0.24.3"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
-edition = "2021"
-rust-version = "1.71"
-license = "LGPL-2.1-only OR BSD-2-Clause"
 keywords = ["bpf", "ebpf", "libbpf"]
 
 [badges]

--- a/vmlinux/Cargo.toml
+++ b/vmlinux/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vmlinux"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]
 # Not intended to be published at this point and only meant to be used as a
 # dev-dependency; licensing is not 100% clear but more importantly we can't


### PR DESCRIPTION
As it turns out Cargo now allows us to define certain Cargo meta-data in a workspace-wide manner and then more easily reuse that. We intend to update things such as the edition for all crates in the workspace and the version of the two crates being published from the repository should always be kept in sync. This makes those properties (and others) perfect candidates for this infrastructure.
With this change we switch over to using workspace-wide properties for a bunch of meta-data.