### PR TITLE
libbpf-cargo: Restrict visibility of some functions/types

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -279,7 +279,7 @@ fn extract_clang_or_default(clang: Option<&PathBuf>) -> PathBuf {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn build(
+pub(crate) fn build(
     debug: bool,
     manifest_path: Option<&PathBuf>,
     clang: Option<&PathBuf>,
@@ -310,7 +310,7 @@ pub fn build(
 
 // Only used in libbpf-cargo library
 #[allow(dead_code)]
-pub fn build_single(
+pub(crate) fn build_single(
     debug: bool,
     source: &Path,
     out: &Path,

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -191,7 +191,7 @@ impl ProgsData {
 }
 
 
-pub enum OutputDest<'a> {
+pub(crate) enum OutputDest<'a> {
     Stdout,
     /// Infer a filename and place file in specified directory
     Directory(&'a Path),
@@ -1217,7 +1217,7 @@ fn gen_skel(
 /// Generate mod.rs in src/bpf directory of each project.
 ///
 /// Each `UnprocessedObj` in `objs` must belong to same project.
-pub fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&PathBuf>) -> Result<()> {
+pub(crate) fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&PathBuf>) -> Result<()> {
     if objs.is_empty() {
         return Ok(());
     }
@@ -1258,7 +1258,7 @@ pub fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&PathBuf>) -> Resu
     Ok(())
 }
 
-pub fn gen_single(
+pub(crate) fn gen_single(
     debug: bool,
     obj_file: &Path,
     output: OutputDest<'_>,
@@ -1352,7 +1352,7 @@ fn gen_project(
     Ok(())
 }
 
-pub fn gen(
+pub(crate) fn gen(
     debug: bool,
     manifest_path: Option<&PathBuf>,
     rustfmt_path: Option<&PathBuf>,


### PR DESCRIPTION
Restrict the visibility of some functions and types currently declared public for seemingly no apparent reason.