### PR TITLE
libbpf-cargo: Stop working with Option<&PathBuf>

### DIFF
--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -289,7 +289,7 @@ fn format_command(command: &Command) -> String {
     concat_command(prog, args).to_string_lossy().to_string()
 }
 
-fn extract_clang_or_default(clang: Option<&PathBuf>) -> PathBuf {
+fn extract_clang_or_default(clang: Option<&Path>) -> PathBuf {
     match clang {
         Some(c) => c.into(),
         // Searches $PATH
@@ -298,8 +298,8 @@ fn extract_clang_or_default(clang: Option<&PathBuf>) -> PathBuf {
 }
 
 pub fn build_project(
-    manifest_path: Option<&PathBuf>,
-    clang: Option<&PathBuf>,
+    manifest_path: Option<&Path>,
+    clang: Option<&Path>,
     clang_args: Vec<OsString>,
 ) -> Result<()> {
     let (_target_dir, to_compile) = metadata::get(manifest_path)?;

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -16,7 +16,6 @@ use std::io::Write;
 use std::mem::size_of;
 use std::os::raw::c_ulong;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
 use std::ptr;
@@ -205,7 +204,7 @@ pub(crate) enum OutputDest<'a> {
 ///
 /// If no `rustfmt` binary could be found the content is left untouched, as
 /// it's only meant as a cosmetic brush up, without change of semantics.
-fn try_rustfmt<'code>(s: &'code str, rustfmt_path: Option<&PathBuf>) -> Result<Cow<'code, [u8]>> {
+fn try_rustfmt<'code>(s: &'code str, rustfmt_path: Option<&Path>) -> Result<Cow<'code, [u8]>> {
     let result = if let Some(r) = rustfmt_path {
         Command::new(r)
     } else {
@@ -1191,7 +1190,7 @@ fn gen_skel(
     name: &str,
     obj: &Path,
     out: OutputDest<'_>,
-    rustfmt_path: Option<&PathBuf>,
+    rustfmt_path: Option<&Path>,
 ) -> Result<()> {
     ensure!(!name.is_empty(), "Object file has no name");
 
@@ -1217,7 +1216,7 @@ fn gen_skel(
 /// Generate mod.rs in src/bpf directory of each project.
 ///
 /// Each `UnprocessedObj` in `objs` must belong to same project.
-pub(crate) fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&PathBuf>) -> Result<()> {
+pub(crate) fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&Path>) -> Result<()> {
     if objs.is_empty() {
         return Ok(());
     }
@@ -1261,7 +1260,7 @@ pub(crate) fn gen_mods(objs: &[UnprocessedObj], rustfmt_path: Option<&PathBuf>) 
 pub(crate) fn gen_single(
     obj_file: &Path,
     output: OutputDest<'_>,
-    rustfmt_path: Option<&PathBuf>,
+    rustfmt_path: Option<&Path>,
 ) -> Result<()> {
     let filename = match obj_file.file_name() {
         Some(n) => n,
@@ -1296,7 +1295,7 @@ pub(crate) fn gen_single(
     Ok(())
 }
 
-fn gen_project(manifest_path: Option<&PathBuf>, rustfmt_path: Option<&PathBuf>) -> Result<()> {
+fn gen_project(manifest_path: Option<&Path>, rustfmt_path: Option<&Path>) -> Result<()> {
     let (_target_dir, to_gen) = metadata::get(manifest_path)?;
     if !to_gen.is_empty() {
         debug!("Found bpf objs to gen skel:");
@@ -1347,9 +1346,9 @@ fn gen_project(manifest_path: Option<&PathBuf>, rustfmt_path: Option<&PathBuf>) 
 }
 
 pub fn gen(
-    manifest_path: Option<&PathBuf>,
-    rustfmt_path: Option<&PathBuf>,
-    object: Option<&PathBuf>,
+    manifest_path: Option<&Path>,
+    rustfmt_path: Option<&Path>,
+    object: Option<&Path>,
 ) -> Result<()> {
     if manifest_path.is_some() && object.is_some() {
         bail!("--manifest-path and --object cannot be used together");

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -126,15 +126,15 @@ fn main() -> Result<()> {
                         clang_path,
                         clang_args,
                     },
-            } => build::build_project(manifest_path.as_ref(), clang_path.as_ref(), clang_args),
+            } => build::build_project(manifest_path.as_deref(), clang_path.as_deref(), clang_args),
             Command::Gen {
                 manifest_path,
                 rustfmt_path,
                 object,
             } => gen::gen(
-                manifest_path.as_ref(),
-                rustfmt_path.as_ref(),
-                object.as_ref(),
+                manifest_path.as_deref(),
+                rustfmt_path.as_deref(),
+                object.as_deref(),
             ),
             Command::Make {
                 manifest_path,
@@ -146,11 +146,11 @@ fn main() -> Result<()> {
                 cargo_build_args,
                 rustfmt_path,
             } => make::make(
-                manifest_path.as_ref(),
-                clang_path.as_ref(),
+                manifest_path.as_deref(),
+                clang_path.as_deref(),
                 clang_args,
                 cargo_build_args,
-                rustfmt_path.as_ref(),
+                rustfmt_path.as_deref(),
             ),
         },
     }

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::bail;
@@ -13,11 +13,11 @@ use crate::build;
 use crate::gen;
 
 pub fn make(
-    manifest_path: Option<&PathBuf>,
-    clang: Option<&PathBuf>,
+    manifest_path: Option<&Path>,
+    clang: Option<&Path>,
     clang_args: Vec<OsString>,
     cargo_build_args: Vec<String>,
-    rustfmt_path: Option<&PathBuf>,
+    rustfmt_path: Option<&Path>,
 ) -> Result<()> {
     debug!("Compiling BPF objects");
     build::build_project(manifest_path, clang, clang_args)

--- a/libbpf-cargo/src/metadata.rs
+++ b/libbpf-cargo/src/metadata.rs
@@ -132,7 +132,7 @@ fn get_package(package: &Package, workspace_target_dir: &Path) -> Result<Vec<Unp
 }
 
 /// Returns the `target_directory` and a list of objects to compile.
-pub(crate) fn get(manifest_path: Option<&PathBuf>) -> Result<(PathBuf, Vec<UnprocessedObj>)> {
+pub(crate) fn get(manifest_path: Option<&Path>) -> Result<(PathBuf, Vec<UnprocessedObj>)> {
     let mut cmd = MetadataCommand::new();
 
     if let Some(path) = manifest_path {
@@ -144,12 +144,12 @@ pub(crate) fn get(manifest_path: Option<&PathBuf>) -> Result<(PathBuf, Vec<Unpro
         bail!("Failed to find targets")
     }
 
-    let target_directory = metadata.target_directory.clone().into_std_path_buf();
+    let target_directory = &metadata.target_directory.as_std_path();
     let mut v: Vec<UnprocessedObj> = Vec::new();
     for id in &metadata.workspace_members {
         for package in &metadata.packages {
             if id == &package.id {
-                let vv = &mut get_package(package, &target_directory)
+                let vv = &mut get_package(package, target_directory)
                     .with_context(|| format!("Failed to process package={}", package.name))?;
                 let () = v.append(vv);
             }


### PR DESCRIPTION
It makes no sense to pass around `Option<&PathBuf>` object: `Option<&Path>`
is more flexible on each axis. Switch to using the latter.