### PR TITLE
Rename Program::get_fd_by_id() to fd_from_id()

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Renamed `Program::get_id_by_fd` to `id_from_fd`
   - Deprecated `Program::get_id_by_fd`
+- Renamed `Program::get_fd_by_id` to `fd_from_id`
+  - Deprecated `Program::get_fd_by_id`
 
 
 0.24.4

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -599,8 +599,14 @@ impl<'obj> Program<'obj> {
         ProgramType::from(unsafe { libbpf_sys::bpf_program__type(self.ptr.as_ptr()) })
     }
 
-    /// Returns program fd by id
+    #[deprecated = "renamed to Program::fd_from_id"]
+    #[inline]
     pub fn get_fd_by_id(id: u32) -> Result<OwnedFd> {
+        Self::fd_from_id(id)
+    }
+
+    /// Returns program file descriptor given a program ID.
+    pub fn fd_from_id(id: u32) -> Result<OwnedFd> {
         let ret = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) };
         let fd = util::parse_ret_i32(ret)?;
         // SAFETY

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1952,7 +1952,7 @@ fn test_program_get_fd_and_id() {
     let prog = get_prog_mut(&mut obj, "handle__sched_wakeup");
     let prog_fd = prog.as_fd();
     let prog_id = Program::id_from_fd(prog_fd).expect("failed to get program id from fd");
-    let _owned_prog_fd = Program::get_fd_by_id(prog_id).expect("failed to get program fd from id");
+    let _owned_prog_fd = Program::fd_from_id(prog_id).expect("failed to get program fd from id");
 }
 
 /// Check that autocreate disabled maps don't prevent object loading


### PR DESCRIPTION
Rename Program::get_fd_by_id() to fd_from_id(). The "by" terminology is weird at best and seems to make little grammatical sense. Keep the former around as deprecated until the next minor version bump.