### PR TITLE
libbpf-cargo: Add proper logging infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +230,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iced-x86"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,12 +329,15 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "env_logger",
  "goblin",
  "libbpf-rs",
+ "log",
  "memmap2",
  "serde",
  "serde_json",
  "tempfile",
+ "test-log",
  "vmlinux",
 ]
 
@@ -370,6 +410,15 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -526,6 +575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +645,50 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "runqslower"
@@ -730,6 +829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +918,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "test-tag"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +968,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -887,6 +1027,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1084,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vmlinux"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Removed `SkeletonBuilder::skip_clang_version_check`
 - Removed `--skip-clang-version-checks` option of `libbpf build`
   sub-command
+- Replaced `--debug` option of `libbpf` sub-command with `-v` /
+  `--verbose`
 
 
 0.25.0-beta.1

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   sub-command
 - Replaced `--debug` option of `libbpf` sub-command with `-v` /
   `--verbose`
+  - Removed `--quiet` option of `libbpf make` sub-command
 
 
 0.25.0-beta.1

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -31,7 +31,9 @@ default = ["libbpf-rs/default"]
 [dependencies]
 anyhow = "1.0.1"
 cargo_metadata = "0.15.0"
+env_logger = { version = "0.11.6", default-features = false, features = ["auto-color", "humantime"] }
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
+log = "0.4.25"
 memmap2 = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -40,4 +42,5 @@ clap = { version = "4.0.32", features = ["derive"] }
 
 [dev-dependencies]
 goblin = "0.9"
+test-log = { version = "0.2.16", default-features = false, features = ["log"] }
 vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -38,6 +38,8 @@ use libbpf_rs::MapType;
 use libbpf_rs::Object;
 use libbpf_rs::Program;
 
+use log::debug;
+use log::info;
 use memmap2::Mmap;
 
 use crate::metadata;
@@ -289,7 +291,7 @@ pub(crate) fn canonicalize_internal_map_name(s: &str) -> Option<InternalMapType<
         let name = s.get(".bss.".len()..).unwrap();
         Some(InternalMapType::CustomBss(name))
     } else {
-        eprintln!("Warning: unrecognized map: {s}");
+        info!("encountered unrecognized map: {s}");
         None
     }
 }
@@ -1293,16 +1295,12 @@ pub(crate) fn gen_single(
     Ok(())
 }
 
-fn gen_project(
-    debug: bool,
-    manifest_path: Option<&PathBuf>,
-    rustfmt_path: Option<&PathBuf>,
-) -> Result<()> {
-    let (_target_dir, to_gen) = metadata::get(debug, manifest_path)?;
-    if debug && !to_gen.is_empty() {
-        println!("Found bpf objs to gen skel:");
+fn gen_project(manifest_path: Option<&PathBuf>, rustfmt_path: Option<&PathBuf>) -> Result<()> {
+    let (_target_dir, to_gen) = metadata::get(manifest_path)?;
+    if !to_gen.is_empty() {
+        debug!("Found bpf objs to gen skel:");
         for obj in &to_gen {
-            println!("\t{obj:?}");
+            debug!("\t{obj:?}");
         }
     } else if to_gen.is_empty() {
         bail!("Did not find any bpf objects to generate skeleton");
@@ -1348,7 +1346,6 @@ fn gen_project(
 }
 
 pub fn gen(
-    debug: bool,
     manifest_path: Option<&PathBuf>,
     rustfmt_path: Option<&PathBuf>,
     object: Option<&PathBuf>,
@@ -1360,6 +1357,6 @@ pub fn gen(
     if let Some(obj_file) = object {
         gen_single(obj_file, OutputDest::Stdout, rustfmt_path)
     } else {
-        gen_project(debug, manifest_path, rustfmt_path)
+        gen_project(manifest_path, rustfmt_path)
     }
 }

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -241,7 +241,6 @@ impl SkeletonBuilder {
         }
 
         build::build_single(
-            self.debug,
             source,
             // Unwrap is safe here since we guarantee that obj.is_some() above
             self.obj.as_ref().unwrap(),

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -90,9 +90,6 @@ enum Command {
         manifest_path: Option<PathBuf>,
         #[command(flatten)]
         clang_opts: ClangOpts,
-        #[arg(short, long)]
-        /// Quiet output
-        quiet: bool,
         /// Arguments to pass to `cargo build`
         ///
         /// Example: cargo libbpf build -- --package mypackage
@@ -146,14 +143,12 @@ fn main() -> Result<()> {
                         clang_path,
                         clang_args,
                     },
-                quiet,
                 cargo_build_args,
                 rustfmt_path,
             } => make::make(
                 manifest_path.as_ref(),
                 clang_path.as_ref(),
                 clang_args,
-                quiet,
                 cargo_build_args,
                 rustfmt_path.as_ref(),
             ),

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -11,7 +11,6 @@ use crate::gen;
 
 #[allow(clippy::too_many_arguments)]
 pub fn make(
-    debug: bool,
     manifest_path: Option<&PathBuf>,
     clang: Option<&PathBuf>,
     clang_args: Vec<OsString>,
@@ -22,13 +21,12 @@ pub fn make(
     if !quiet {
         println!("Compiling BPF objects");
     }
-    build::build(debug, manifest_path, clang, clang_args)
-        .context("Failed to compile BPF objects")?;
+    build::build(manifest_path, clang, clang_args).context("Failed to compile BPF objects")?;
 
     if !quiet {
         println!("Generating skeletons");
     }
-    gen::gen(debug, manifest_path, None, rustfmt_path).context("Failed to generate skeletons")?;
+    gen::gen(manifest_path, None, rustfmt_path).context("Failed to generate skeletons")?;
 
     let mut cmd = Command::new("cargo");
     cmd.arg("build");

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -5,32 +5,29 @@ use std::process::Command;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use log::debug;
+use log::log_enabled;
+use log::Level::Info;
 
 use crate::build;
 use crate::gen;
 
-#[allow(clippy::too_many_arguments)]
 pub fn make(
     manifest_path: Option<&PathBuf>,
     clang: Option<&PathBuf>,
     clang_args: Vec<OsString>,
-    quiet: bool,
     cargo_build_args: Vec<String>,
     rustfmt_path: Option<&PathBuf>,
 ) -> Result<()> {
-    if !quiet {
-        println!("Compiling BPF objects");
-    }
+    debug!("Compiling BPF objects");
     build::build(manifest_path, clang, clang_args).context("Failed to compile BPF objects")?;
 
-    if !quiet {
-        println!("Generating skeletons");
-    }
+    debug!("Generating skeletons");
     gen::gen(manifest_path, None, rustfmt_path).context("Failed to generate skeletons")?;
 
     let mut cmd = Command::new("cargo");
     cmd.arg("build");
-    if quiet {
+    if !log_enabled!(Info) {
         cmd.arg("--quiet");
     }
     for arg in cargo_build_args {

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -301,7 +301,7 @@ fn test_make_basic() {
     let _prog_file =
         File::create(proj_dir.join("src/bpf/prog.bpf.c")).expect("failed to create prog file");
 
-    make(Some(&cargo_toml), None, Vec::new(), true, Vec::new(), None).unwrap();
+    make(Some(&cargo_toml), None, Vec::new(), Vec::new(), None).unwrap();
 
     // Validate generated object file
     validate_bpf_o(proj_dir.as_path().join("target/bpf/prog.bpf.o").as_path());
@@ -333,7 +333,6 @@ fn test_make_workspace() {
         Some(&workspace_cargo_toml),
         None,
         Vec::new(),
-        true,
         Vec::new(),
         None,
     )
@@ -385,7 +384,7 @@ fn build_rust_project_from_bpf_c_impl(bpf_c: &str, rust: &str, run: bool) {
     // Lay down the necessary header files
     add_vmlinux_header(&proj_dir);
 
-    make(Some(&cargo_toml), None, Vec::new(), true, Vec::new(), None).unwrap();
+    make(Some(&cargo_toml), None, Vec::new(), Vec::new(), None).unwrap();
 
     let mut cargo = OpenOptions::new()
         .append(true)


### PR DESCRIPTION
We support a very limited form of logging by printing certain actions happening when the --debug option is provided. While not particularly useful at the current stage, this is probably functionality worth keeping in the long run.
However, the current implementation is questionable at best: we plumb through some boolean flag everywhere, which convolutes various call sites and requires potentially excessive changes to support emitting a new log message somewhere.
With this change we switch over to using proper logging based on the log crate and other parts of the ecosystem. As a result, we get support for multiple log levels, proper time stamping, limited output coloring, and additional filtering capabilities via environment variables. At the same time, we remove usage of flags that have to be plumbed through everywhere, because logging state is global state.

Before:
```
  $ cargo run -- libbpf build --manifest-path libbpf-rs/examples/capable/Cargo.toml --clang-args='-I~/.cargo/git/checkouts/vmlinux.h-ec81e0afb9d5f7e2/83a228/include/x86/' --debug
  > Metadata for package=libbpf-cargo
  >         null
  > Metadata for package=libbpf-rs
  >         null
```

After:
```
  $ cargo run -- libbpf build --manifest-path libbpf-rs/examples/capable/Cargo.toml --clang-args='-I~/.cargo/git/checkouts/vmlinux.h-ec81e0afb9d5f7e2/83a228/include/x86/' -vvv
  > [2025-01-16T17:10:44Z DEBUG libbpf_cargo::metadata] Metadata for package=libbpf-cargo
  > [2025-01-16T17:10:44Z DEBUG libbpf_cargo::metadata]     null
  > [2025-01-16T17:10:44Z DEBUG libbpf_cargo::metadata] Metadata for package=libbpf-rs
  > [2025-01-16T17:10:44Z DEBUG libbpf_cargo::metadata]     null
```

For tests, usage is simple as well:
```
  $ RUST_LOG=trace cargo test -- test::test_make_basic --nocapture
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::metadata] Metadata for package=proj
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::metadata]     null
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::build] Found bpf progs to compile:
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::build]        UnprocessedObj { package: "proj", path: "/tmp/.tmpXhQPS6/proj/src/bpf/prog.bpf.c", out: "/tmp/.tmpXhQPS6/proj/target/bpf", name: "prog" }
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::build] Building /tmp/.tmpXhQPS6/proj/src/bpf/prog.bpf.c
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::metadata] Metadata for package=proj
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::metadata]     null
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::gen] Found bpf objs to gen skel:
  > [2025-01-16T17:17:46Z DEBUG libbpf_cargo::gen]  UnprocessedObj { package: "proj", path: "/tmp/.tmpXhQPS6/proj/src/bpf/prog.bpf.c", out: "/tmp/.tmpXhQPS6/proj/target/bpf", name: "prog" }
  > test test::test_make_basic ... ok
```