### PR TITLE
libbpf-cargo: Expose inner Rust "enum" values publicly

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -810,7 +810,7 @@ impl<'s> GenBtf<'s> {
 
         writeln!(def, r#"#[derive(Debug, Copy, Clone, Eq, PartialEq)]"#)?;
         writeln!(def, r#"#[repr(transparent)]"#)?;
-        writeln!(def, r#"pub struct {enum_name}({signed}{repr_size});"#)?;
+        writeln!(def, r#"pub struct {enum_name}(pub {signed}{repr_size});"#)?;
         writeln!(def, "#[allow(non_upper_case_globals)]")?;
         writeln!(def, r#"impl {enum_name} {{"#,)?;
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1880,7 +1880,7 @@ pub struct Bar {
 }
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct Foo(u32);
+pub struct Foo(pub u32);
 #[allow(non_upper_case_globals)]
 impl Foo {
     pub const Zero: Foo = Foo(0);
@@ -2618,7 +2618,7 @@ pub struct Foo {
 }
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct __anon_1(u32);
+pub struct __anon_1(pub u32);
 #[allow(non_upper_case_globals)]
 impl __anon_1 {
     pub const FOO: __anon_1 = __anon_1(1);


### PR DESCRIPTION
With the switch from emitting C enums as Rust enums to mapping them to Rust structs instead, we no longer allow access to the underlying integer. That's a bit of a usability snag, because it forces users to fall back to transmuting constants just to get a hold of the inner value.
Expose the inner value publicly to make that easier.