### PR TITLE
Release 0.25.0-beta.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
           cargo init --bin libbpf-rs-test-project
           cd libbpf-rs-test-project
           cat >> Cargo.toml <<EOF
-          libbpf-rs = { version = "*", path = "../libbpf-rs", ${{ matrix.args }} }
+          libbpf-rs = { path = "../libbpf-rs", ${{ matrix.args }} }
           EOF
           cat > src/main.rs <<EOF
           fn main() {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.24.8"
+version = "0.25.0-beta.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.24.8"
+version = "0.25.0-beta.0"
 dependencies = [
  "bitflags 2.6.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.24.8"
+version = "0.25.0-beta.0"
 edition = "2021"
 rust-version = "1.71"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0-beta.0
+-------------
 - Represent C enums with custom types and const fields
   - Adjusted Rust correspondents in generated skeletons to no longer be
     wrapped in `MaybeUninit`

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ default = ["libbpf-rs/default"]
 [dependencies]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
-libbpf-rs = { version = "0.24", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "=0.25.0-beta.0", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }
 semver = "1.0"

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -12,7 +12,7 @@ Helps you build and develop BPF programs with standard Rust tooling.
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [build-dependencies]
-libbpf-cargo = "0.24"
+libbpf-cargo = "=0.25.0-beta.0"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0-beta.0
+-------------
 - Added `Map::lookup_batch` and `Map::lookup_and_delete_batch` method
 
 

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -12,7 +12,7 @@ Idiomatic Rust wrapper around [libbpf](https://github.com/libbpf/libbpf).
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [dependencies]
-libbpf-rs = "0.24"
+libbpf-rs = "=0.25.0-beta.0"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).


### PR DESCRIPTION
Prepare for release of `0.25.0-beta.0` by bumping both libbpf-rs and libbpf-cargo versions accordingly.