### PR TITLE
Release 0.24.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.24.6"
+version = "0.24.7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.24.6"
+version = "0.24.7"
 dependencies = [
  "bitflags 2.6.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.24.6"
+version = "0.24.7"
 edition = "2021"
 rust-version = "1.71"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.24.7
+------
 - Fixed handling of empty unions in BPF types
 
 


### PR DESCRIPTION
Prepare for release of 0.24.7 by bumping both libbpf-rs and libbpf-cargo versions accordingly.