### PR TITLE
Add CHANGELOG entry for #1119

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -7,8 +7,10 @@ Unreleased
 - Allow to provide additional options when attaching programs to kprobes
 - Added `max_entries` getter to various map types
 - Added `OpenProgramMut::set_autoattach`
+- Added additional `ProgramAttachType` variants
 - Adjusted `UprobeOpts::func_name` to be an `Option`
 - Implemented `Sync` for `Link`
+- Updated `libbpf-sys` dependency to `1.5.0`
 
 
 0.25.0-beta.1


### PR DESCRIPTION
Add a CHANGELOG entry or pull request #1119, which bumped the libbpf-sys dependency and added new program attach type variants.