### PR TITLE
libbpf-cargo: Simplify build_btf_mmap() test helper

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -199,7 +199,7 @@ impl BpfObjBuilder {
     /// Build a BPF object file.
     pub fn build(&mut self, src: &Path, dst: &Path) -> Result<CompilationOutput> {
         self.build_many([src], dst).map(|vec| {
-            // SANITY: We pass in a single file we `build_many` is
+            // SANITY: We pass in a single file and `build_many` is
             //         guaranteed to produce as many outputs as input
             //         files; so there must be one.
             vec.into_iter().next().unwrap()


### PR DESCRIPTION
The `build_btf_mmap()` function is almost comically complex in what it does. In order to compile a single `.bpf.c` file it creates an entire Cargo Rust project and builds that, instead of simply compiling the file directly. Now that we have the `BpfObjBuilder` type, we can just about accomplish the latter without jumping through dozens of hoops. Do it. As a pleasant side effect of this reduction in complexity, the `btf_dump` test runtime more than halves:

Before:
```
  $ time target/debug/deps/libbpf_cargo-37cf1fde780326f7 btf_dump
  > running 34 tests
  > [...]
  > ________________________________________________________
  > Executed in    2.09 secs    fish           external
```

After:
```
  $ time target/debug/deps/libbpf_cargo-37cf1fde780326f7 btf_dump
  > running 34 tests
  > [...]
  > ________________________________________________________
  > Executed in  810.13 millis    fish           external
```

Not the motivating factor at this point, but we take it.