### PR TITLE
Run apt-get update before installing packages in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         components: rustfmt
     - name: Install deps
       run: |
+        sudo apt-get update
         sudo apt-get install --yes --no-install-recommends clang-18 libelf-dev zlib1g-dev linux-headers-$(uname -r)
         sudo ln -s /usr/include/asm-generic /usr/include/asm
         sudo rm -f /bin/clang && sudo ln -s /usr/bin/clang-18 /bin/clang
@@ -71,6 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
+          sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libelf-dev linux-headers-$(uname -r)
           sudo ln -s /usr/include/asm-generic /usr/include/asm
       - uses: dtolnay/rust-toolchain@nightly
@@ -102,7 +104,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
-        run: sudo apt-get install --yes --no-install-recommends libelf-dev autopoint
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libelf-dev autopoint
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build libbpf-rs sample
@@ -127,6 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
+          sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libelf-dev linux-headers-$(uname -r)
           sudo ln -s /usr/include/asm-generic /usr/include/asm
       - name: Install Nightly Rust
@@ -149,7 +154,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
-        run: sudo apt-get install --yes --no-install-recommends libelf-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libelf-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # `-lzstd` is necessary because Ubuntu's system libelf.a is built
@@ -219,6 +226,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
+          sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libelf-dev linux-headers-$(uname -r)
           sudo ln -s /usr/include/asm-generic /usr/include/asm
       - uses: dtolnay/rust-toolchain@stable
@@ -250,6 +258,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
+          sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libelf-dev linux-headers-$(uname -r)
           sudo ln -s /usr/include/asm-generic /usr/include/asm
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Ubuntu requires us to run `apt-get update` before being able to expect successful package installation, so do that.