### PR TITLE
Add CHANGELOG entry for #1106

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added `max_entries` getter to various map types
+- Added `OpenProgramMut::set_autoattach`
 - Adjusted `UprobeOpts::func_name` to be an `Option`
 - Implemented `Sync` for `Link`
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -241,8 +241,8 @@ impl<'obj> OpenProgramMut<'obj> {
 
     /// Set whether a bpf program should be automatically attached by default
     /// when the bpf object is loaded.
-    pub fn set_autoattach(&mut self, autoload: bool) {
-        unsafe { libbpf_sys::bpf_program__set_autoattach(self.ptr.as_ptr(), autoload) };
+    pub fn set_autoattach(&mut self, autoattach: bool) {
+        unsafe { libbpf_sys::bpf_program__set_autoattach(self.ptr.as_ptr(), autoattach) };
     }
 
     #[allow(missing_docs)]


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1106, which added the `OpenProgramMut::set_autoattach()` functionality.