### PR TITLE
libbpf-cargo: Handle empty unions in BTF types

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed handling of empty unions in BPF types
+
+
 0.24.6
 ------
 - Fixed incorrect Cargo environment variable query when used in build

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -2734,6 +2734,36 @@ pub struct __anon_4 {
 }
 
 #[test]
+fn test_btf_dump_definition_empty_union() {
+    let prog_text = r#"
+#include "vmlinux.h"
+
+struct struct_with_empty_union {
+    int member;
+    union {};
+};
+struct struct_with_empty_union s;
+"#;
+
+    let expected_output = r#"
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct struct_with_empty_union {
+    pub member: i32,
+}
+"#;
+
+    let mmap = build_btf_mmap(prog_text);
+    let btf = btf_from_mmap(&mmap);
+
+    // Find the struct
+    let struct_with_empty_union =
+        find_type_in_btf!(btf, types::Struct<'_>, "struct_with_empty_union");
+
+    assert_definition(&btf, &struct_with_empty_union, expected_output);
+}
+
+#[test]
 fn test_btf_dump_definition_struct_ops_mixed() {
     let prog_text = r#"
 #include "vmlinux.h"

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -579,6 +579,13 @@ impl<'btf> TryFrom<Composite<'btf>> for Union<'btf> {
     }
 }
 
+impl Composite<'_> {
+    /// Returns whether this composite type is a `union {}`.
+    pub fn is_empty_union(&self) -> bool {
+        !self.is_struct && self.is_empty()
+    }
+}
+
 // Composite
 gen_collection_members_concrete_type! {
     btf_member as Composite with HasSize;


### PR DESCRIPTION
This was noticed because a "vmlinux.h" contained:

```
struct bio {
...
	union {};
...
};
```

Which caused the following error when trying to use "struct bio" in a .bpf.c file:

```
  thread 'main' panicked at /home/jrc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libbpf-cargo-0.24.6/src/gen/btf.rs:769:49:
  index out of bounds: the len is 0 but the index is 0
```

Fix this by hiding empty unions from the generated types. Rust does not allow union types with zero fields.

Fixes #974.