### PR TITLE
Add CHANGELOG entry for #1096

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added `max_entries` getter to various map types
+- Adjusted `UprobeOpts::func_name` to be an `Option`
 - Implemented `Sync` for `Link`
 
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -53,6 +53,10 @@ pub struct UprobeOpts {
     /// `func_name` and use `func_offset` argument to specify offset within the
     /// function. Shared library functions must specify the shared library
     /// binary_path.
+    ///
+    /// If `func_name` is `None`, `func_offset` will be treated as the
+    /// absolute offset of the symbol to attach to, rather than a
+    /// relative one.
     pub func_name: Option<String>,
     #[doc(hidden)]
     pub _non_exhaustive: (),


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1096, which adjusted the `UprobeOpts::func_name member` to be an Option. Also improve the documentation for the same slightly, by covering the `None` case.