### PR TITLE
libbpf-cargo: Restrict libbpf-sys versions we support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "env_logger",
  "goblin",
  "libbpf-rs",
+ "libbpf-sys",
  "log",
  "memmap2",
  "serde",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -40,6 +40,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3"
 clap = { version = "4.0.32", features = ["derive"] }
+# `libbpf` is unable to provide necessary backwards compatibility
+# guarantees so we have to explicitly opt-in to newer versions...
+libbpf-sys_restricted = { package = "libbpf-sys", version = ">=1.5.0, <=1.5.1", default-features = false }
 
 [dev-dependencies]
 goblin = "0.9"


### PR DESCRIPTION
With version 1.5.0, libbpf has broken backwards compatibility, by requiring the bpf_map_skeleton.link member to be set to non-NULL [0] [1], segfaulting otherwise. This has since been fixed [2], but the maintainer has clarified that such breakage may happen again in the future and is in line with the unarticulated backwards compatibility contract.
Providing a stable interface on an unstable foundation like this is obviously impossible, generally speaking, as we can't anticipate what will break next. As such, we have to resort to restricting the set of supported libbpf(-sys) versions to known good ones. We do that on the libbpf-cargo front, as it's mostly the code gen APIs that are said to be at risk (though who knows...). Furthermore, we anticipate that 1.5.1, which is slated to arrive soon(tm), will be backwards compatible (though who knows...), so we allow-list it in advance.

[0] https://github.com/libbpf/libbpf/commit/e6f1ae25570c95d259eeada63886ed6eada6f201
[1] https://github.com/libbpf/libbpf/commit/bf7ddbef99d0c1e597c12b8b64ccd0c4d0c70282
[2] https://lore.kernel.org/bpf/20250514113220.219095-1-mykyta.yatsenko5@gmail.com/