### PR TITLE
libbpf-cargo: Relax log version constraint

### DIFF
--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false, path = "../libbpf-rs" }
-log = "0.4.25"
+log = "0.4.14"
 memmap2 = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
There is no reason for us to depend on log 0.4.25 or higher specifically, anything from the 0.4 branch will do. Relax the version constraint.