### PR TITLE
Add CHANGELOG entry for #980

### DIFF
--- a/examples/netfilter_blocklist/src/bpf/netfilter_blocklist.bpf.c
+++ b/examples/netfilter_blocklist/src/bpf/netfilter_blocklist.bpf.c
@@ -51,8 +51,8 @@ int netfilter_local_in(struct bpf_nf_ctx *ctx) {
         /* To view log output, use: cat /sys/kernel/debug/tracing/trace_pipe */
         __be32 addr_host = bpf_ntohl(key.addr);
         bpf_printk("Blocked IP: %d.%d.%d.%d, prefix length: %d, map value: %d\n",
-           (addr_host >> 24) & 0xFF, (addr_host >> 16) & 0xFF, 
-           (addr_host >> 8) & 0xFF, addr_host & 0xFF, 
+           (addr_host >> 24) & 0xFF, (addr_host >> 16) & 0xFF,
+           (addr_host >> 8) & 0xFF, addr_host & 0xFF,
            key.prefixlen, *match_value);
         return NF_DROP;
     }

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Added `Program::attach_netfilter_with_opts` for attaching to netfilter
+  hooks
+
+
 0.24.5
 ------
 - Renamed `Program::get_id_by_fd` to `id_from_fd`

--- a/libbpf-rs/tests/bin/src/netfilter.bpf.c
+++ b/libbpf-rs/tests/bin/src/netfilter.bpf.c
@@ -21,7 +21,7 @@ int handle_netfilter(struct bpf_nf_ctx *ctx) {
 
     *value = 1;
     bpf_ringbuf_submit(value, 0);
-    
+
     bpf_printk("handle_netfilter: submitted ringbuf value");
     return NF_ACCEPT;
 }


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #980, which added support for attaching to netfilter hooks. Also fix a few minor things that slipped through review and remove tests for one more hook which is not available on a local system and causing test failures because of it.