### PR TITLE
Make ARM builds optional in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,9 @@ jobs:
   build-aarch64:
     name: Build for aarch64
     runs-on: ubuntu-latest
+    # Make this job optional until Ubuntu gets their act together and
+    # provides usable infrastructure.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Add apt sources for arm64
@@ -180,6 +183,9 @@ jobs:
   build-armhf:
     name: Build for aarch32
     runs-on: ubuntu-latest
+    # Make this job optional until Ubuntu gets their act together and
+    # provides usable infrastructure.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Add apt sources for armhf


### PR DESCRIPTION
Ubuntu can't get their act together and provide reliably accessible servers. Make the repeatedly failing jobs optional for the time being.