### PR TITLE
Apply a few changes to #989

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,7 +1,11 @@
+Unreleased
+----------
+- Represent C enums with custom types and const fields
+
+
 0.24.7
 ------
 - Fixed handling of empty unions in BPF types
-- Represent C enums with custom types and const fields
 
 
 0.24.6


### PR DESCRIPTION
Fix the CHANGELOG entry for pull request #989 and convert the compilation test to a proper end-to-end style one going all the way from C code to buildable Rust project.