### PR TITLE
Add CHANGELOG entry for #1114

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Added kprobe multi support for attaching programs, with and without providing
   additional options
+- Introduced `TracepointCategory` enum for specifying tracepoint
+  categories
 - Allow to provide additional options when attaching programs to raw
   tracepoints
 - Allow to provide additional options when attaching programs to kprobes


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1114, which introduced the `TracepointCategory` enumeration.