### PR TITLE
Use runtime CARGO_CFG_TARGET_ARCH in build-script

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::env;
 use std::env::consts::ARCH;
 use std::ffi::OsStr;
 use std::ffi::OsString;
@@ -184,7 +185,8 @@ fn compile_one(
     {
         // We may end up being invoked by a build script, in which case
         // `CARGO_CFG_TARGET_ARCH` would represent the target architecture.
-        let arch = option_env!("CARGO_CFG_TARGET_ARCH").unwrap_or(ARCH);
+        let arch = env::var("CARGO_CFG_TARGET_ARCH");
+        let arch = arch.as_deref().unwrap_or(ARCH);
         let arch = match arch {
             "x86_64" => "x86",
             "aarch64" => "arm64",


### PR DESCRIPTION
option_env retrieves the CARGO_CFG_TARGET_ARCH at compile-time, which is not correct for the usage here. Instead, we should retrieve the variable using env::var at runtime in the build-script.

Fix https://github.com/kxxt/tracexec/actions/runs/11213953908/job/31168026074?pr=41

See also #958