### PR TITLE
Add CHANGELOG entry for #939

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   - Deprecated `Program::get_id_by_fd`
 - Renamed `Program::get_fd_by_id` to `fd_from_id`
   - Deprecated `Program::get_fd_by_id`
+- Adjusted `PerfBufferBuilder` to work with `MapCore` objects
 
 
 0.24.4


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #939, which adjusted the PerfBufferBuilder type to work with anything implementing the MapCore trait instead of strictly requiring a Map object.