### PR TITLE
Mark link with must_use

### DIFF
--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -17,6 +17,7 @@ use crate::Result;
 /// This struct is used to model ownership. The underlying program will be detached
 /// when this object is dropped if nothing else is holding a reference count.
 #[derive(Debug)]
+#[must_use = "not using this `Link` will detach the underlying program immediately"]
 pub struct Link {
     ptr: NonNull<libbpf_sys::bpf_link>,
 }


### PR DESCRIPTION
This is a small fix that marks Link with `must_use`, as discussed in #940. This makes it clear right away that the program will detach immediately if not used.
