### PR TITLE
RingBuffer: Introduce consume_raw_n()

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -18,6 +18,7 @@ Unreleased
 - Added `ProgramInput::repeat` field to run a test multiple times
 - Added `ProgramOutput::duration` field which represent the average
   duration per repetition
+- Added `RingBuffer::consume_raw_n` method to consume up to N items
 
 
 0.25.0-beta.1

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -200,6 +200,15 @@ impl RingBuffer<'_> {
     }
 
     /// Greedily consume from all open ring buffers, calling the registered
+    /// callback for each one. Continues until `len` items have been consumed,
+    /// no more events are available, or a callback returns a non-zero value.
+    ///
+    /// Return the amount of events consumed, or a negative value in case of error.
+    pub fn consume_raw_n(&self, len: usize) -> i32 {
+        unsafe { libbpf_sys::ring_buffer__consume_n(self.ptr.as_ptr(), len as libbpf_sys::size_t) }
+    }
+
+    /// Greedily consume from all open ring buffers, calling the registered
     /// callback for each one. Consumes continually until we run out of events
     /// to consume or one of the callbacks returns a non-zero integer.
     pub fn consume(&self) -> Result<()> {

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -986,6 +986,23 @@ fn test_object_ringbuf_raw() {
     // Consume from a (potentially) empty ring buffer using poll()
     let ret = mgr.poll_raw(Duration::from_millis(100));
     assert!(ret >= 0);
+
+    // Call getpid multiple times, to refill the ring buffer.
+    for _ in 1..=10 {
+        unsafe { libc::getpid() };
+    }
+
+    // Consume exactly one item
+    let ret = mgr.consume_raw_n(1);
+    assert!(ret == 1);
+
+    // Consume two items
+    let ret = mgr.consume_raw_n(2);
+    assert!(ret == 2);
+
+    // Consume all the remaining items, but no more than 10
+    let ret = mgr.consume_raw_n(10);
+    assert!((7..=10).contains(&ret));
 }
 
 #[tag(root)]


### PR DESCRIPTION
libbpf provides the ring_buffer__consume_n() API to consume up to a certain amount of items from ringbuffers [1].

Add the new method consume_raw_n() also in RingBuffer to provide the same functionality.

This is needed by sched_ext to allow user-space schedulers (based on scx_rustland_core) to selectively consume task items from BPF ring buffer [2].

[1] https://lore.kernel.org/bpf/20240406092005.92399-1-andrea.righi@canonical.com/
[2] https://github.com/sched-ext/scx/blob/ea361886f714b968092a1ea14bdee8330beb4d5f/rust/scx_rustland_core/assets/bpf.rs#L228