### PR TITLE
examples: ringbuf_multi: include vmlinux.h than linux/bpf.h

### DIFF
--- a/examples/ringbuf_multi/src/bpf/ringbuf_multi.bpf.c
+++ b/examples/ringbuf_multi/src/bpf/ringbuf_multi.bpf.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2020 Facebook
 
-#include <linux/bpf.h>
+#include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Using linux/bpf.h could make compile error. Fix this with using vmlinux.h
