### PR TITLE
Fix build-capable CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,9 @@ jobs:
         run: sudo apt-get install -y libelf-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu" cargo build --locked --package capable --features=static
+      # `-lzstd` is necessary because Ubuntu's system libelf.a is built
+      # with zstd support.
+      - run: RUSTFLAGS="$RUSTFLAGS -L /usr/lib/x86_64-linux-gnu -lzstd" cargo build --locked --package capable --features=static
 
   build-aarch64:
     name: Build for aarch64


### PR DESCRIPTION
It appears that recent Ubuntu upstream changes broke our build-capable job, because the system libelf.a now seems to have built in support for zstd, necessitating the linking of the corresponding library. Do just that.