### PR TITLE
Introduce required-checks CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,3 +245,21 @@ jobs:
         run: sudo apt-get install --yes --no-install-recommends libelf-dev
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc --locked --no-deps
+
+  required-checks:
+    needs: [
+      build-aarch64,
+      build-armhf,
+      build-capable,
+      build-features,
+      build-minimum,
+      cargo-doc,
+      clippy,
+      run-tcp-ca,
+      rustfmt,
+      test,
+    ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
GitHub Actions comes with an auto-merge feature, which allows for automatically merging PRs once certain requirements are met. For us, these requirements would be the passing of all CI checks. Alas, their !@#*&()$&@!(#* configuration requires us to explicitly list all CI jobs that need to pass, which is an absolute maintenance nightmare. To improve on the situation at least somewhat, introduce a job that captures all required checks, so that the definition of this arbitrary entity is at least co-located with the definition of these jobs and not hidden behind four layers of clicky-bunti UI fluff.

The logic is adapted from:
https://github.com/orgs/community/discussions/75568#discussioncomment-10351973