### PR TITLE
Remove 'missing_docs' lint annotation from OpenMap impl

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -56,8 +56,6 @@ pub struct OpenMapImpl<'obj, T = ()> {
     _phantom: PhantomData<&'obj T>,
 }
 
-// TODO: Document members.
-#[allow(missing_docs)]
 impl<'obj> OpenMap<'obj> {
     /// Create a new [`OpenMap`] from a ptr to a `libbpf_sys::bpf_map`.
     pub fn new(object: &'obj libbpf_sys::bpf_map) -> Self {


### PR DESCRIPTION
Remove the 'missing_docs' lint annotation from OpenMap impl, as it is no longer required.