### PR TITLE
Fix __TARGET_ARCH_xx define for riscv64,loongarch64,sparc64,mips64

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -190,6 +190,10 @@ fn compile_one(
             "aarch64" => "arm64",
             "powerpc64" => "powerpc",
             "s390x" => "s390",
+            "riscv64" => "riscv",
+            "loongarch64" => "loongarch",
+            "sparc64" => "sparc",
+            "mips64" => "mips",
             x => x,
         };
         cmd.arg(format!("-D__TARGET_ARCH_{arch}"));


### PR DESCRIPTION
This commit updates the __TARGET_ARCH_xx define to match what is used in bpf_tracing.h.

Reference https://github.com/torvalds/linux/blob/8cf0b93919e13d1e8d4466eb4080a4c4d9d66d7b/tools/lib/bpf/bpf_tracing.h#L8-L38
