### PR TITLE
Release 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.25.0-beta.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.25.0-beta.1"
+version = "0.25.0"
 dependencies = [
  "bitflags 2.8.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.25.0-beta.1"
+version = "0.25.0"
 edition = "2021"
 rust-version = "1.78"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0
+------
 - Removed `SkeletonBuilder::skip_clang_version_check` and
   `SkeletonBuilder::debug`
 - Removed `--skip-clang-version-checks` option of `libbpf build`

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ default = ["libbpf-rs/default"]
 anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
 env_logger = { version = "0.11.6", default-features = false, features = ["auto-color", "humantime"] }
-libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "0.25", default-features = false, path = "../libbpf-rs" }
 log = "0.4.25"
 memmap2 = "0.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -12,7 +12,7 @@ Helps you build and develop BPF programs with standard Rust tooling.
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [build-dependencies]
-libbpf-cargo = "=0.25.0-beta.1"
+libbpf-cargo = "0.25"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.25.0
+------
 - Added kprobe multi support for attaching programs, with and without providing
   additional options
 - Allow to provide additional options when attaching programs to raw

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -12,7 +12,7 @@ Idiomatic Rust wrapper around [libbpf](https://github.com/libbpf/libbpf).
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [dependencies]
-libbpf-rs = "=0.25.0-beta.1"
+libbpf-rs = "0.25"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).


### PR DESCRIPTION
Prepare for release of 0.25.0 by bumping both libbpf-rs and libbpf-cargo versions accordingly.