### PR TITLE
libbpf-rs: Add suport for repeat and duration in Program{Input,Output}

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 - Implemented `Sync` for `Link`
 - Updated `libbpf-sys` dependency to `1.5.0`
 - Added `Program::attach_perf_event_with_opts` for attaching to perf events.
+- Added `ProgramInput::repeat` field to run a test multiple times.
+- Added `ProgramOutput::duration` field which represent the average duration per repetition.
 
 
 0.25.0-beta.1


### PR DESCRIPTION
The former, when non-zero, is used to run the program `repeat` times. The latter is the number of ns a run took on average.

A test was added to confirm the behaviour. The program bumps a counter, said counter is verified to match `repeat`.