### PR TITLE
Add CHANGELOG entry for #959

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Fixed incorrect Cargo environment variable query when used in build
+  script context
+
+
 0.24.4
 ------
 - Adjusted skeleton generation code to work around `libbpf` forward


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #959, which fixed the CARGO_CFG_TARGET_ARCH environment variable query from a build script in a cross-compilation context.