### PR TITLE
libbpf-cargo: Allow renamed lint usage in skeleton

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -868,6 +868,7 @@ fn gen_skel_contents(raw_obj_name: &str, obj_file_path: &Path) -> Result<String>
 
         pub use self::imp::*;
 
+        #[allow(renamed_and_removed_lints)]
         #[allow(dead_code)]
         #[allow(non_snake_case)]
         #[allow(non_camel_case_types)]


### PR DESCRIPTION
We have seen several lints get renamed or removed over time. Our generated skeletons explicitly allow a couple of lints and these may be affected by such changes as well. To make that less of an event, silently allow the usage of renamed lints down there.