### PR TITLE
Add a few program attach variants

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,10 @@
 Unreleased
 ----------
+- Added kprobe multi support for attaching programs, with and without providing
+  additional options
+- Allow to provide additional options when attaching programs to raw
+  tracepoints
+- Allow to provide additional options when attaching programs to kprobes
 - Added `max_entries` getter to various map types
 - Added `OpenProgramMut::set_autoattach`
 - Adjusted `UprobeOpts::func_name` to be an `Option`

--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -354,6 +354,14 @@ impl Error {
         Self::with_io_error(io::ErrorKind::InvalidData, error)
     }
 
+    #[inline]
+    pub(crate) fn with_invalid_input<E>(error: E) -> Self
+    where
+        E: ToString,
+    {
+        Self::with_io_error(io::ErrorKind::InvalidInput, error)
+    }
+
     /// Retrieve a rough error classification in the form of an
     /// [`ErrorKind`].
     #[inline]

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -152,6 +152,7 @@ pub use crate::program::ProgramAttachType;
 pub use crate::program::ProgramImpl;
 pub use crate::program::ProgramMut;
 pub use crate::program::ProgramType;
+pub use crate::program::RawTracepointOpts;
 pub use crate::program::TracepointOpts;
 pub use crate::program::UprobeOpts;
 pub use crate::program::UsdtOpts;

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -142,6 +142,7 @@ pub use crate::print::set_print;
 pub use crate::print::PrintCallback;
 pub use crate::print::PrintLevel;
 pub use crate::program::Input as ProgramInput;
+pub use crate::program::KprobeMultiOpts;
 pub use crate::program::OpenProgram;
 pub use crate::program::OpenProgramImpl;
 pub use crate::program::OpenProgramMut;

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -143,6 +143,7 @@ pub use crate::print::PrintCallback;
 pub use crate::print::PrintLevel;
 pub use crate::program::Input as ProgramInput;
 pub use crate::program::KprobeMultiOpts;
+pub use crate::program::KprobeOpts;
 pub use crate::program::OpenProgram;
 pub use crate::program::OpenProgramImpl;
 pub use crate::program::OpenProgramMut;

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -139,6 +139,32 @@ impl From<RawTracepointOpts> for libbpf_sys::bpf_raw_tracepoint_opts {
     }
 }
 
+/// Options to optionally be provided when attaching to a kprobe.
+#[derive(Clone, Debug, Default)]
+pub struct KprobeOpts {
+    /// Custom user-provided value accessible through `bpf_get_attach_cookie`.
+    pub cookie: u64,
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl From<KprobeOpts> for libbpf_sys::bpf_kprobe_opts {
+    fn from(opts: KprobeOpts) -> Self {
+        let KprobeOpts {
+            cookie,
+            _non_exhaustive,
+        } = opts;
+
+        #[allow(clippy::needless_update)]
+        libbpf_sys::bpf_kprobe_opts {
+            sz: size_of::<Self>() as _,
+            bpf_cookie: cookie,
+            // bpf_kprobe_opts might have padding fields on some platform
+            ..Default::default()
+        }
+    }
+}
+
 /// Options to optionally be provided when attaching to multiple kprobes.
 #[derive(Clone, Debug, Default)]
 pub struct KprobeMultiOpts {
@@ -897,6 +923,34 @@ impl<'obj> ProgramMut<'obj> {
         let func_name_ptr = func_name.as_ptr();
         let ptr = unsafe {
             libbpf_sys::bpf_program__attach_kprobe(self.ptr.as_ptr(), retprobe, func_name_ptr)
+        };
+        let ptr = validate_bpf_ret(ptr).context("failed to attach kprobe")?;
+        // SAFETY: the pointer came from libbpf and has been checked for errors.
+        let link = unsafe { Link::new(ptr) };
+        Ok(link)
+    }
+
+    /// Attach this program to a [kernel
+    /// probe](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html),
+    /// providing additional options.
+    pub fn attach_kprobe_with_opts<T: AsRef<str>>(
+        &self,
+        retprobe: bool,
+        func_name: T,
+        opts: KprobeOpts,
+    ) -> Result<Link> {
+        let func_name = util::str_to_cstring(func_name.as_ref())?;
+        let func_name_ptr = func_name.as_ptr();
+
+        let mut opts = libbpf_sys::bpf_kprobe_opts::from(opts);
+        opts.retprobe = retprobe;
+
+        let ptr = unsafe {
+            libbpf_sys::bpf_program__attach_kprobe_opts(
+                self.ptr.as_ptr(),
+                func_name_ptr,
+                &opts as *const _,
+            )
         };
         let ptr = validate_bpf_ret(ptr).context("failed to attach kprobe")?;
         // SAFETY: the pointer came from libbpf and has been checked for errors.

--- a/libbpf-rs/tests/bin/src/kprobe.bpf.c
+++ b/libbpf-rs/tests/bin/src/kprobe.bpf.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+SEC("kprobe/bpf_fentry_test1")
+int handle__kprobe(void *ctx)
+{
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
The following variants are added to attach a program:
- Kprobe multi, with and without providing additional options.
- Kprobe with additional options.
- Raw tracepoint with addition options.

The main motivation is 1) kprobe multi has significant performance benefits and 2) using additional options allows to use BPF cookies in probes.

In addition tests for raw tracepoints are added (for the existing support and for the new variant added), as well as basic tests for all kprobe variants (excluding kretprobes).

A few things to note wrt. to reviews:
- `attach_kprobe_with_opts` kept the `kretprobe` flag as an argument even though it is part of the underlying `libbpf-sys` options struct. It felt more natural IMO to keep this flag visible and in sync with the normal kprobe API, but this can be changed easily.
- The kprobe tests are quite minimal. The difficulty of having kprobe tests is the stability of the probed functions, they could disappear without notice (kernel version, inlined, etc). The approach here was to use the exposed testing kfuncs, which should be a bit more stable and not inlined. There will always be a risk though. Also using this approach prevents from actually doing something in the probe as we can't trigger it. The patch can be removed if not wanted.