### PR TITLE
libbpf-cargo: Remove SkeletonBuilder::debug() method

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
-- Removed `SkeletonBuilder::skip_clang_version_check`
+- Removed `SkeletonBuilder::skip_clang_version_check` and
+  `SkeletonBuilder::debug`
 - Removed `--skip-clang-version-checks` option of `libbpf build`
   sub-command
 - Replaced `--debug` option of `libbpf` sub-command with `-v` /

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -98,14 +98,12 @@ mod test;
 ///
 /// SkeletonBuilder::new()
 ///     .source("myobject.bpf.c")
-///     .debug(true)
 ///     .clang("/opt/clang/clang")
 ///     .build_and_generate("/output/path")
 ///     .unwrap();
 /// ```
 #[derive(Debug)]
 pub struct SkeletonBuilder {
-    debug: bool,
     source: Option<PathBuf>,
     obj: Option<PathBuf>,
     clang: Option<PathBuf>,
@@ -123,7 +121,6 @@ impl Default for SkeletonBuilder {
 impl SkeletonBuilder {
     pub fn new() -> Self {
         SkeletonBuilder {
-            debug: false,
             source: None,
             obj: None,
             clang: None,
@@ -146,14 +143,6 @@ impl SkeletonBuilder {
     /// Default is None
     pub fn obj<P: AsRef<Path>>(&mut self, obj: P) -> &mut SkeletonBuilder {
         self.obj = Some(obj.as_ref().to_path_buf());
-        self
-    }
-
-    /// Turn debug output on or off
-    ///
-    /// Default is off
-    pub fn debug(&mut self, debug: bool) -> &mut SkeletonBuilder {
-        self.debug = debug;
         self
     }
 

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -661,7 +661,6 @@ fn test_skeleton_builder_basic() {
     let skel = NamedTempFile::new().unwrap();
     SkeletonBuilder::new()
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
-        .debug(true)
         .build_and_generate(skel.path())
         .unwrap();
 
@@ -770,7 +769,6 @@ fn test_skeleton_builder_clang_opts() {
     // Should fail b/c `PURPOSE` not defined
     SkeletonBuilder::new()
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
-        .debug(true)
         .clang("clang")
         .build_and_generate(skel.path())
         .unwrap_err();
@@ -778,7 +776,6 @@ fn test_skeleton_builder_clang_opts() {
     // Should succeed b/c we defined the macro
     SkeletonBuilder::new()
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
-        .debug(true)
         .clang("clang")
         .clang_args(["-DPURPOSE=you_pass_the_butter"])
         .build_and_generate(skel.path())
@@ -1084,7 +1081,6 @@ fn test_skeleton_builder_deterministic() {
     let skel1 = NamedTempFile::new().unwrap();
     SkeletonBuilder::new()
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
-        .debug(true)
         .clang("clang")
         .build_and_generate(skel1.path())
         .unwrap();
@@ -1093,7 +1089,6 @@ fn test_skeleton_builder_deterministic() {
     let skel2 = NamedTempFile::new().unwrap();
     SkeletonBuilder::new()
         .source(proj_dir.join("src/bpf/prog.bpf.c"))
-        .debug(true)
         .clang("clang")
         .build_and_generate(skel2.path())
         .unwrap();


### PR DESCRIPTION
Remove the SkeletonBuilder::debug() method, now that we have proper logging support. It is now solely up to the user to configure the logging sink, which is more flexible but also more involved compared to blindly dumping stuff to stdout.