### PR TITLE
Gate out test functions that use probe! on ppc64le and s390x

### DIFF
--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -48,7 +48,7 @@ libbpf-rs = {path = ".", features = ["generate-test-files"]}
 log = "0.4.4"
 memmem = "0.1.1"
 plain = "0.2.3"
-probe = "0.3"
+probe = ">=0.3, <0.6"
 scopeguard = "1.1"
 serial_test = { version = "3.0", default-features = false }
 tempfile = "3.3"

--- a/libbpf-rs/tests/common/mod.rs
+++ b/libbpf-rs/tests/common/mod.rs
@@ -9,7 +9,6 @@ use libbpf_rs::ObjectBuilder;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramMut;
 
-
 pub fn get_test_object_path(filename: &str) -> PathBuf {
     let mut path = PathBuf::new();
     // env!() macro fails at compile time if var not found

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -56,7 +56,6 @@ use crate::common::get_test_object;
 use crate::common::get_test_object_path;
 use crate::common::open_test_object;
 
-
 /// A helper function for instantiating a `RingBuffer` with a callback meant to
 /// be invoked when `action` is executed and that is intended to trigger a write
 /// to said `RingBuffer` from kernel space, which then reads a single `i32` from
@@ -1565,6 +1564,10 @@ fn test_object_map_handle_clone() {
     );
 }
 
+#[cfg(not(any(
+    all(target_arch = "powerpc64", target_endian = "little"),
+    target_arch = "s390x"
+)))]
 #[tag(root)]
 #[test]
 fn test_object_usdt() {
@@ -1593,6 +1596,10 @@ fn test_object_usdt() {
     assert_eq!(result, 1);
 }
 
+#[cfg(not(any(
+    all(target_arch = "powerpc64", target_endian = "little"),
+    target_arch = "s390x"
+)))]
 #[tag(root)]
 #[test]
 fn test_object_usdt_cookie() {


### PR DESCRIPTION
These require `feature(asm_experimental_arch)` which only works on nightly compilers.

See https://github.com/rust-lang/rust/issues/93335

Also loosen version requirement on `probe`; on Fedora we have been building with `probe` 0.5.1 with no issue.

Tested by doing a scratch build on Fedora's Koji build system:

https://koji.fedoraproject.org/koji/taskinfo?taskID=123361398