### PR TITLE
Introduce btf_query example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "btf_query"
+version = "0.0.0"
+dependencies = [
+ "libbpf-rs",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "libbpf-rs",
   "libbpf-rs/dev",
   "examples/bpf_query",
+  "examples/btf_query",
   "examples/capable",
   "examples/compiler_warnings",
   "examples/netfilter_blocklist",

--- a/examples/btf_query/Cargo.toml
+++ b/examples/btf_query/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "btf_query"
+version = "0.0.0"
+edition.workspace = true
+authors = ["Daniel Müller <deso@posteo.net>"]
+license = "LGPL-2.1-only OR BSD-2-Clause"
+
+[dependencies]
+libbpf-rs = { path = "../../libbpf-rs" }
+
+[lints]
+workspace = true

--- a/examples/btf_query/src/main.rs
+++ b/examples/btf_query/src/main.rs
@@ -1,0 +1,25 @@
+//! Example illustrating how to query some system BTF information.
+
+use std::ffi::OsStr;
+
+use libbpf_rs::btf;
+use libbpf_rs::btf::types;
+
+
+fn main() {
+    let btf = btf::Btf::from_vmlinux().expect("failed to retrieve vmlinux BTF information");
+    let task_struct = btf
+        .type_by_name::<types::Struct>("task_struct")
+        .expect("failed to find `task_struct` in vmlinux BTF");
+    println!(
+        "struct {:?} has type ID: {}",
+        task_struct.name().unwrap(),
+        task_struct.type_id()
+    );
+
+    // Print names of the first five members, for illustration purposes.
+    println!("first five members:");
+    for member in task_struct.iter().take(5) {
+        println!("\t{:?}", member.name.unwrap_or(OsStr::new("anonymous")));
+    }
+}


### PR DESCRIPTION
Introduce the `btf_query` example, illustrating how to query some properties of the vmlinux BTF information.