### PR TITLE
libbpf-rs: Remove unused `log` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,6 @@ dependencies = [
  "libbpf-rs-dev",
  "libbpf-sys",
  "libc",
- "log",
  "memmem",
  "pkg-config",
  "plain",

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -46,7 +46,6 @@ tempfile = { version = "3.3", optional = true }
 [dev-dependencies]
 libbpf-rs = {path = ".", features = ["generate-test-files"]}
 libbpf-rs-dev = {path = "dev", features = ["generate-test-files"]}
-log = "0.4.4"
 memmem = "0.1.1"
 plain = "0.2.3"
 probe = "0.3"


### PR DESCRIPTION
libbpf-rs: Remove unused log dependency