### PR TITLE
Add CHANGELOG entry for #1178

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Adjusted all `<xxx>_data` BPF map skeleton members to be `Option`s
+- Adjusted numbering of generated Rust structs for anonymous C types to be
+  less fragile in the presence of type additions
 - Removed `SkeletonBuilder::skip_clang_version_check` and
   `SkeletonBuilder::debug`
 - Removed `--skip-clang-version-checks` option of `libbpf build`

--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -372,13 +372,13 @@ fn escape_reserved_keyword(identifier: Cow<'_, str>) -> Cow<'_, str> {
 struct BtfDependency {
     /// Name of the dependency parent
     parent_name: Option<String>,
-
     /// Dependency id relative to the parent's `child_counter`
     dep_id: i32,
-
     /// The `child_counter` for the dependency if it is intended to be
     /// a parent itself.
-    /// For an anonymous unit this should be a pointer to the parent's `child_counter`
+    ///
+    /// For an anonymous unit this should be a pointer to the parent's
+    /// `child_counter`
     child_counter: Rc<RefCell<i32>>,
 }
 
@@ -392,8 +392,7 @@ pub(crate) struct TypeMap {
     /// Mapping from type name to the number of times we have seen this
     /// name already.
     names_count: RefCell<HashMap<String, u8>>,
-
-    /// Mapping from type to it's parent. Used in anonymous members naming
+    /// Mapping from type to its parent. Used in anonymous members naming.
     dependency_tree: RefCell<HashMap<TypeId, BtfDependency>>,
 }
 
@@ -412,19 +411,18 @@ impl TypeMap {
 
         let mut dep = pdep.clone();
 
-        // If parent is named, derive it.
-        // Otherwise derive parent's parent
+        // If parent is named, derive it. Otherwise derive parent's parent.
         if let Some(n) = parent.name() {
             dep.parent_name = Some(n.to_string_lossy().to_string());
         }
 
-        // If the current unit is named, self-assign the child_counter.
+        // If the current unit is named, self-assign the `child_counter`.
         // Otherwise derive a parent's one
         if ty.name().is_some() {
             dep.child_counter = Rc::new(RefCell::new(0));
         }
 
-        // Increment parent's `child_counter` and assign the new value to dep_id
+        // Increment parent's `child_counter` and assign the new value to `dep_id`.
         let parent_counter = Rc::clone(&pdep.child_counter);
         *parent_counter.borrow_mut() += 1;
         dep.dep_id = *parent_counter.borrow();


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1178, which adjusted the naming of generated Rust types for anonymous C equivalents.