### PR TITLE
libbpf-cargo: Handle duplicated types in BTF more gracefully

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
 - Replaced `--debug` option of `libbpf` sub-command with `-v` /
   `--verbose`
   - Removed `--quiet` option of `libbpf make` sub-command
+- Fixed handling of multiple types of same name in BTF by enumerating
+  them in the generated skeleton
 
 
 0.25.0-beta.1


### PR DESCRIPTION
Our `SkeletonBuilder` currently only support building a skeleton from a single `.bpf.c` file. However, users may very well compile multiple `.bpf.c` files into `.bpf.o` and link them into a single object. In such a scenario, it is easily possible that we end up with multiple types of the same name in the corresponding BTF. Currently, this results in compilation errors.
With this change we handle this case more gracefully, by enumerating these types, similar to what libbpf does in its dumping logic.