### PR TITLE
Stop specifying version for vmlinux dependency

### DIFF
--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 anyhow = "1.0.4"

--- a/examples/netfilter_blocklist/Cargo.toml
+++ b/examples/netfilter_blocklist/Cargo.toml
@@ -6,7 +6,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [[bin]]
 name = "netfilter_blocklist"

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 clap = { version = "4.0.32", features = ["derive"] }

--- a/examples/tcp_option/Cargo.toml
+++ b/examples/tcp_option/Cargo.toml
@@ -6,7 +6,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tcp_option/src/main.rs
+++ b/examples/tcp_option/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
         .unwrap()
         .into_raw_fd();
 
-    let _kprobe = skel
+    let _link = skel
         .progs
         .sockops_write_tcp_options
         .attach_cgroup(cgroup_fd)

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -10,7 +10,7 @@ name = "proxy"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
The vmlinux crate isn't really versioned as such, as the only compatibility guarantee provided is that git history won't be clobbered. There is also no intention of publishing it.
As such, there is no point in specifying a version -- the SHA1 pinning the git commit is sufficient. Remove any version specifications.