### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Please make sure that each `unsafe` block your code requires is accompanied by a
 `SAFETY` comment. Similar for `unsafe` functions. These comments should state
 why required invariants are upheld at the callsite or what invariants exist,
 respectively. Please refer to the [Standard Library Developer's
-Guide](https://std-dev-guide.rust-lang.org/documentation/safety-comments.html#safety-comments).
+Guide](https://std-dev-guide.rust-lang.org/policy/safety-comments.html).
 
 - **Accompany your code with tests.**
 Please make an effort to add regression tests for bug fixes and unit or


### PR DESCRIPTION
The link to `Safety comments` is broken, fix it.
