### PR TITLE
libbpf-rs: add missing link types

### DIFF
--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -91,6 +91,8 @@ fn link() {
             query::LinkTypeInfo::StructOps(_) => "structops",
             query::LinkTypeInfo::KprobeMulti(_) => "kprobemulti",
             query::LinkTypeInfo::UprobeMulti(_) => "uprobemulti",
+            query::LinkTypeInfo::SockMap(_) => "sockmap",
+            query::LinkTypeInfo::PerfEvent => "perf_event",
         };
 
         println!(

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -771,6 +771,10 @@ pub enum LinkTypeInfo {
     Tcx(TcxLinkInfo),
     /// Link type for netkit programs.
     Netkit(NetkitLinkInfo),
+    /// Link type for sockmap programs.
+    SockMap(SockMapLinkInfo),
+    /// Link type for perf-event programs.
+    PerfEvent,
     /// Unknown link type.
     Unknown,
 }
@@ -869,6 +873,13 @@ impl LinkInfo {
                     pid: unsafe { s.__bindgen_anon_1.uprobe_multi.pid },
                 })
             }
+            libbpf_sys::BPF_LINK_TYPE_SOCKMAP => LinkTypeInfo::SockMap(SockMapLinkInfo {
+                map_id: unsafe { s.__bindgen_anon_1.sockmap.map_id },
+                attach_type: ProgramAttachType::from(unsafe {
+                    s.__bindgen_anon_1.sockmap.attach_type
+                }),
+            }),
+            libbpf_sys::BPF_LINK_TYPE_PERF_EVENT => LinkTypeInfo::PerfEvent,
             _ => LinkTypeInfo::Unknown,
         };
 


### PR DESCRIPTION
We have moved to the libbpf-sys v1.5. Added sockmap link type now. 
Perf-event link type was missed in the previous pr. 