### PR TITLE
libbpf-rs: Make func_name optional for uprobe attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ version = "0.25.0-beta.1"
 dependencies = [
  "bitflags 2.8.0",
  "cc",
+ "goblin",
  "libbpf-rs",
  "libbpf-rs-dev",
  "libbpf-sys",

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -45,6 +45,7 @@ libbpf-sys = { version = "1.4.1", default-features = false, optional = true }
 tempfile = { version = "3.3", optional = true }
 
 [dev-dependencies]
+goblin = "0.9.3"
 libbpf-rs = {path = ".", features = ["generate-test-files"]}
 libbpf-rs-dev = {path = "dev", features = ["generate-test-files"]}
 log = "0.4.4"

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1684,7 +1684,7 @@ fn test_object_uprobe_with_opts() {
     let path = current_exe().expect("failed to find executable name");
     let func_offset = 0;
     let opts = UprobeOpts {
-        func_name: "uprobe_target".to_string(),
+        func_name: Some("uprobe_target".into()),
         ..Default::default()
     };
     let _link = prog
@@ -1713,7 +1713,7 @@ fn test_object_uprobe_with_cookie() {
     let path = current_exe().expect("failed to find executable name");
     let func_offset = 0;
     let opts = UprobeOpts {
-        func_name: "uprobe_target".to_string(),
+        func_name: Some("uprobe_target".into()),
         cookie: cookie_val.into(),
         ..Default::default()
     };


### PR DESCRIPTION
Change UprobeOpts::func_name to Option<String> 
so that user can attach uprobe to specifc offset in binary. 
This would be useful for target that have symbol stripped.
