### PR TITLE
libbpf-cargo: Stop treating C enums as "unsafe"

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -199,12 +199,7 @@ fn main() -> Result<()> {
         .tool_config
         .verbose
         .write(opts.verbose);
-    open_skel
-        .maps
-        .rodata_data
-        .tool_config
-        .unique_type
-        .write(opts.unique_type);
+    open_skel.maps.rodata_data.tool_config.unique_type = opts.unique_type;
 
     let mut skel = open_skel.load()?;
     skel.attach()?;

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Represent C enums with custom types and const fields
+  - Adjusted Rust correspondents in generated skeletons to no longer be
+    wrapped in `MaybeUninit`
 
 
 0.24.7
@@ -74,7 +76,7 @@ Unreleased
 - Fixed potential naming issues by escaping reserved keywords used in
   identifiers
 - Fixed potential unsoundness issues in generated skeletons by wrapping "unsafe"
-  type in `MaybeUninit`
+  types in `MaybeUninit`
 - Added pointer based ("raw") access to datasec type to generated skeletons
 - Added better handling for bitfields to code generation logic
 - Updated `libbpf-sys` dependency to `1.4.0`

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -40,7 +40,6 @@ fn is_unsafe(ty: BtfType<'_>) -> bool {
 
     btf_type_match!(match ty {
         BtfKind::Int(t) => matches!(t.encoding, types::IntEncoding::Bool),
-        BtfKind::Enum | BtfKind::Enum64 => true,
         _ => false,
     })
 }

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1860,17 +1860,10 @@ struct Bar bar;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Bar {
-    pub foo: std::mem::MaybeUninit<Foo>,
-}
-impl Default for Bar {
-    fn default() -> Self {
-        Self {
-            foo: std::mem::MaybeUninit::new(Foo::default()),
-        }
-    }
+    pub foo: Foo,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
@@ -1885,7 +1878,6 @@ impl Foo {
 impl Default for Foo {
     fn default() -> Self { Foo::Zero }
 }
-
 "#;
 
     let mmap = build_btf_mmap(prog_text);
@@ -2606,17 +2598,10 @@ struct Foo foo;
 "#;
 
     let expected_output = r#"
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct Foo {
-    pub test: std::mem::MaybeUninit<__anon_1>,
-}
-impl Default for Foo {
-    fn default() -> Self {
-        Self {
-            test: std::mem::MaybeUninit::new(__anon_1::default()),
-        }
-    }
+    pub test: __anon_1,
 }
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
@@ -2627,7 +2612,8 @@ impl __anon_1 {
 }
 impl Default for __anon_1 {
     fn default() -> Self { __anon_1::FOO }
-}"#;
+}
+"#;
 
     let mmap = build_btf_mmap(prog_text);
     let btf = btf_from_mmap(&mmap);


### PR DESCRIPTION
In the past C enums were mapped to Rust enums in the generated skeletons. Because Rust enums enums have stricter requirements than C ones, we have to wrap them in MaybeUninit (see 87929fff0d9d ("libbpf-cargo: Wrap generated "unsafe" types in MaybeUninit")).

With the switch to using regular constants for representing these C enums in Rust as done in commit e24198391c0a ("libbpf-cargo: Generate C enums as custom types with const fields"), we no longer have to treat them as "unsafe" and can remove the MaybeUninit wrapper.