### PR TITLE
Rename Program::get_id_by_fd() to id_from_fd()

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Renamed `Program::get_id_by_fd` to `id_from_fd`
+  - Deprecated `Program::get_id_by_fd`
+
+
 0.24.4
 ------
 - Added `Program::fd_from_pinned_path` method for restoring program descriptor

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -609,8 +609,15 @@ impl<'obj> Program<'obj> {
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
-    /// Returns program id by fd
+    // TODO: Remove once 0.25 is cut.
+    #[deprecated = "renamed to Program::id_from_fd"]
+    #[inline]
     pub fn get_id_by_fd(fd: BorrowedFd<'_>) -> Result<u32> {
+        Self::id_from_fd(fd)
+    }
+
+    /// Returns program ID given a file descriptor.
+    pub fn id_from_fd(fd: BorrowedFd<'_>) -> Result<u32> {
         let mut prog_info = libbpf_sys::bpf_prog_info::default();
         let prog_info_ptr: *mut libbpf_sys::bpf_prog_info = &mut prog_info;
         let mut len = size_of::<libbpf_sys::bpf_prog_info>() as u32;

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -759,12 +759,12 @@ fn test_program_loading_fd_from_pinned_path() {
     let mut obj = get_test_object("runqslower.bpf.o");
     let mut prog = get_prog_mut(&mut obj, prog_name);
     prog.pin(path).expect("pinning prog failed");
-    let prog_id = Program::get_id_by_fd(prog.as_fd()).expect("failed to determine prog id");
+    let prog_id = Program::id_from_fd(prog.as_fd()).expect("failed to determine prog id");
 
     let pinned_prog_fd =
         Program::fd_from_pinned_path(path).expect("failed to get fd of pinned prog");
     let pinned_prog_id =
-        Program::get_id_by_fd(pinned_prog_fd.as_fd()).expect("failed to determine pinned prog id");
+        Program::id_from_fd(pinned_prog_fd.as_fd()).expect("failed to determine pinned prog id");
 
     assert_eq!(prog_id, pinned_prog_id);
 
@@ -1951,8 +1951,8 @@ fn test_program_get_fd_and_id() {
     let mut obj = get_test_object("runqslower.bpf.o");
     let prog = get_prog_mut(&mut obj, "handle__sched_wakeup");
     let prog_fd = prog.as_fd();
-    let prog_id = Program::get_id_by_fd(prog_fd).expect("failed to get program id by fd");
-    let _owned_prog_fd = Program::get_fd_by_id(prog_id).expect("failed to get program fd by id");
+    let prog_id = Program::id_from_fd(prog_fd).expect("failed to get program id from fd");
+    let _owned_prog_fd = Program::get_fd_by_id(prog_id).expect("failed to get program fd from id");
 }
 
 /// Check that autocreate disabled maps don't prevent object loading


### PR DESCRIPTION
Rename Program::get_id_by_fd() to id_from_fd(). The "by" terminology is weird at best and seems to make little grammatical sense. Keep the former around as deprecated until the next minor version bump.