### PR TITLE
libbpf-cargo: Update cargo_metadata to 0.19.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           # Please adjust README and rust-version field in Cargo.toml files when
           # bumping version.
-          toolchain: 1.71.0
+          toolchain: 1.78.0
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -368,6 +368,8 @@ name = "libbpf-rs-dev"
 version = "0.0.0"
 dependencies = [
  "libbpf-sys",
+ "serde",
+ "serde_json",
  "tempfile",
  "vmlinux",
 ]
@@ -606,9 +608,9 @@ checksum = "216e81fcf486280f0b8b18ca43ceafd32739eb0eb703eb024a8d00814eeba556"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -857,9 +859,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -952,18 +954,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.25.0-beta.1"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.78"
 license = "LGPL-2.1-only OR BSD-2-Clause"
 repository = "https://github.com/libbpf/libbpf-rs"
 homepage = "https://github.com/libbpf/libbpf-rs"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
   - Removed `--quiet` option of `libbpf make` sub-command
 - Fixed handling of multiple types of same name in BTF by enumerating
   them in the generated skeleton
+- Bumped minimum Rust version to `1.78`
 
 
 0.25.0-beta.1

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -29,8 +29,8 @@ path = "src/lib.rs"
 default = ["libbpf-rs/default"]
 
 [dependencies]
-anyhow = "1.0.1"
-cargo_metadata = "0.15.0"
+anyhow = "1.0.40"
+cargo_metadata = "0.19.1"
 env_logger = { version = "0.11.6", default-features = false, features = ["auto-color", "humantime"] }
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
 log = "0.4.25"

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml)
-[![rustc](https://img.shields.io/badge/rustc-1.71+-blue.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.78+-blue.svg)](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html)
 
 # libbpf-cargo
 

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/libbpf/libbpf-rs/actions/workflows/test.yml)
-[![rustc](https://img.shields.io/badge/rustc-1.71+-blue.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.78+-blue.svg)](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html)
 
 # libbpf-rs
 

--- a/libbpf-rs/dev/Cargo.toml
+++ b/libbpf-rs/dev/Cargo.toml
@@ -20,5 +20,14 @@ dont-generate-test-files = []
 
 [build-dependencies]
 libbpf-sys = { version = "1.4.1", default-features = false, optional = true }
-tempfile = { version = "3.3", optional = true }
+tempfile = { version = "3.15", optional = true }
 vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+
+[dev-dependencies]
+# A set of unused dependencies that we require to force correct minimum versions
+# of transitive dependencies, for cases where our dependencies have incorrect
+# dependency specifications themselves.
+# error: unknown serde variant attribute `untagged`
+_serde_unused = { package = "serde", version = "1.0.200" }
+# error[E0277]: the trait bound `serde_json::Value: Hash` is not satisfied
+_serde_json_unused = { package = "serde_json", version = "1.0.137" }

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -56,7 +56,7 @@ pub fn c_char_slice_to_cstr(s: &[c_char]) -> Option<&CStr> {
 
 /// Round up a number to the next multiple of `r`
 pub fn roundup(num: usize, r: usize) -> usize {
-    ((num + (r - 1)) / r) * r
+    num.div_ceil(r) * r
 }
 
 /// Get the number of CPUs in the system, e.g., to interact with per-cpu maps.
@@ -194,16 +194,10 @@ mod tests {
         assert_eq!(c_char_slice_to_cstr(&slice), None);
 
         let slice = [0];
-        assert_eq!(
-            c_char_slice_to_cstr(&slice).unwrap(),
-            CStr::from_bytes_with_nul(b"\0").unwrap()
-        );
+        assert_eq!(c_char_slice_to_cstr(&slice).unwrap(), c"");
 
         let slice = ['a' as _, 'b' as _, 'c' as _, 0 as _];
-        assert_eq!(
-            c_char_slice_to_cstr(&slice).unwrap(),
-            CStr::from_bytes_with_nul(b"abc\0").unwrap()
-        );
+        assert_eq!(c_char_slice_to_cstr(&slice).unwrap(), c"abc");
 
         // Missing terminating NUL byte.
         let slice = ['a' as _, 'b' as _, 'c' as _];


### PR DESCRIPTION
Update the `cargo_metadata` dependency to version `0.19.1`, in order to get the latest and greatest.