### PR TITLE
Downgrade Ubuntu version for Arm testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-aarch64:
     name: Build for aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Make this job optional until Ubuntu gets their act together and
     # provides usable infrastructure.
     continue-on-error: true
@@ -184,7 +184,7 @@ jobs:
 
   build-armhf:
     name: Build for aarch32
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Make this job optional until Ubuntu gets their act together and
     # provides usable infrastructure.
     continue-on-error: true


### PR DESCRIPTION
Our Arm jobs have been failing for a while. At first that was sporadic (in retrospect likely because we got runners sporting different images due to staged rollout of a new Ubuntu version) and now its permanent. The cause of the failure seems to be some change in format of their sources.list, causing us to no longer be able to no longer fetch necessary package lists. I haven't found a guide in their documentation how to properly update, so roll back to a known good distro version until somebody has the nerves to deal with this %#&*($&#*($.