### PR TITLE
libbpf-cargo: Relax env_logger version constraint

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -32,7 +32,7 @@ default = ["libbpf-rs/default"]
 [dependencies]
 anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
-env_logger = { version = "0.11.6", default-features = false, features = ["auto-color", "humantime"] }
+env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
 log = "0.4.25"
 memmap2 = "0.5"


### PR DESCRIPTION
There is no reason for us to depend on env_logger 0.11.6 or higher specifically, anything from the 0.11 branch will do. Relax the version constraint.