### PR TITLE
examples/bpf_query: Fix disassemble output

### DIFF
--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -39,7 +39,7 @@ fn prog(args: ProgArgs) {
             {
                 use iced_x86::Formatter;
 
-                let mut d = iced_x86::Decoder::new(32, &prog.jited_prog_insns, 0);
+                let mut d = iced_x86::Decoder::new(64, &prog.jited_prog_insns, 0);
                 let mut f = iced_x86::GasFormatter::new();
                 while d.can_decode() {
                     let ip = d.ip();


### PR DESCRIPTION
The BPF prog disassemble output seems incorrect compared to bpftool. 
Change the bitness to 64 fix this.
