### PR TITLE
Fix documentation of MapCore::delete_batch()

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -497,7 +497,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
 
     /// Deletes many elements in batch mode from the map.
     ///
-    /// `keys` must have exactly [`Self::key_size()` * count] elements.
+    /// `keys` must have exactly `Self::key_size() * count` elements.
     fn delete_batch(
         &self,
         keys: &[u8],


### PR DESCRIPTION
Similar to commit 62130a056fae ("Fix documentation of MapCore::update_batch()"), fix the rendering of the documentation of MapCore::delete_batch() method, whose 'keys' description contained wrong markdown.