### PR TITLE
libbpf-cargo: Generate C enums as custom types with const fields

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.24.7
 ------
 - Fixed handling of empty unions in BPF types
+- Represent C enums with custom types and const fields
 
 
 0.24.6


### PR DESCRIPTION
Rather than generating Rust enums from C enums, which might not be correct, as for example, C allows enum variants to share a value while Rust does not.

This fixes #982.

Test Plan
=========

Verified that tests pass in CI in my fork and that my project compiles fine and works will with this change.
