### PR TITLE
add: binding for `set_autoattach`

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -239,6 +239,12 @@ impl<'obj> OpenProgramMut<'obj> {
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
+    /// Set whether a bpf program should be automatically attached by default
+    /// when the bpf object is loaded.
+    pub fn set_autoattach(&mut self, autoload: bool) {
+        unsafe { libbpf_sys::bpf_program__set_autoattach(self.ptr.as_ptr(), autoload) };
+    }
+
     #[allow(missing_docs)]
     pub fn set_attach_target(
         &mut self,


### PR DESCRIPTION
Add binding for `bpf_program__set_autoattach` as discussed in #1085 . 
`bpf_program__set_autoattach` is of type `void`. So, no return checks are needed. 

Thanks to @mmullin-halcyon