### PR TITLE
Overhaul and reuse workspace-wide Rust lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,16 @@
+# For general information about this file, check
+# https://doc.rust-lang.org/stable/clippy/configuration.html
+
+doc-valid-idents = [
+  "Host1X",
+  "HugeTLB",
+  "InfiniBand",
+  "JITed",
+  "NetFilter",
+  "QLogic",
+  "RxRPC",
+  "SMBus",
+  "SunRPC",
+  "Video4Linux2",
+  "..",
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,10 +111,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build libbpf-rs sample
         run: |
-          cargo init --bin libbpf-rs-test-project
-          cd libbpf-rs-test-project
+          cargo init --bin ../libbpf-rs-test-project
+          cd ../libbpf-rs-test-project
           cat >> Cargo.toml <<EOF
-          libbpf-rs = { path = "../libbpf-rs", ${{ matrix.args }} }
+          libbpf-rs = { path = "../libbpf-rs/libbpf-rs", ${{ matrix.args }} }
           EOF
           cat > src/main.rs <<EOF
           fn main() {
@@ -237,7 +237,7 @@ jobs:
           # We want the old resolver here as it has more suitable feature
           # unification logic for this invocation.
           sed -i 's@resolver = "2"@resolver = "1"@' Cargo.toml
-          cargo clippy --locked --no-deps --all-targets --tests --features=dont-generate-test-files -- -D warnings -D clippy::absolute_paths
+          cargo clippy --locked --no-deps --all-targets --tests --features=dont-generate-test-files -- -D warnings
 
   rustfmt:
     name: Check code formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,34 @@ members = [
   "examples/tproxy",
 ]
 resolver = "2"
+
+[workspace.lints.rust]
+deprecated-safe = "warn"
+future-incompatible = "warn"
+keyword-idents = "warn"
+let-underscore = "warn"
+missing-debug-implementations = "warn"
+missing-docs = "warn"
+trivial-numeric-casts = "warn"
+unexpected_cfgs = {level = "warn", check-cfg = ['cfg(has_procmap_query_ioctl)', 'cfg(has_large_test_files)']}
+unsafe-op-in-unsafe-fn = "warn"
+unused = "warn"
+
+[workspace.lints.clippy]
+collapsible-else-if = "allow"
+collapsible-if = "allow"
+fn-to-numeric-cast = "allow"
+let-and-return = "allow"
+let-unit-value = "allow"
+module-inception = "allow"
+type-complexity = "allow"
+absolute-paths = "warn"
+clone-on-ref-ptr = "warn"
+dbg-macro = "warn"
+doc-markdown = "warn"
+join-absolute-paths = "warn"
+large-enum-variant = "warn"
+redundant-closure-for-method-calls = "warn"
+unchecked-duration-subtraction = "warn"
+uninlined-format-args = "warn"
+wildcard-imports = "warn"

--- a/examples/bpf_query/Cargo.toml
+++ b/examples/bpf_query/Cargo.toml
@@ -12,3 +12,6 @@ clap = { version = "4.0.32", default-features = false, features = ["std", "deriv
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 iced-x86 = "1.20.0"
+
+[lints]
+workspace = true

--- a/examples/bpf_query/src/main.rs
+++ b/examples/bpf_query/src/main.rs
@@ -1,3 +1,5 @@
+//! Example illustrating how to query certain BPF information.
+
 use std::process::exit;
 
 use clap::Parser;
@@ -46,7 +48,7 @@ fn prog(args: ProgArgs) {
                     let insn = d.decode();
                     let mut f_insn = String::new();
                     f.format(&insn, &mut f_insn);
-                    println!("  {}: {}", ip, f_insn);
+                    println!("  {ip}: {f_insn}");
                 }
             }
 

--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -20,3 +20,6 @@ clap = { version = "4.0.32", default-features = false, features = ["std", "deriv
 
 [features]
 static = ["libbpf-rs/static"]
+
+[lints]
+workspace = true

--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `capable` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/capable/src/main.rs
+++ b/examples/capable/src/main.rs
@@ -3,6 +3,9 @@
 // Author Devasia Thomas <https://www.linkedin.com/in/devasiathomas/>
 //
 // Based on capable(8) by Brendan Gregg
+
+//! Example showing basic functionality of capable(8).
+
 use core::time::Duration;
 use std::mem::MaybeUninit;
 use std::str;
@@ -27,7 +30,7 @@ mod capable {
 }
 
 use capable::types::uniqueness;
-use capable::*;
+use capable::CapableSkelBuilder;
 
 static CAPS: phf::Map<i32, &'static str> = phf_map! {
     0i32 => "CAP_CHOWN",

--- a/examples/netfilter_blocklist/Cargo.toml
+++ b/examples/netfilter_blocklist/Cargo.toml
@@ -17,3 +17,6 @@ clap = { version = "4.0.32", default-features = false, features = ["std", "deriv
 ctrlc = "3.2"
 libbpf-rs = { path = "../../libbpf-rs" }
 plain = "0.2"
+
+[lints]
+workspace = true

--- a/examples/netfilter_blocklist/build.rs
+++ b/examples/netfilter_blocklist/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `netfilter_blocklist` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/netfilter_blocklist/src/main.rs
+++ b/examples/netfilter_blocklist/src/main.rs
@@ -1,3 +1,5 @@
+//! A NetFilter blocklist example.
+
 use std::mem::MaybeUninit;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
@@ -26,6 +28,7 @@ mod netfilter {
     ));
 }
 
+#[allow(clippy::wildcard_imports)]
 use netfilter::*;
 
 /// Netfilter Blocklist Example
@@ -51,7 +54,7 @@ fn main() -> Result<()> {
 
     // Install Ctrl-C handler
     let running = Arc::new(AtomicBool::new(true));
-    let r = running.clone();
+    let r = Arc::clone(&running);
     ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
     })?;

--- a/examples/ringbuf_multi/Cargo.toml
+++ b/examples/ringbuf_multi/Cargo.toml
@@ -13,3 +13,6 @@ vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc
 libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 plain = "0.2"
+
+[lints]
+workspace = true

--- a/examples/ringbuf_multi/build.rs
+++ b/examples/ringbuf_multi/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `ringbuf_multi` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/ringbuf_multi/src/main.rs
+++ b/examples/ringbuf_multi/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
+//! Example illustrating `BPF_MAP_TYPE_ARRAY_OF_MAPS` usage.
+
 use core::time::Duration;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
@@ -18,6 +20,7 @@ mod ringbuf_multi {
     ));
 }
 
+#[allow(clippy::wildcard_imports)]
 use ringbuf_multi::*;
 
 unsafe impl Plain for types::sample {}

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -16,3 +16,6 @@ libc = "0.2"
 plain = "0.2"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"]}
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
+
+[lints]
+workspace = true

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `runqslower` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/runqslower/src/main.rs
+++ b/examples/runqslower/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
+//! An example illustrating how to trace run queue latency using BPF.
+
 use std::mem::MaybeUninit;
 use std::str;
 use std::time::Duration;
@@ -21,6 +23,7 @@ mod runqslower {
     ));
 }
 
+#[allow(clippy::wildcard_imports)]
 use runqslower::*;
 
 /// Trace high run queue latency

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -15,3 +15,6 @@ libbpf-rs = { path = "../../libbpf-rs" }
 libc = "0.2"
 nix = { version = "0.28", default-features = false, features = ["net", "user"] }
 clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
+
+[lints]
+workspace = true

--- a/examples/tc_port_whitelist/build.rs
+++ b/examples/tc_port_whitelist/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `rc_port_whitelist` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/tc_port_whitelist/src/main.rs
+++ b/examples/tc_port_whitelist/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+//! An example showing how to block ports using TC.
 
 use std::mem::MaybeUninit;
 use std::os::unix::io::AsFd as _;
@@ -24,7 +24,7 @@ use nix::net::if_::if_nametoindex;
 mod tc {
     include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/tc.skel.rs"));
 }
-use tc::*;
+use tc::TcSkelBuilder;
 
 #[derive(Debug, Parser)]
 struct Command {

--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -15,3 +15,6 @@ clap = { version = "4.0.32", features = ["derive"] }
 # works with that.
 the-original-libbpf-rs = { path = "../../libbpf-rs", package = "libbpf-rs" }
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/examples/tcp_ca/build.rs
+++ b/examples/tcp_ca/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `runqslower` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/tcp_ca/src/main.rs
+++ b/examples/tcp_ca/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
-#![allow(clippy::let_unit_value)]
+//! An example illustrating `struct_opt` usage to change TCP congestion
+//! algorithms.
 
 use std::ffi::c_int;
 use std::ffi::c_void;
@@ -80,7 +81,7 @@ fn set_tcp_ca(fd: BorrowedFd<'_>, tcp_ca: &OsStr) -> Result<()> {
         IPPROTO_TCP,
         TCP_CONGESTION,
         bytes.as_ptr().cast(),
-        bytes.len() as _,
+        bytes.len(),
     )
     .with_context(|| {
         format!(

--- a/examples/tcp_option/Cargo.toml
+++ b/examples/tcp_option/Cargo.toml
@@ -14,3 +14,6 @@ libbpf-rs = { path = "../../libbpf-rs" }
 clap = { version = "4.0.32", features = ["derive"] }
 libc = "0.2"
 ctrlc = "3.2"
+
+[lints]
+workspace = true

--- a/examples/tcp_option/build.rs
+++ b/examples/tcp_option/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `tcp_option` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -18,3 +18,6 @@ clap = { version = "4.0.32", default-features = false, features = ["std", "deriv
 ctrlc = "3.2"
 libbpf-rs = { path = "../../libbpf-rs" }
 nix = { version = "0.28", default-features = false, features = ["net", "user"] }
+
+[lints]
+workspace = true

--- a/examples/tproxy/build.rs
+++ b/examples/tproxy/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the `tproxy` example.
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/examples/tproxy/src/bin/proxy.rs
+++ b/examples/tproxy/src/bin/proxy.rs
@@ -1,3 +1,5 @@
+//! A fake proxy.
+
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::os::unix::io::AsRawFd as _;

--- a/examples/tproxy/src/main.rs
+++ b/examples/tproxy/src/main.rs
@@ -1,3 +1,5 @@
+//! Example implementing the classic iptables TPROXY target.
+
 use std::mem::MaybeUninit;
 use std::net::Ipv4Addr;
 use std::os::unix::io::AsFd as _;
@@ -23,7 +25,7 @@ mod tproxy {
     ));
 }
 
-use tproxy::*;
+use tproxy::TproxySkelBuilder;
 
 /// Transparent proxy driver
 ///
@@ -53,7 +55,7 @@ fn main() -> Result<()> {
 
     // Install Ctrl-C handler
     let running = Arc::new(AtomicBool::new(true));
-    let r = running.clone();
+    let r = Arc::clone(&running);
     ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
     })?;

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -45,3 +45,6 @@ clap = { version = "4.0.32", features = ["derive"] }
 goblin = "0.9"
 test-log = { version = "0.2.16", default-features = false, features = ["log"] }
 vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+
+[lints]
+workspace = true

--- a/libbpf-cargo/src/build.rs
+++ b/libbpf-cargo/src/build.rs
@@ -62,8 +62,9 @@ impl BpfObjBuilder {
     }
 
     /// We're essentially going to run:
-    ///
-    ///   clang -g -O2 -target bpf -c -D__TARGET_ARCH_$(ARCH) runqslower.bpf.c -o runqslower.bpf.o
+    /// ```text
+    /// clang -g -O2 -target bpf -c -D__TARGET_ARCH_$(ARCH) runqslower.bpf.c -o runqslower.bpf.o
+    /// ```
     ///
     /// for each prog.
     fn compile_single(
@@ -297,6 +298,8 @@ fn extract_clang_or_default(clang: Option<&Path>) -> PathBuf {
     }
 }
 
+/// Build the project, assuming necessary skeleton files have already
+/// been generated.
 pub fn build_project(
     manifest_path: Option<&Path>,
     clang: Option<&Path>,

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -787,10 +787,7 @@ impl<'s> GenBtf<'s> {
                         def = format!("std::mem::MaybeUninit::new({def})")
                     }
 
-                    impl_default.push(format!(
-                        r#"            {field_name}: {field_ty_str}"#,
-                        field_ty_str = def
-                    ));
+                    impl_default.push(format!(r#"            {field_name}: {def}"#));
                 }
                 Err(e) => {
                     if gen_impl_default || !t.is_struct {

--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -876,7 +876,7 @@ fn gen_skel_contents(raw_obj_name: &str, obj_file_path: &Path) -> Result<String>
         #[allow(clippy::zero_repeat_side_effects)]
         #[warn(single_use_lifetimes)]
         mod imp {{
-        #[allow(unused_imports)]
+        #[allow(unused_imports, clippy::wildcard_imports)]
         use super::*;
         use libbpf_rs::libbpf_sys;
         use libbpf_rs::skel::OpenSkel;
@@ -1034,8 +1034,8 @@ fn gen_skel_contents(raw_obj_name: &str, obj_file_path: &Path) -> Result<String>
     // Generate struct_ops types before anything else, as they are slightly
     // modified compared to the dumb structure contained in BTF.
     if let Some(btf) = &btf {
-        let gen = GenStructOps::new(btf)?;
-        let () = gen.gen_struct_ops_def(&mut skel)?;
+        let ops = GenStructOps::new(btf)?;
+        let () = ops.gen_struct_ops_def(&mut skel)?;
         write!(
             skel,
             "\
@@ -1045,7 +1045,7 @@ fn gen_skel_contents(raw_obj_name: &str, obj_file_path: &Path) -> Result<String>
             "
         )?;
 
-        let () = gen.gen_dependent_types(&mut processed, &mut skel)?;
+        let () = ops.gen_dependent_types(&mut processed, &mut skel)?;
     } else {
         write!(
             skel,
@@ -1345,7 +1345,8 @@ fn gen_project(manifest_path: Option<&Path>, rustfmt_path: Option<&Path>) -> Res
     Ok(())
 }
 
-pub fn gen(
+/// Generate skeleton files for a project.
+pub fn generate(
     manifest_path: Option<&Path>,
     rustfmt_path: Option<&Path>,
     object: Option<&Path>,

--- a/libbpf-cargo/src/lib.rs
+++ b/libbpf-cargo/src/lib.rs
@@ -55,16 +55,6 @@
 //! build`. This is a convenience command so you don't forget any steps. Alternatively, you could
 //! write a Makefile for your project.
 
-#![allow(clippy::let_unit_value)]
-#![warn(
-    elided_lifetimes_in_paths,
-    missing_debug_implementations,
-    single_use_lifetimes,
-    clippy::absolute_paths,
-    clippy::wildcard_imports
-)]
-#![deny(unsafe_op_in_unsafe_fn)]
-
 pub use build::CompilationOutput;
 
 use std::ffi::OsStr;
@@ -80,7 +70,7 @@ use tempfile::tempdir;
 use tempfile::TempDir;
 
 mod build;
-mod gen;
+mod r#gen;
 mod make;
 mod metadata;
 
@@ -122,6 +112,7 @@ impl Default for SkeletonBuilder {
 }
 
 impl SkeletonBuilder {
+    /// Create a new [`SkeletonBuilder`].
     pub fn new() -> Self {
         SkeletonBuilder {
             source: None,
@@ -201,9 +192,9 @@ impl SkeletonBuilder {
         Ok(comp_output)
     }
 
-    // Build BPF programs without generating a skeleton.
-    //
-    // [`SkeletonBuilder::source`] must be set for this to succeed.
+    /// Build BPF programs without generating a skeleton.
+    ///
+    /// [`SkeletonBuilder::source`] must be set for this to succeed.
     pub fn build(&mut self) -> Result<CompilationOutput> {
         let source = self
             .source
@@ -244,15 +235,15 @@ impl SkeletonBuilder {
             .with_context(|| format!("failed to build `{}`", source.display()))
     }
 
-    // Generate a skeleton at path `output` without building BPF programs.
-    //
-    // [`SkeletonBuilder::obj`] must be set for this to succeed.
+    /// Generate a skeleton at path `output` without building BPF programs.
+    ///
+    /// [`SkeletonBuilder::obj`] must be set for this to succeed.
     pub fn generate<P: AsRef<Path>>(&mut self, output: P) -> Result<()> {
         let objfile = self.obj.as_ref().ok_or_else(|| anyhow!("No object file"))?;
 
-        gen::gen_single(
+        r#gen::gen_single(
             objfile,
-            gen::OutputDest::File(output.as_ref()),
+            r#gen::OutputDest::File(output.as_ref()),
             Some(&self.rustfmt),
         )
         .with_context(|| format!("failed to generate `{}`", objfile.display()))?;
@@ -270,8 +261,8 @@ pub mod __private {
     pub mod build {
         pub use crate::build::build_project;
     }
-    pub mod gen {
-        pub use crate::gen::gen;
+    pub mod r#gen {
+        pub use crate::r#gen::generate;
     }
     pub mod make {
         pub use crate::make::make;

--- a/libbpf-cargo/src/main.rs
+++ b/libbpf-cargo/src/main.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::let_unit_value)]
-#![warn(clippy::absolute_paths)]
+//! The `libbpf-cargo` `cargo` sub-command.
 
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -12,8 +11,8 @@ use clap::Parser;
 use clap::Subcommand;
 
 use libbpf_cargo::__private::build;
-use libbpf_cargo::__private::gen;
 use libbpf_cargo::__private::make;
+use libbpf_cargo::__private::r#gen;
 use log::Level;
 
 
@@ -131,7 +130,7 @@ fn main() -> Result<()> {
                 manifest_path,
                 rustfmt_path,
                 object,
-            } => gen::gen(
+            } => r#gen::generate(
                 manifest_path.as_deref(),
                 rustfmt_path.as_deref(),
                 object.as_deref(),

--- a/libbpf-cargo/src/make.rs
+++ b/libbpf-cargo/src/make.rs
@@ -10,8 +10,10 @@ use log::log_enabled;
 use log::Level::Info;
 
 use crate::build;
-use crate::gen;
+use crate::r#gen;
 
+
+/// Build the project, end-to-end.
 pub fn make(
     manifest_path: Option<&Path>,
     clang: Option<&Path>,
@@ -24,7 +26,7 @@ pub fn make(
         .context("Failed to compile BPF objects")?;
 
     debug!("Generating skeletons");
-    gen::gen(manifest_path, None, rustfmt_path).context("Failed to generate skeletons")?;
+    r#gen::generate(manifest_path, None, rustfmt_path).context("Failed to generate skeletons")?;
 
     let mut cmd = Command::new("cargo");
     cmd.arg("build");

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -21,9 +21,9 @@ use test_log::test;
 
 use crate::build::build_project;
 use crate::build::BpfObjBuilder;
-use crate::gen::GenBtf;
-use crate::gen::GenStructOps;
 use crate::make::make;
+use crate::r#gen::GenBtf;
+use crate::r#gen::GenStructOps;
 use crate::SkeletonBuilder;
 
 /// Creates a temporary directory and initializes a default cargo project inside.
@@ -1190,10 +1190,11 @@ fn test_skeleton_duplicate_struct() {
 
 // -- TEST RUST GENERATION OF BTF PROGRAMS --
 
-/// Searches the Btf struct for a BtfType
+/// Searches the Btf struct for a `BtfType`
 /// returns type identifier <u32> if found
 /// fails calling test if not found, or if duplicates exist
 ///
+/// ```
 /// usage: -- search for basic struct/union/enum with exact match to name
 ///        find_type_in_btf!(<Btf to search in>,
 ///                          <BtfType to search for>,
@@ -1213,6 +1214,7 @@ fn test_skeleton_duplicate_struct() {
 ///                          <&str search name>);
 ///        eg
 ///        let let my_type = find_type_in_btf!(btf, Var, "name");
+/// ```
 macro_rules! find_type_in_btf {
     // match for a named BtfType::Var inside all vars in a Datasec
     ($btf:ident, Var, $name:literal) => {{
@@ -1318,10 +1320,10 @@ fn assert_output(actual_output: &str, expected_output: &str) {
     assert!(eo == ao);
 }
 
-/// Tests the type_definition output of a type_id against a given expected output
+/// Tests the `type_definition` output of a `type_id` against a given expected output
 /// Will trim leading and trailing whitespace from both expected output and from
-/// the generated type_definition
-/// fails calling text if type_definition does not match expected_output
+/// the generated `type_definition`
+/// fails calling text if `type_definition` does not match `expected_output`
 #[track_caller]
 fn assert_definition(btf: &GenBtf<'_>, btf_item: &BtfType<'_>, expected_output: &str) {
     let actual_output = btf
@@ -3094,9 +3096,9 @@ impl Default for bpf_dummy_ops {
     let btf = btf_from_mmap(&mmap);
     let mut processed = HashSet::new();
     let mut def = String::new();
-    let gen = GenStructOps::new(&btf).unwrap();
-    let () = gen.gen_struct_ops_def(&mut def).unwrap();
-    let () = gen.gen_dependent_types(&mut processed, &mut def).unwrap();
+    let ops = GenStructOps::new(&btf).unwrap();
+    let () = ops.gen_struct_ops_def(&mut def).unwrap();
+    let () = ops.gen_dependent_types(&mut processed, &mut def).unwrap();
 
     assert_output(&def, expected_output);
 }

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -62,3 +62,6 @@ test-tag = "0.1"
 # dependency specifications themselves.
 _cc_unused = { package = "cc", version = "1.0.3" }
 _pkg-config_unused = { package = "pkg-config", version = "0.3.3" }
+
+[lints]
+workspace = true

--- a/libbpf-rs/dev/Cargo.toml
+++ b/libbpf-rs/dev/Cargo.toml
@@ -31,3 +31,6 @@ vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc
 _serde_unused = { package = "serde", version = "1.0.200" }
 # error[E0277]: the trait bound `serde_json::Value: Hash` is not satisfied
 _serde_json_unused = { package = "serde_json", version = "1.0.137" }
+
+[lints]
+workspace = true

--- a/libbpf-rs/dev/build.rs
+++ b/libbpf-rs/dev/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+//! Build script for `libbpf-rs-dev`.
 
 use std::env;
 use std::env::consts::ARCH;

--- a/libbpf-rs/dev/lib.rs
+++ b/libbpf-rs/dev/lib.rs
@@ -1,1 +1,1 @@
-
+//! Development-only functionality for `libbpf-rs`.

--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! To find a specific type you can use one of 3 methods
 //!
-//! - [Btf::type_by_name]
-//! - [Btf::type_by_id]
-//! - [Btf::type_by_kind]
+//! - [`Btf::type_by_name`]
+//! - [`Btf::type_by_id`]
+//! - [`Btf::type_by_kind`]
 //!
 //! All of these are generic over `K`, which is any type that can be created from a [`BtfType`],
 //! for all of these methods, not finding any type by the passed parameter or finding a type of
@@ -76,17 +76,17 @@ pub enum BtfKind {
     Restrict,
     /// [Func](types::Func)
     Func,
-    /// [FuncProto](types::FuncProto)
+    /// [`FuncProto`](types::FuncProto)
     FuncProto,
     /// [Var](types::Var)
     Var,
-    /// [DataSec](types::DataSec)
+    /// [`DataSec`](types::DataSec)
     DataSec,
     /// [Float](types::Float)
     Float,
-    /// [DeclTag](types::DeclTag)
+    /// [`DeclTag`](types::DeclTag)
     DeclTag,
-    /// [TypeTag](types::TypeTag)
+    /// [`TypeTag`](types::TypeTag)
     TypeTag,
     /// [Enum64](types::Enum64)
     Enum64,
@@ -312,7 +312,7 @@ impl<'btf> Btf<'btf> {
         self.len() == 0
     }
 
-    /// The number of [BtfType]s in this object.
+    /// The number of [`BtfType`]s in this object.
     pub fn len(&self) -> usize {
         unsafe {
             // SAFETY: the btf pointer is valid.
@@ -351,7 +351,7 @@ impl<'btf> Btf<'btf> {
         }
     }
 
-    /// Find a type by it's [TypeId].
+    /// Find a type by its [`TypeId`].
     pub fn type_by_id<'s, K>(&'s self, type_id: TypeId) -> Option<K>
     where
         K: TryFrom<BtfType<'s>>,
@@ -457,13 +457,6 @@ pub struct BtfType<'btf> {
     type_id: TypeId,
     name: Option<&'btf OsStr>,
     source: &'btf Btf<'btf>,
-    ///  the __bindgen_anon_1 field is a union defined as
-    ///  ```no_run
-    ///  union btf_type__bindgen_ty_1 {
-    ///      size_: u32,
-    ///      type_: u32,
-    ///  }
-    ///  ```
     ty: &'btf libbpf_sys::btf_type,
 }
 
@@ -606,7 +599,7 @@ impl<'btf> BtfType<'btf> {
     /// Given a type, follows the refering type ids until it finds a type that isn't a modifier or
     /// a [`BtfKind::Typedef`].
     ///
-    /// See [is_mod](Self::is_mod).
+    /// See [`is_mod`](Self::is_mod).
     pub fn skip_mods_and_typedefs(&self) -> Self {
         let mut ty = *self;
         loop {
@@ -621,7 +614,7 @@ impl<'btf> BtfType<'btf> {
     /// Returns the alignment of this type, if this type points to some modifier or typedef, those
     /// will be skipped until the underlying type (with an alignment) is found.
     ///
-    /// See [skip_mods_and_typedefs](Self::skip_mods_and_typedefs).
+    /// See [`skip_mods_and_typedefs`](Self::skip_mods_and_typedefs).
     pub fn alignment(&self) -> Result<NonZeroUsize> {
         let skipped = self.skip_mods_and_typedefs();
         match skipped.kind() {
@@ -695,7 +688,7 @@ impl<'btf> BtfType<'btf> {
 ///
 /// # Safety
 ///
-/// It's only safe to implement this for types where the underlying btf_type has a .size set.
+/// It's only safe to implement this for types where the underlying `btf_type` has a .size set.
 ///
 /// See the [docs](https://www.kernel.org/doc/html/latest/bpf/btf.html) for a reference of which
 /// [`BtfKind`] can implement this trait.
@@ -711,7 +704,7 @@ pub unsafe trait HasSize<'btf>: Deref<Target = BtfType<'btf>> + sealed::Sealed {
 ///
 /// # Safety
 ///
-/// It's only safe to implement this for types where the underlying btf_type has a .type set.
+/// It's only safe to implement this for types where the underlying `btf_type` has a .type set.
 ///
 /// See the [docs](https://www.kernel.org/doc/html/latest/bpf/btf.html) for a reference of which
 /// [`BtfKind`] can implement this trait.

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -351,7 +351,7 @@ pub enum IntEncoding {
     None,
     /// Signed.
     Signed,
-    /// It's a c_char.
+    /// It's a `c_char`.
     Char,
     /// It's a bool.
     Bool,
@@ -807,7 +807,7 @@ gen_concrete_type! {
 impl DeclTag<'_> {
     /// The component index is present only when the tag points to a struct/union member or a
     /// function argument.
-    /// And component_idx indicates which member or argument, this decl tag refers to.
+    /// And `component_idx` indicates which member or argument, this decl tag refers to.
     #[inline]
     pub fn component_index(&self) -> Option<u32> {
         self.ptr.component_idx.try_into().ok()
@@ -890,7 +890,7 @@ impl Enum64<'_> {
 ///     }
 /// ```
 ///
-/// NonBinding.
+/// Non-binding.
 ///
 /// ```compile_fail
 ///     BtfKind::Int => {

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -66,18 +66,6 @@
 //!
 //! [See example here](https://github.com/libbpf/libbpf-rs/tree/master/examples/runqslower).
 
-#![allow(clippy::let_and_return, clippy::let_unit_value)]
-#![warn(
-    elided_lifetimes_in_paths,
-    missing_debug_implementations,
-    missing_docs,
-    single_use_lifetimes,
-    clippy::absolute_paths,
-    clippy::wildcard_imports,
-    rustdoc::broken_intra_doc_links
-)]
-#![deny(unsafe_op_in_unsafe_fn)]
-
 pub mod btf;
 mod error;
 mod iter;

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -60,7 +60,7 @@ impl Link {
 
     /// Release "ownership" of underlying BPF resource (typically, a BPF program
     /// attached to some BPF hook, e.g., tracepoint, kprobe, etc). Disconnected
-    /// links, when destructed through bpf_link__destroy() call won't attempt to
+    /// links, when destructed through `bpf_link__destroy()` call won't attempt to
     /// detach/unregistered that BPF resource. This is useful in situations where,
     /// say, attached BPF program has to outlive userspace program that attached it
     /// in the system. Depending on type of BPF program, though, there might be

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -140,7 +140,7 @@ impl ObjectBuilder {
         Ok(self)
     }
 
-    /// Set the pin_root_path for maps that are pinned by name.
+    /// Set the `pin_root_path` for maps that are pinned by name.
     ///
     /// By default, this is NULL which bpf translates to /sys/fs/bpf
     pub fn pin_root_path<T: AsRef<Path>>(&mut self, path: T) -> Result<&mut Self> {

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -39,7 +39,7 @@ pub type PrintCallback = fn(PrintLevel, String);
 /// previous callback had been set, with the intention of restoring it, everything will behave as
 /// expected.
 fn default_callback(_lvl: PrintLevel, msg: String) {
-    let _ = io::stderr().write(msg.as_bytes());
+    let _count = io::stderr().write(msg.as_bytes());
 }
 
 // While we can't say that set_print is thread-safe, because we shouldn't assume that of

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -55,8 +55,7 @@ pub struct UprobeOpts {
     /// To specify function entry, `func_name` should be set while `func_offset`
     /// argument to should be 0. To trace an offset within a function, specify
     /// `func_name` and use `func_offset` argument to specify offset within the
-    /// function. Shared library functions must specify the shared library
-    /// binary_path.
+    /// function. Shared library functions must specify the shared library path.
     ///
     /// If `func_name` is `None`, `func_offset` will be treated as the
     /// absolute offset of the symbol to attach to, rather than a
@@ -393,7 +392,7 @@ impl ProgramType {
     }
 
     /// Detects if host kernel supports the use of a given BPF helper from this BPF program type.
-    /// * `helper_id` - BPF helper ID (enum bpf_func_id) to check support for
+    /// * `helper_id` - BPF helper ID (enum `bpf_func_id`) to check support for
     ///
     /// Make sure the process has required set of CAP_* permissions (or runs as
     /// root) when performing feature checking.
@@ -751,8 +750,7 @@ impl<'obj> Program<'obj> {
         match fd_type {
             BpfObjectType::Program => Ok(fd),
             other => Err(Error::with_invalid_data(format!(
-                "retrieved BPF fd is not a program fd: {:#?}",
-                other
+                "retrieved BPF fd is not a program fd: {other:#?}"
             ))),
         }
     }

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -410,7 +410,7 @@ impl ProgramInfo {
             btf_id: item.btf_id,
             func_info_rec_size: item.func_info_rec_size,
             func_info,
-            line_info: line_info.iter().map(|li| li.into()).collect(),
+            line_info: line_info.iter().map(Into::into).collect(),
             jited_line_info,
             line_info_rec_size: item.line_info_rec_size,
             jited_line_info_rec_size: item.jited_line_info_rec_size,
@@ -690,7 +690,7 @@ pub struct TcxLinkInfo {
     pub attach_type: ProgramAttachType,
 }
 
-/// Information about a BPF struct_ops link.
+/// Information about a BPF `struct_ops` link.
 #[derive(Debug, Clone)]
 pub struct StructOpsLinkInfo {
     /// The ID of the BPF map to which the `struct_ops` link is attached.
@@ -744,9 +744,9 @@ pub enum LinkTypeInfo {
     /// Contains information about the XDP link, such as the interface index
     /// to which the XDP link is attached.
     Xdp(XdpLinkInfo),
-    /// Link type for struct_ops programs.
+    /// Link type for `struct_ops` programs.
     ///
-    /// Contains information about the BPF map to which the struct_ops link is
+    /// Contains information about the BPF map to which the `struct_ops` link is
     /// attached.
     StructOps(StructOpsLinkInfo),
     /// Link type for netfilter programs.

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -167,7 +167,7 @@ pub struct RingBuffer<'cb> {
 impl RingBuffer<'_> {
     /// Poll from all open ring buffers, calling the registered callback for
     /// each one. Polls continually until we either run out of events to consume
-    /// or `timeout` is reached. If `timeout` is Duration::MAX, this will block
+    /// or `timeout` is reached. If `timeout` is `Duration::MAX`, this will block
     /// indefinitely until an event occurs.
     ///
     /// Return the amount of events consumed, or a negative value in case of error.
@@ -182,7 +182,7 @@ impl RingBuffer<'_> {
 
     /// Poll from all open ring buffers, calling the registered callback for
     /// each one. Polls continually until we either run out of events to consume
-    /// or `timeout` is reached. If `timeout` is Duration::MAX, this will block
+    /// or `timeout` is reached. If `timeout` is `Duration::MAX`, this will block
     /// indefinitely until an event occurs.
     pub fn poll(&self, timeout: Duration) -> Result<()> {
         let ret = self.poll_raw(timeout);

--- a/libbpf-rs/src/skeleton.rs
+++ b/libbpf-rs/src/skeleton.rs
@@ -314,7 +314,7 @@ impl Drop for ObjectSkeletonConfig<'_> {
             }
         }
 
-        let _ = unsafe { Box::from_raw(self.inner.obj) };
+        let () = drop(unsafe { Box::from_raw(self.inner.obj) });
     }
 }
 

--- a/libbpf-rs/src/tc.rs
+++ b/libbpf-rs/src/tc.rs
@@ -40,7 +40,7 @@ pub const TC_H_MIN_MASK: u32 = 0x0000FFFF;
 /// more independently from other [`Program`][crate::Program]s.
 ///
 /// This struct exposes operations to create, attach, query and destroy
-/// a bpf_tc_hook using the TC subsystem.
+/// a `bpf_tc_hook` using the TC subsystem.
 ///
 /// Documentation about the libbpf TC interface can be found
 /// [here](https://lwn.net/ml/bpf/20210512103451.989420-3-memxor@gmail.com/).
@@ -165,7 +165,7 @@ impl TcHook {
         self.opts.priority
     }
 
-    /// Query a hook to inspect the program identifier (prog_id)
+    /// Query a hook to inspect the program identifier (`prog_id`)
     pub fn query(&mut self) -> Result<u32> {
         let mut opts = self.opts;
         opts.prog_id = 0;
@@ -180,14 +180,14 @@ impl TcHook {
         }
     }
 
-    /// Attach a filter to the TcHook so that the program starts processing
+    /// Attach a filter to the `TcHook` so that the program starts processing
     ///
     /// Once the hook is processing, changing the values will have no effect unless the hook is
     /// [`Self::attach()`]'d again (`replace=true` being required)
     ///
-    /// Users can create a second hook by changing the handle, the priority or the attach_point and
+    /// Users can create a second hook by changing the handle, the priority or the attach point and
     /// calling the [`Self::attach()`] method again.  Beware doing this.  It might be better to
-    /// Copy the TcHook and change the values on the copied hook for easier [`Self::detach()`]
+    /// Copy the `TcHook` and change the values on the copied hook for easier [`Self::detach()`]
     ///
     /// NOTE: Once a [`TcHook`] is attached, it, and the maps it uses, will outlive the userspace
     /// application that spawned them Make sure to detach if this is not desired
@@ -220,14 +220,14 @@ impl TcHook {
 
     /// Destroy attached filters
     ///
-    /// If called on a hook with an attach_point of `TC_EGRESS`, will detach all egress hooks
+    /// If called on a hook with an `attach_point` of `TC_EGRESS`, will detach all egress hooks
     ///
-    /// If called on a hook with an attach_point of `TC_INGRESS`, will detach all ingress hooks
+    /// If called on a hook with an `attach_point` of `TC_INGRESS`, will detach all ingress hooks
     ///
-    /// If called on a hook with an attach_point of `TC_EGRESS|TC_INGRESS`, will destroy the clsact
-    /// tc qdisc and detach all hooks
+    /// If called on a hook with an `attach_point` of `TC_EGRESS|TC_INGRESS`, will destroy the
+    /// clsact tc qdisc and detach all hooks
     ///
-    /// Will error with EOPNOTSUPP if attach_point is `TC_CUSTOM`
+    /// Will error with `EOPNOTSUPP` if `attach_point` is `TC_CUSTOM`
     ///
     /// It is good practice to query before destroying as the tc qdisc may be used by multiple
     /// programs

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -109,14 +109,14 @@ pub enum BpfObjectType {
 
 /// Get type of BPF object by fd.
 ///
-/// This information is not exported directly by bpf_*_get_info_by_fd() functions,
+/// This information is not exported directly by `bpf_*_get_info_by_fd()` functions,
 /// as kernel relies on the userspace code to know what kind of object it
 /// queries. The type of object can be recovered by fd only from the proc
 /// filesystem. The same approach is used in bpftool.
 pub fn object_type_from_fd(fd: BorrowedFd<'_>) -> Result<BpfObjectType> {
     let fd_link = format!("/proc/self/fd/{}", fd.as_raw_fd());
     let link_type = fs::read_link(fd_link)
-        .map_err(|e| Error::with_invalid_data(format!("can't read fd link: {}", e)))?;
+        .map_err(|e| Error::with_invalid_data(format!("can't read fd link: {e}")))?;
     let link_type = link_type
         .to_str()
         .ok_or_invalid_data(|| "can't convert PathBuf to str")?;
@@ -204,16 +204,16 @@ mod tests {
         assert_eq!(c_char_slice_to_cstr(&slice), None);
     }
 
-    /// Check that object_type_from_fd() doesn't allow descriptors of usual
+    /// Check that `object_type_from_fd()` doesn't allow descriptors of usual
     /// files to be used. Testing with BPF objects requires BPF to be
     /// loaded.
     #[test]
     fn test_object_type_from_fd_with_unexpected_fds() {
         let not_object = NamedTempFile::new().unwrap();
 
-        let _ = object_type_from_fd(not_object.as_fd())
+        let _ty = object_type_from_fd(not_object.as_fd())
             .expect_err("a common file was treated as a BPF object");
-        let _ = object_type_from_fd(io::stdout().as_fd())
+        let _ty = object_type_from_fd(io::stdout().as_fd())
             .expect_err("the stdout fd was treated as a BPF object");
     }
 }

--- a/libbpf-rs/src/xdp.rs
+++ b/libbpf-rs/src/xdp.rs
@@ -13,19 +13,19 @@ bitflags! {
         /// No flags.
         const NONE              = 0;
         /// See [`libbpf_sys::XDP_FLAGS_UPDATE_IF_NOEXIST`].
-        const UPDATE_IF_NOEXIST = libbpf_sys::XDP_FLAGS_UPDATE_IF_NOEXIST as _;
+        const UPDATE_IF_NOEXIST = libbpf_sys::XDP_FLAGS_UPDATE_IF_NOEXIST;
         /// See [`libbpf_sys::XDP_FLAGS_SKB_MODE`].
-        const SKB_MODE          = libbpf_sys::XDP_FLAGS_SKB_MODE as _;
+        const SKB_MODE          = libbpf_sys::XDP_FLAGS_SKB_MODE;
         /// See [`libbpf_sys::XDP_FLAGS_DRV_MODE`].
-        const DRV_MODE          = libbpf_sys::XDP_FLAGS_DRV_MODE as _;
+        const DRV_MODE          = libbpf_sys::XDP_FLAGS_DRV_MODE;
         /// See [`libbpf_sys::XDP_FLAGS_HW_MODE`].
-        const HW_MODE           = libbpf_sys::XDP_FLAGS_HW_MODE as _;
+        const HW_MODE           = libbpf_sys::XDP_FLAGS_HW_MODE;
         /// See [`libbpf_sys::XDP_FLAGS_REPLACE`].
-        const REPLACE           = libbpf_sys::XDP_FLAGS_REPLACE as _;
+        const REPLACE           = libbpf_sys::XDP_FLAGS_REPLACE;
         /// See [`libbpf_sys::XDP_FLAGS_MODES`].
-        const MODES             = libbpf_sys::XDP_FLAGS_MODES as _;
+        const MODES             = libbpf_sys::XDP_FLAGS_MODES;
         /// See [`libbpf_sys::XDP_FLAGS_MASK`].
-        const MASK              = libbpf_sys::XDP_FLAGS_MASK as _;
+        const MASK              = libbpf_sys::XDP_FLAGS_MASK;
     }
 
 }
@@ -85,7 +85,7 @@ impl<'fd> Xdp<'fd> {
         util::parse_ret(err).map(|()| opts)
     }
 
-    /// Query to inspect the program identifier (prog_id)
+    /// Query to inspect the program identifier (`prog_id`)
     pub fn query_id(&self, ifindex: i32, flags: XdpFlags) -> Result<u32> {
         let mut prog_id = 0;
         let err =
@@ -93,7 +93,7 @@ impl<'fd> Xdp<'fd> {
         util::parse_ret(err).map(|()| prog_id)
     }
 
-    /// Replace an existing xdp program (identified by old_prog_fd) with this xdp program
+    /// Replace an existing xdp program (identified by `old_prog_fd`) with this xdp program
     pub fn replace(&self, ifindex: i32, old_prog_fd: BorrowedFd<'_>) -> Result<()> {
         let mut opts = self.attach_opts;
         opts.old_prog_fd = old_prog_fd.as_raw_fd();

--- a/libbpf-rs/tests/common/mod.rs
+++ b/libbpf-rs/tests/common/mod.rs
@@ -125,11 +125,7 @@ pub fn get_symbol_offset(binary_path: &Path, symbol_name: &str) -> Result<usize,
         }
     }
 
-    Err(format!(
-        "Symbol `{}` not found in binary {:?}",
-        symbol_name, binary_path
-    )
-    .into())
+    Err(format!("Symbol `{symbol_name}` not found in binary {binary_path:?}").into())
 }
 
 fn check_symbol_offset(elf: &Elf, sym: &sym::Sym) -> Option<usize> {

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::let_unit_value)]
-#![warn(clippy::absolute_paths)]
+//! End-to-end tests for `libbpf-rs`.
 
 mod common;
 
@@ -777,7 +776,7 @@ fn test_program_loading_fd_from_pinned_path_with_wrong_pin_type() {
     map.pin(path).expect("pinning map failed");
 
     // Must fail, as the pinned path points to a map, not program.
-    let _ = Program::fd_from_pinned_path(path).expect_err("program fd obtained from pinned map");
+    let _err = Program::fd_from_pinned_path(path).expect_err("program fd obtained from pinned map");
 
     map.unpin(path).expect("unpinning program failed");
 }
@@ -832,7 +831,7 @@ fn test_object_program_pin() {
 
     // Backup cleanup method in case test errors
     defer! {
-        let _ = fs::remove_file(path);
+        let _unused = fs::remove_file(path);
     }
 
     // Unpin should be successful
@@ -859,7 +858,7 @@ fn test_object_link_pin() {
 
     // Backup cleanup method in case test errors
     defer! {
-        let _ = fs::remove_file(path);
+        let _unused = fs::remove_file(path);
     }
 
     // Unpin should be successful
@@ -888,7 +887,7 @@ fn test_object_reuse_pined_map() {
 
     // Backup cleanup method in case test errors somewhere
     defer! {
-        let _ = fs::remove_file(path);
+        let _unused = fs::remove_file(path);
     }
 
     // Reuse the pinned map
@@ -1308,7 +1307,7 @@ fn test_object_user_ringbuf_not_enough_space() {
     let _link = prog.attach().expect("failed to attach prog");
     let urb_map = get_map_mut(&mut obj, "user_ringbuf");
     let user_ringbuf = UserRingBuffer::new(&urb_map).expect("failed to create user ringbuf");
-    let _ = user_ringbuf
+    let _sample = user_ringbuf
         .reserve(1024 * 3)
         .expect("failed to reserve space");
     let err = user_ringbuf.reserve(1024 * 3).unwrap_err();
@@ -1985,7 +1984,7 @@ fn test_map_pinned_status() {
     let get_path = map.get_pin_path().expect("get map pin path failed");
     assert_eq!(expected_path, get_path.to_str().unwrap());
     // cleanup
-    let _ = fs::remove_file(expected_path);
+    let _unused = fs::remove_file(expected_path);
 }
 
 /// Change the root_pin_path and see if it works.
@@ -2009,8 +2008,8 @@ fn test_map_pinned_status_with_pin_root_path() {
     let get_path = map.get_pin_path().expect("get map pin path failed");
     assert_eq!(expected_path, get_path.to_str().unwrap());
     // cleanup
-    let _ = fs::remove_file(expected_path);
-    let _ = fs::remove_dir("/sys/fs/bpf/test_namespace");
+    let _unused = fs::remove_file(expected_path);
+    let _unused = fs::remove_dir("/sys/fs/bpf/test_namespace");
 }
 
 /// Check that we can get program fd by id and vice versa.

--- a/libbpf-rs/tests/test_netfilter.rs
+++ b/libbpf-rs/tests/test_netfilter.rs
@@ -1,3 +1,5 @@
+//! Tests for the NetFilter functionality.
+
 #[allow(dead_code)]
 mod common;
 
@@ -34,8 +36,7 @@ fn test_attach_and_detach(obj: &mut Object, protocol_family: i32, hooknum: i32, 
         .attach_netfilter_with_opts(netfilter_opt)
         .unwrap_or_else(|err| {
             panic!(
-                "Failed to attach netfilter protocol {}, hook: {}: {err}",
-                protocol_family, hook_desc
+                "Failed to attach netfilter protocol {protocol_family}, hook: {hook_desc}: {err}"
             )
         });
 
@@ -53,7 +54,7 @@ fn test_attach_and_detach(obj: &mut Object, protocol_family: i32, hooknum: i32, 
     let result = match hooknum {
         NF_INET_PRE_ROUTING | NF_INET_POST_ROUTING => {
             let action = || {
-                let _ = TcpStream::connect(trigger_addr);
+                let _stream = TcpStream::connect(trigger_addr);
             };
             with_ringbuffer(&map, action)
         }

--- a/libbpf-rs/tests/test_print.rs
+++ b/libbpf-rs/tests/test_print.rs
@@ -1,7 +1,7 @@
-//! This test is in its own file because the underlying libbpf_set_print function used by
-//! set_print() and ObjectBuilder::debug() sets global state. The default is to run multiple tests
-//! in different threads, so this test will always race with the others unless its isolated to a
-//! different process.
+//! This test is in its own file because the underlying `libbpf_set_print` function used by
+//! `set_print()` and `ObjectBuilder::debug()` sets global state. The default is to run multiple
+//! tests in different threads, so this test will always race with the others unless its isolated to
+//! a different process.
 //!
 //! For the same reason, all tests here must run serially.
 

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,3 +1,5 @@
+//! Tests for the TC functionality.
+
 #[allow(dead_code)]
 mod common;
 

--- a/libbpf-rs/tests/test_xdp.rs
+++ b/libbpf-rs/tests/test_xdp.rs
@@ -1,3 +1,5 @@
+//! Tests for the XDP functionality.
+
 #[allow(dead_code)]
 mod common;
 


### PR DESCRIPTION
Overhaul the set of Rust lints in use and make them apply in a workspace-wide manner. Fix everything new that is being flagged.