### PR TITLE
libbpf-cargo: Remove clang version check logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,8 +295,6 @@ dependencies = [
  "goblin",
  "libbpf-rs",
  "memmap2",
- "regex",
- "semver",
  "serde",
  "serde_json",
  "tempfile",
@@ -601,35 +590,6 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "runqslower"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+- Removed `SkeletonBuilder::skip_clang_version_check`
+- Removed `--skip-clang-version-checks` option of `libbpf build`
+  sub-command
+
+
 0.25.0-beta.1
 -------------
 - Fixed skeleton generation when `enum64` types are present

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,8 +33,6 @@ anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.5"
-regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }
-semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3"

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -110,7 +110,6 @@ pub struct SkeletonBuilder {
     obj: Option<PathBuf>,
     clang: Option<PathBuf>,
     clang_args: Vec<OsString>,
-    skip_clang_version_check: bool,
     rustfmt: PathBuf,
     dir: Option<TempDir>,
 }
@@ -129,7 +128,6 @@ impl SkeletonBuilder {
             obj: None,
             clang: None,
             clang_args: Vec::new(),
-            skip_clang_version_check: false,
             rustfmt: "rustfmt".into(),
             dir: None,
         }
@@ -195,14 +193,6 @@ impl SkeletonBuilder {
         self
     }
 
-    /// Specify whether or not to skip clang version check
-    ///
-    /// Default is `false`
-    pub fn skip_clang_version_check(&mut self, skip: bool) -> &mut SkeletonBuilder {
-        self.skip_clang_version_check = skip;
-        self
-    }
-
     /// Specify which `rustfmt` binary to use
     ///
     /// Default searches `$PATH` for `rustfmt`
@@ -256,7 +246,6 @@ impl SkeletonBuilder {
             // Unwrap is safe here since we guarantee that obj.is_some() above
             self.obj.as_ref().unwrap(),
             self.clang.as_ref(),
-            self.skip_clang_version_check,
             self.clang_args.clone(),
         )
         .with_context(|| format!("failed to build `{}`", source.display()))

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -52,9 +52,6 @@ pub struct ClangOpts {
     /// Additional arguments to pass to `clang`.
     #[arg(long, value_parser)]
     clang_args: Vec<OsString>,
-    /// Skip clang version checks
-    #[arg(long)]
-    skip_clang_version_checks: bool,
 }
 
 /// cargo-libbpf is a cargo subcommand that helps develop and build eBPF (BPF) programs.
@@ -116,14 +113,12 @@ fn main() -> Result<()> {
                     ClangOpts {
                         clang_path,
                         clang_args,
-                        skip_clang_version_checks,
                     },
             } => build::build(
                 debug,
                 manifest_path.as_ref(),
                 clang_path.as_ref(),
                 clang_args,
-                skip_clang_version_checks,
             ),
             Command::Gen {
                 manifest_path,
@@ -141,7 +136,6 @@ fn main() -> Result<()> {
                     ClangOpts {
                         clang_path,
                         clang_args,
-                        skip_clang_version_checks,
                     },
                 quiet,
                 cargo_build_args,
@@ -151,7 +145,6 @@ fn main() -> Result<()> {
                 manifest_path.as_ref(),
                 clang_path.as_ref(),
                 clang_args,
-                skip_clang_version_checks,
                 quiet,
                 cargo_build_args,
                 rustfmt_path.as_ref(),

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -15,7 +15,6 @@ pub fn make(
     manifest_path: Option<&PathBuf>,
     clang: Option<&PathBuf>,
     clang_args: Vec<OsString>,
-    skip_clang_version_checks: bool,
     quiet: bool,
     cargo_build_args: Vec<String>,
     rustfmt_path: Option<&PathBuf>,
@@ -23,14 +22,8 @@ pub fn make(
     if !quiet {
         println!("Compiling BPF objects");
     }
-    build::build(
-        debug,
-        manifest_path,
-        clang,
-        clang_args,
-        skip_clang_version_checks,
-    )
-    .context("Failed to compile BPF objects")?;
+    build::build(debug, manifest_path, clang, clang_args)
+        .context("Failed to compile BPF objects")?;
 
     if !quiet {
         println!("Generating skeletons");

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -139,17 +139,17 @@ fn test_build_default() {
     let (_dir, proj_dir, cargo_toml) = setup_temp_project();
 
     // No bpf progs yet
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     // Add a prog
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -167,7 +167,7 @@ fn test_build_invalid_prog() {
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
     writeln!(prog_file, "1").expect("write to prog file failed");
 
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 }
 
 #[test]
@@ -186,14 +186,14 @@ fn test_build_custom() {
         .expect("write to Cargo.toml failed");
 
     // No bpf progs yet
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     // Add a prog
     create_dir(proj_dir.join("src/other_bpf_dir")).expect("failed to create prog dir");
     let _prog_file = File::create(proj_dir.join("src/other_bpf_dir/prog.bpf.c"))
         .expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap();
 
     // Validate generated object file
     validate_bpf_o(
@@ -223,13 +223,13 @@ fn test_unknown_metadata_section() {
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     // Add a prog
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -241,15 +241,15 @@ fn test_enforce_file_extension() {
 
     // Add prog dir
     create_dir(proj_dir.join("src/bpf")).expect("failed to create prog dir");
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     let _prog_file = File::create(proj_dir.join("src/bpf/prog_BAD_EXTENSION.c"))
         .expect("failed to create prog file");
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap_err();
 
     let _prog_file_again = File::create(proj_dir.join("src/bpf/prog_GOOD_EXTENSION.bpf.c"))
         .expect("failed to create prog file");
-    build(true, Some(&cargo_toml), None, Vec::new(), true).unwrap();
+    build(true, Some(&cargo_toml), None, Vec::new()).unwrap();
 }
 
 #[test]
@@ -257,7 +257,7 @@ fn test_build_workspace() {
     let (_dir, _, workspace_cargo_toml, proj_one_dir, proj_two_dir) = setup_temp_workspace();
 
     // No bpf progs yet
-    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new()).unwrap_err();
 
     // Create bpf prog for project one
     create_dir(proj_one_dir.join("src/bpf")).expect("failed to create prog dir");
@@ -269,7 +269,7 @@ fn test_build_workspace() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog2.bpf.c"))
         .expect("failed to create prog file 2");
 
-    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new()).unwrap();
 }
 
 #[test]
@@ -286,7 +286,7 @@ fn test_build_workspace_collision() {
     let _prog_file_2 = File::create(proj_two_dir.join("src/bpf/prog.bpf.c"))
         .expect("failed to create prog file 2");
 
-    build(true, Some(&workspace_cargo_toml), None, Vec::new(), true).unwrap_err();
+    build(true, Some(&workspace_cargo_toml), None, Vec::new()).unwrap_err();
 }
 
 #[test]
@@ -305,7 +305,6 @@ fn test_make_basic() {
         Some(&cargo_toml),
         None,
         Vec::new(),
-        true,
         true,
         Vec::new(),
         None,
@@ -343,7 +342,6 @@ fn test_make_workspace() {
         Some(&workspace_cargo_toml),
         None,
         Vec::new(),
-        true,
         true,
         Vec::new(),
         None,
@@ -401,7 +399,6 @@ fn build_rust_project_from_bpf_c_impl(bpf_c: &str, rust: &str, run: bool) {
         Some(&cargo_toml),
         None,
         Vec::new(),
-        true,
         true,
         Vec::new(),
         None,
@@ -1220,7 +1217,7 @@ fn build_btf_mmap(prog_text: &str) -> Mmap {
     add_vmlinux_header(&proj_dir);
 
     // Build the .bpf.o
-    build(true, Some(&cargo_toml), None, Vec::new(), true).expect("failed to compile");
+    build(true, Some(&cargo_toml), None, Vec::new()).expect("failed to compile");
 
     let obj = OpenOptions::new()
         .read(true)


### PR DESCRIPTION
Remove the logic for checking the clang version in use. This logic is worrisome and insufficient for a couple of reasons.

It is insufficient, because we don't actually know what clang version we require -- that is a moving target. Nobody is actively testing against the lowest supported clang version to make sure that our stuff actually works with it. At this point, the stated minimum of `10.0.0` is also increasingly unlikely to be found in the wild, rendering the check less and less useful with every passing year. Ultimately, if a necessary feature really is not available, one would hope that the emitted error isn't too cryptic for anybody to make sense of it.

On the "worrisome" front, the over reliance on anything and everything clang (not just with this check, but with naming more generally) boxes us into a single-compiler world. It is entirely conceivable that a GCC BPF backend arrives eventually (has it already?), which, if past is any guidance, shoulder understand roughly the same arguments as clang itself and, hence, potentially being a drop-in replacement. We should be ready to support this future without shenanigans such as "gcc" being passed to an API asking for "clang". Furthermore, parsing the compiler's output using regular expressions is at best a fragile endeavor. What's more, the amount of dependencies (direct + transitive) pulled in just in service of this one feature is penalizing everybody, for no obvious value-add.
Lastly, the plumping necessary for this feature is part of the reason we have nonsensical call sites such as the following to deal with:
```rust
     make(
       true,
       Some(&cargo_toml),
       None,
       Vec::new(),
       true,
       true,
       Vec::new(),
       None,
     )
```

In short, removal of this checking logic is our best option. Take it.