### PR TITLE
Disable LeakSanitizer tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
     - name: "Set environmental variables"
       shell: bash
       run: |
-        RUST_BACKTRACE_nightly='1'
-        CFLAGS_nightly='-fsanitize=leak'
-        CXXFLAGS_nightly='-fsanitize=leak'
-        RUSTFLAGS_nightly='-Zsanitizer=leak'
+        #RUST_BACKTRACE_nightly='1'
+        #CFLAGS_nightly='-fsanitize=leak'
+        #CXXFLAGS_nightly='-fsanitize=leak'
+        #RUSTFLAGS_nightly='-Zsanitizer=leak'
 
         # A function for defining a variable conditional on the toolchain in
         # use.
@@ -76,10 +76,10 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Run tcp_ca
-        env:
-          CFLAGS: '-fsanitize=leak'
-          CXXFLAGS: '-fsanitize=leak'
-          RUSTFLAGS: '-Zsanitizer=leak'
+        #env:
+        #  CFLAGS: '-fsanitize=leak'
+        #  CXXFLAGS: '-fsanitize=leak'
+        #  RUSTFLAGS: '-Zsanitizer=leak'
         run: |
           cargo build --package tcp_ca
           sudo target/debug/tcp_ca


### PR DESCRIPTION
Leak sanitizer infrastructure in Rust is badly broken [0]. Disable it until it resembles something of a working piece of software again.

[0] https://github.com/rust-lang/rust/issues/111073