### PR TITLE
Release 0.25.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.25.0-beta.0"
+version = "0.25.0-beta.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.25.0-beta.0"
+version = "0.25.0-beta.1"
 dependencies = [
  "bitflags 2.6.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.25.0-beta.0"
+version = "0.25.0-beta.1"
 edition = "2021"
 rust-version = "1.71"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0-beta.1
+-------------
 - Fixed skeleton generation when `enum64` types are present
 
 

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,7 @@ default = ["libbpf-rs/default"]
 [dependencies]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
-libbpf-rs = { version = "=0.25.0-beta.0", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }
 semver = "1.0"

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -12,7 +12,7 @@ Helps you build and develop BPF programs with standard Rust tooling.
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [build-dependencies]
-libbpf-cargo = "=0.25.0-beta.0"
+libbpf-cargo = "=0.25.0-beta.1"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0-beta.1
+-------------
 - Adjusted `btf::types::EnumMember` to store value as `i64`
 - Adjusted `btf::types::Enum64Member` to store value as `i128`
 

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -12,7 +12,7 @@ Idiomatic Rust wrapper around [libbpf](https://github.com/libbpf/libbpf).
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [dependencies]
-libbpf-rs = "=0.25.0-beta.0"
+libbpf-rs = "=0.25.0-beta.1"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).


### PR DESCRIPTION
Prepare for release of 0.25.0-beta.1 by bumping both libbpf-rs and libbpf-cargo versions accordingly.