### PR TITLE
Use `#[expect(...)]` instead of `#[allow(...)]` in some places

### DIFF
--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -124,7 +124,7 @@ fn bump_memlock_rlimit() -> Result<()> {
 }
 
 fn print_banner(extra_fields: bool) {
-    #[allow(clippy::print_literal)]
+    #[expect(clippy::print_literal)]
     if extra_fields {
         println!(
             "{:9} {:6} {:6} {:6} {:16} {:4} {:20} {:6} {}",

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -179,14 +179,14 @@ impl<'obj> OpenMapMut<'obj> {
     }
 
     // TODO: Document member.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_numa_node(&mut self, numa_node: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_numa_node(self.ptr.as_ptr(), numa_node) };
         util::parse_ret(ret)
     }
 
     // TODO: Document member.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_inner_map_fd(&mut self, inner_map_fd: BorrowedFd<'_>) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::bpf_map__set_inner_map_fd(self.ptr.as_ptr(), inner_map_fd.as_raw_fd())
@@ -195,7 +195,7 @@ impl<'obj> OpenMapMut<'obj> {
     }
 
     // TODO: Document member.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_map_extra(&mut self, map_extra: u64) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_map_extra(self.ptr.as_ptr(), map_extra) };
         util::parse_ret(ret)
@@ -377,7 +377,7 @@ fn lookup_batch_raw<M>(
 where
     M: MapCore + ?Sized,
 {
-    #[allow(clippy::needless_update)]
+    #[expect(clippy::needless_update)]
     let opts = libbpf_sys::bpf_map_batch_opts {
         sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
         elem_flags: elem_flags.bits(),
@@ -586,7 +586,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
             )));
         };
 
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
             elem_flags: elem_flags.bits(),
@@ -702,7 +702,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
             )));
         }
 
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         let opts = libbpf_sys::bpf_map_batch_opts {
             sz: mem::size_of::<libbpf_sys::bpf_map_batch_opts>() as _,
             elem_flags: elem_flags.bits(),
@@ -1204,7 +1204,7 @@ bitflags! {
 #[repr(u32)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum MapType {
     Unspec = libbpf_sys::BPF_MAP_TYPE_UNSPEC,
     Hash = libbpf_sys::BPF_MAP_TYPE_HASH,

--- a/libbpf-rs/src/netfilter.rs
+++ b/libbpf-rs/src/netfilter.rs
@@ -55,7 +55,7 @@ impl From<NetfilterOpts> for libbpf_sys::bpf_netfilter_opts {
             _non_exhaustive,
         } = opts;
 
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         libbpf_sys::bpf_netfilter_opts {
             sz: size_of::<Self>() as _,
             pf: protocol_family as u32,

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -202,7 +202,7 @@ pub struct PerfBuffer<'b> {
 }
 
 // TODO: Document methods.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 impl PerfBuffer<'_> {
     pub fn epoll_fd(&self) -> i32 {
         unsafe { libbpf_sys::perf_buffer__epoll_fd(self.ptr.as_ptr()) }

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -123,7 +123,7 @@ pub fn set_print(
 ) -> Option<(PrintLevel, PrintCallback)> {
     // # Safety
     // outer_print_cb has the same function signature as libbpf_print_fn_t
-    #[allow(clippy::missing_transmute_annotations)]
+    #[expect(clippy::missing_transmute_annotations)]
     let real_cb: libbpf_sys::libbpf_print_fn_t =
         unsafe { Some(mem::transmute(outer_print_cb as *const ())) };
     let real_cb: libbpf_sys::libbpf_print_fn_t = callback.as_ref().and(real_cb);

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -72,7 +72,7 @@ impl From<UsdtOpts> for libbpf_sys::bpf_usdt_opts {
             cookie,
             _non_exhaustive,
         } = opts;
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         libbpf_sys::bpf_usdt_opts {
             sz: size_of::<Self>() as _,
             usdt_cookie: cookie,
@@ -98,7 +98,7 @@ impl From<TracepointOpts> for libbpf_sys::bpf_tracepoint_opts {
             _non_exhaustive,
         } = opts;
 
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         libbpf_sys::bpf_tracepoint_opts {
             sz: size_of::<Self>() as _,
             bpf_cookie: cookie,
@@ -234,7 +234,7 @@ impl<'obj> OpenProgramMut<'obj> {
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_attach_target(
         &mut self,
         attach_prog_fd: i32,
@@ -293,7 +293,7 @@ impl<T> AsRawLibbpf for OpenProgramImpl<'_, T> {
 #[repr(u32)]
 #[derive(Copy, Clone, Debug)]
 // TODO: Document variants.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ProgramType {
     Unspec = 0,
     SocketFilter = libbpf_sys::BPF_PROG_TYPE_SOCKET_FILTER,
@@ -408,7 +408,7 @@ impl From<u32> for ProgramType {
 #[repr(u32)]
 #[derive(Clone, Debug)]
 // TODO: Document variants.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ProgramAttachType {
     CgroupInetIngress = libbpf_sys::BPF_CGROUP_INET_INGRESS,
     CgroupInetEgress = libbpf_sys::BPF_CGROUP_INET_EGRESS,
@@ -606,7 +606,7 @@ impl<'obj> Program<'obj> {
     }
 
     #[deprecated = "renamed to Program::fd_from_id"]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[inline]
     pub fn get_fd_by_id(id: u32) -> Result<OwnedFd> {
         Self::fd_from_id(id)
@@ -624,7 +624,7 @@ impl<'obj> Program<'obj> {
 
     // TODO: Remove once 0.25 is cut.
     #[deprecated = "renamed to Program::id_from_fd"]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[inline]
     pub fn get_id_by_fd(fd: BorrowedFd<'_>) -> Result<u32> {
         Self::id_from_fd(fd)

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -125,7 +125,7 @@ pub struct Tag(pub [u8; 8]);
 /// Information about a BPF program
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct ProgramInfo {
     pub name: CString,
     pub ty: ProgramType,
@@ -439,7 +439,7 @@ impl Iterator for ProgInfoIter {
 /// Information about a BPF map
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct MapInfo {
     pub name: CString,
     pub ty: MapType,
@@ -588,21 +588,21 @@ impl Iterator for BtfInfoIter {
 
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct RawTracepointLinkInfo {
     pub name: String,
 }
 
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct TracingLinkInfo {
     pub attach_type: ProgramAttachType,
 }
 
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct CgroupLinkInfo {
     pub cgroup_id: u64,
     pub attach_type: ProgramAttachType,
@@ -610,7 +610,7 @@ pub struct CgroupLinkInfo {
 
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct NetNsLinkInfo {
     pub ino: u32,
     pub attach_type: ProgramAttachType,
@@ -618,7 +618,7 @@ pub struct NetNsLinkInfo {
 
 #[derive(Debug, Clone)]
 // TODO: Document variants.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum LinkTypeInfo {
     RawTracepoint(RawTracepointLinkInfo),
     Tracing(TracingLinkInfo),
@@ -631,7 +631,7 @@ pub enum LinkTypeInfo {
 /// Information about a BPF link
 #[derive(Debug, Clone)]
 // TODO: Document members.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct LinkInfo {
     pub info: LinkTypeInfo,
     pub id: u32,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -159,7 +159,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
 #[derive(Debug)]
 pub struct RingBuffer<'cb> {
     ptr: NonNull<libbpf_sys::ring_buffer>,
-    #[allow(clippy::vec_box)]
+    #[expect(clippy::vec_box)]
     _cbs: Vec<Box<RingBufferCallback<'cb>>>,
 }
 

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -42,7 +42,7 @@ struct ProgSkelConfig {
     link: Box<*mut bpf_link>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug)]
 pub struct ObjectSkeletonConfigBuilder<'dat> {
     data: &'dat [u8],
@@ -77,7 +77,7 @@ impl<'dat> ObjectSkeletonConfigBuilder<'dat> {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn name<T: AsRef<str>>(&mut self, name: T) -> &mut Self {
         self.name = Some(name.as_ref().to_string());
         self
@@ -180,7 +180,7 @@ impl<'dat> ObjectSkeletonConfigBuilder<'dat> {
         Some(layout)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn build(mut self) -> Result<ObjectSkeletonConfig<'dat>> {
         // Holds `CString`s alive so pointers to them stay valid
         let mut string_pool = Vec::new();

--- a/libbpf-rs/src/tc.rs
+++ b/libbpf-rs/src/tc.rs
@@ -20,13 +20,13 @@ pub type TcFlags = libbpf_sys::bpf_tc_flags;
 pub const BPF_TC_F_REPLACE: TcFlags = libbpf_sys::BPF_TC_F_REPLACE;
 
 // from kernel @ include/uapi/linux/pkt_sched.h
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub const TC_H_INGRESS: u32 = 0xFFFFFFF1;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub const TC_H_CLSACT: u32 = TC_H_INGRESS;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub const TC_H_MIN_INGRESS: u32 = 0xFFF2;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub const TC_H_MIN_EGRESS: u32 = 0xFFF3;
 #[allow(missing_docs)]
 pub const TC_H_MAJ_MASK: u32 = 0xFFFF0000;


### PR DESCRIPTION
Use the `#[expect(...)]` attribute instead of `#[allow(...)]` in a bunch of places where we only have the attribute to silence a lint. The former makes sure that the silenced issue is actually flagged, or prints a warning otherwise.