### PR TITLE
Rebuild BPF skeleton when header files change

### DIFF
--- a/examples/capable/build.rs
+++ b/examples/capable/build.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use libbpf_cargo::SkeletonBuilder;
 
 const SRC: &str = "src/bpf/capable.bpf.c";
+const HEADER: &str = "src/bpf/capable.h";
 
 fn main() {
     let out = PathBuf::from(
@@ -28,4 +29,5 @@ fn main() {
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");
+    println!("cargo:rerun-if-changed={HEADER}");
 }

--- a/examples/runqslower/build.rs
+++ b/examples/runqslower/build.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use libbpf_cargo::SkeletonBuilder;
 
 const SRC: &str = "src/bpf/runqslower.bpf.c";
+const HEADER: &str = "src/bpf/runqslower.h";
 
 fn main() {
     let out = PathBuf::from(
@@ -28,4 +29,5 @@ fn main() {
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={SRC}");
+    println!("cargo:rerun-if-changed={HEADER}");
 }


### PR DESCRIPTION
Thank you for considering a contribution!

In order to streamline review experience for contributors and reviewers, please
be sure to *read* and *follow* the [Contributor's Guide][cont-guide]. It
lays out basic best practices, which, if followed will reduce unnecessary back
and forth and, ultimately, minimize the time it takes to get your change into
the library.

[cont-guide]: https://github.com/libbpf/libbpf-rs/blob/master/CONTRIBUTING.md

Add monitoring of related header files (*.h) in build.rs to trigger skeleton rebuilding when they are modified, not just when the BPF source (*.bpf.c) changes.