### PR TITLE
Make attach_kprobe_multi consistent with attach_kprobe

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -991,8 +991,8 @@ impl<'obj> ProgramMut<'obj> {
     /// at once.
     pub fn attach_kprobe_multi<T: AsRef<str>>(
         &self,
-        symbols: Vec<T>,
         retprobe: bool,
+        symbols: Vec<T>,
     ) -> Result<Link> {
         let cnt = Self::check_kprobe_multi_args(&symbols, &[])?;
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1665,7 +1665,7 @@ fn test_object_kprobe_multi() {
     let mut obj = open_obj.load().expect("failed to load object");
     let prog = get_prog_mut(&mut obj, "handle__kprobe");
     let _link = prog
-        .attach_kprobe_multi(vec!["bpf_fentry_test1", "bpf_fentry_test2"], false)
+        .attach_kprobe_multi(false, vec!["bpf_fentry_test1", "bpf_fentry_test2"])
         .expect("failed to attach prog");
 }
 


### PR DESCRIPTION
The attach_kprobe helper has a kretprobe boolean as a first argument and then the target name. The attach_kprobe_multi helper has similar arguments, but in the inverse order. Reorder them to make the API consistent.

This shouldn't break production software as the kprobe multi support isn't part of an official release yet.
