### PR TITLE
Add CHANGELOG entry for #1064

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `max_entries` getter to various map types
 - Implemented `Sync` for `Link`
 
 

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -102,7 +102,7 @@ impl<'obj> OpenMap<'obj> {
         }
     }
 
-    /// Retrieve max_entries of the map.
+    /// Retrieve the maximum number of entries of the map.
     pub fn max_entries(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__max_entries(self.ptr.as_ptr()) }
     }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1999,10 +1999,10 @@ fn test_map_autocreate_disable() {
     open_obj.load().expect("failed to load object");
 }
 
-/// Check that we can resize a map value.
+/// Check that we can adjust a map's value size.
 #[tag(root)]
 #[test]
-fn test_map_resize_value() {
+fn test_map_adjust_value_size() {
     bump_rlimit_mlock();
 
     let mut open_obj = open_test_object("map_auto_pin.bpf.o");
@@ -2021,7 +2021,7 @@ fn test_map_resize_value() {
     assert_eq!(new_len, len * 2);
 }
 
-/// Check that we can resize map max entries.
+/// Check that we can adjust a map's maximum entries.
 #[tag(root)]
 #[test]
 fn test_object_map_max_entries() {


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1064, which added the max_entries() getter to various map types. Also improve on a few minor details that did not justify another round trip.