### PR TITLE
Add direct links to documentation

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+documentation = "https://docs.rs/libbpf-cargo"
 description = "Cargo plugin to build bpf programs"
 readme = "README.md"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+documentation = "https://docs.rs/libbpf-rs"
 description = "libbpf-rs is a safe, idiomatic, and opinionated wrapper around libbpf-sys"
 readme = "README.md"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]


### PR DESCRIPTION
Make the URL to the documentation of each of the library crates known so that it will be easier to click through to it from a crates.io search.