### PR TITLE
Implement Sync for Link

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@
 -------------
 - Adjusted `btf::types::EnumMember` to store value as `i64`
 - Adjusted `btf::types::Enum64Member` to store value as `i128`
+- Implemented `Sync` for `Link`
 
 
 0.25.0-beta.0

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -121,6 +121,8 @@ impl AsRawLibbpf for Link {
 
 // SAFETY: `bpf_link` objects can safely be sent to a different thread.
 unsafe impl Send for Link {}
+// SAFETY: `bpf_link` has no interior mutability.
+unsafe impl Sync for Link {}
 
 impl AsFd for Link {
     #[inline]


### PR DESCRIPTION
Implement Sync for Link. The only operations that can be performed on a &Link are pin_path() and detach(), neither of which modify the object. pin_path() just reads an attribute and detach() performs a system call with the link's file descriptor. Hence, Sync should be fine to implement for Link.