### PR TITLE
Add CHANGELOG entry for #994

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Represent C enums with custom types and const fields
   - Adjusted Rust correspondents in generated skeletons to no longer be
     wrapped in `MaybeUninit`
+- Adjusted `SkeletonBuilder::build*` methods to return
+  `CompilationOutput` on success
 
 
 0.24.7

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -26,8 +26,6 @@ pub struct CompilationOutput {
 }
 
 impl CompilationOutput {
-    // Only used in libbpf-cargo library
-    #[allow(dead_code)]
     /// Read the stderr from the compilation
     pub fn stderr(&self) -> &[u8] {
         &self.stderr


### PR DESCRIPTION
Add a CHANGELOG entry for #994, which introduced the CompilationOutput type to libbpf-cargo and made SkeletonBuilder::build* methods return in on success.