### PR TITLE
Add CHANGELOG entry for #1028

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.25.0-beta.0
 -------------
 - Added `Map::lookup_batch` and `Map::lookup_and_delete_batch` method
+- Added `Send` & `Sync` impl for `OpenObject` & `Object` types
 
 
 0.24.8

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -222,9 +222,6 @@ pub struct OpenObject {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }
 
-unsafe impl Send for OpenObject {}
-unsafe impl Sync for OpenObject {}
-
 impl OpenObject {
     /// Takes ownership from pointer.
     ///
@@ -299,6 +296,11 @@ impl OpenObject {
     }
 }
 
+// SAFETY: `bpf_object` is freely transferable between threads.
+unsafe impl Send for OpenObject {}
+// SAFETY: `bpf_object` has no interior mutability.
+unsafe impl Sync for OpenObject {}
+
 impl AsRawLibbpf for OpenObject {
     type LibbpfType = libbpf_sys::bpf_object;
 
@@ -317,6 +319,7 @@ impl Drop for OpenObject {
     }
 }
 
+
 /// Represents a loaded BPF object file.
 ///
 /// An `Object` is logically in charge of all the contained [`Program`]s and [`Map`]s as well as
@@ -331,9 +334,6 @@ impl Drop for OpenObject {
 pub struct Object {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }
-
-unsafe impl Send for Object {}
-unsafe impl Sync for Object {}
 
 impl Object {
     /// Takes ownership from pointer.
@@ -392,6 +392,11 @@ impl Object {
             .map(|mut ptr| unsafe { ProgramMut::new_mut(ptr.as_mut()) })
     }
 }
+
+// SAFETY: `bpf_object` is freely transferable between threads.
+unsafe impl Send for Object {}
+// SAFETY: `bpf_object` has no interior mutability.
+unsafe impl Sync for Object {}
 
 impl AsRawLibbpf for Object {
     type LibbpfType = libbpf_sys::bpf_object;


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1028, which added Send + Sync bounds to the OpenObject and Object types. Also add missing SAFETY comments.