### PR TITLE
libbpf-cargo: Implement PartialEq for generated Rust "enums"

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -808,7 +808,7 @@ impl<'s> GenBtf<'s> {
 
         let mut first_field = None;
 
-        writeln!(def, r#"#[derive(Debug, Copy, Clone)]"#)?;
+        writeln!(def, r#"#[derive(Debug, Copy, Clone, Eq, PartialEq)]"#)?;
         writeln!(def, r#"#[repr(transparent)]"#)?;
         writeln!(def, r#"pub struct {enum_name}({signed}{repr_size});"#)?;
         writeln!(def, "#[allow(non_upper_case_globals)]")?;


### PR DESCRIPTION
With the switch from emitting C enums as Rust enums to mapping them to Rust struct instead, we dropped the PartialEq and Eq derives. Add them back to make working with these generated types more convenient.