### PR TITLE
Exempt 'blocked' PRs from auto close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
           days-before-pr-close: 5
           stale-pr-message: 'This pull request is considered stale because it has been open 30 days with no activity. Remove stale label or comment or it will be closed in 5 days.'
           close-pr-message: 'Closing pull request as it is stale.'
+          exempt-pr-labels: blocked


### PR DESCRIPTION
As of commit 48a95e26201b ("Add GitHub workflow to close stale PRs") we automatically close stale PRs after a while. Some PRs, however, may not be actionable at the moment, in which case auto closing is not a desired action.
To cater to such cases, honor the 'blocked' label and exclude PRs with it from staleness detection.