### PR TITLE
libbpf-cargo: Warn on missing Debug impls

### DIFF
--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -58,6 +58,7 @@
 #![allow(clippy::let_unit_value)]
 #![warn(
     elided_lifetimes_in_paths,
+    missing_debug_implementations,
     single_use_lifetimes,
     clippy::absolute_paths,
     clippy::wildcard_imports
@@ -106,6 +107,7 @@ mod test;
 ///     .build_and_generate("/output/path")
 ///     .unwrap();
 /// ```
+#[derive(Debug)]
 pub struct SkeletonBuilder {
     debug: bool,
     source: Option<PathBuf>,


### PR DESCRIPTION
Warn about lack of Debug impls on publicly exposed types, similar to what we have been doing in libbpf-rs ever since commit f9479934d66e ("libbpf-rs: add warn(missing_debug_implementations) to lib.rs").