### PR TITLE
example: add task_perf example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,20 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blazesym"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d5caf72227115ce486e764e9199d6eab3437c51dacd78c3fae78ca1340c27d"
+dependencies = [
+ "cpp_demangle",
+ "gimli",
+ "libc",
+ "memmap2 0.9.5",
+ "miniz_oxide",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bpf_query"
@@ -268,6 +288,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +330,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -315,6 +356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "goblin"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +376,12 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -365,6 +423,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,7 +464,7 @@ dependencies = [
  "goblin",
  "libbpf-rs",
  "libbpf-sys",
- "memmap2",
+ "memmap2 0.5.10",
  "serde",
  "serde_json",
  "tempfile",
@@ -504,6 +572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memmem"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -809,6 +896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1057,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -974,6 +1079,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "task_longrun"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blazesym",
+ "clap",
+ "libbpf-cargo",
+ "libbpf-rs",
+ "plain",
+ "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "examples/tcp_ca",
   "examples/tcp_option",
   "examples/tproxy",
+  "examples/task_longrun",
 ]
 resolver = "2"
 

--- a/examples/task_longrun/Cargo.toml
+++ b/examples/task_longrun/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "task_longrun"
+version = "0.1.0"
+edition.workspace = true
+authors = ["Jiawei Zhao <Phoenix500526@163.com>"]
+license = "LGPL-2.1-only OR BSD-2-Clause"
+
+[build-dependencies]
+libbpf-cargo = { path = "../../libbpf-cargo" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+
+[dependencies]
+anyhow = "1.0"
+libbpf-rs = { path = "../../libbpf-rs" }
+plain = "0.2"
+clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
+blazesym = "0.2.0-rc.3"
+
+[lints]
+workspace = true

--- a/examples/task_longrun/build.rs
+++ b/examples/task_longrun/build.rs
@@ -1,0 +1,33 @@
+//! Build script for the `task_longrun` example.
+
+use std::env;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+use libbpf_cargo::SkeletonBuilder;
+
+const SRC: &str = "src/bpf/task_longrun.bpf.c";
+const HEADER: &str = "src/bpf/task_longrun.h";
+
+fn main() {
+    let out = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set in build script"),
+    )
+    .join("src")
+    .join("bpf")
+    .join("task_longrun.skel.rs");
+
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
+    SkeletonBuilder::new()
+        .source(SRC)
+        .clang_args([
+            OsStr::new("-I"),
+            vmlinux::include_path_root().join(arch).as_os_str(),
+        ])
+        .build_and_generate(&out)
+        .unwrap();
+    println!("cargo:rerun-if-changed={SRC}");
+    println!("cargo:rerun-if-changed={HEADER}");
+}

--- a/examples/task_longrun/src/bpf/task_longrun.bpf.c
+++ b/examples/task_longrun/src/bpf/task_longrun.bpf.c
@@ -1,0 +1,82 @@
+#include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include "task_longrun.h"
+
+// Dummy instance to get skeleton to generate definition for `struct event`
+struct event _event = {0};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, PERF_MAX_STACK_DEPTH * sizeof(u64));
+    __uint(max_entries, __NR_STACKS__);
+} stacks SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, struct running_task);
+    __uint(max_entries, 1);
+} running_tasks SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch(u64 *ctx)
+{
+        // TP_PROTO(bool preempt, struct task_struct *prev, struct task_struct *next, struct rq_flags *rf)
+        struct task_struct *prev = (struct task_struct *)ctx[1];
+        struct task_struct *next = (struct task_struct *)ctx[2];
+        s32 cpu = bpf_get_smp_processor_id();
+        u64 now = bpf_ktime_get_ns();
+        struct running_task *t;
+        if (!(t = bpf_map_lookup_elem(&running_tasks, &cpu)))
+                return 0;
+        if (t->running_at && prev->pid) {
+                s64 dur = now - t->running_at;
+                if (dur > runtime_thresh_ns) {
+                        struct event event = {0};
+                        bpf_probe_read_kernel(event.comm, TASK_COMM_LEN, prev->comm);
+                        bpf_probe_read_kernel(event.bt, sizeof(t->bt), t->bt);
+                        event.pid = prev->pid;
+                        event.duration = dur;
+                        event.bt_sample_cnt = t->bt_sample_cnt;
+                        bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+                }
+        }
+        t->running_at = 0;
+        t->bt_at = 0;
+        if (kthread_only && !(next->flags & PF_KTHREAD))
+                return 0;
+        if (percpu_only && next->nr_cpus_allowed != 1)
+                return 0;
+        t->running_at = now;
+        t->bt_at = now;
+        t->bt_sample_cnt = 0;
+        return 0;
+}
+
+
+SEC("kprobe/scheduler_tick")
+void handle__sched_tick(struct pt_regs *ctx)
+{
+        s32 cpu = bpf_get_smp_processor_id();
+        u64 now = bpf_ktime_get_ns();
+        struct running_task *t;
+        u32 stkid, idx;
+        if (!(t = bpf_map_lookup_elem(&running_tasks, &cpu)))
+                return;
+        if (!t->bt_at || now - t->bt_at < backtrace_interval_ns)
+                return;
+        
+        idx = t->bt_sample_cnt++ % __NR_BTS__;
+        t->bt[idx] = bpf_get_stackid(ctx, &stacks, BPF_F_REUSE_STACKID);
+        t->bt_at = now;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/examples/task_longrun/src/bpf/task_longrun.h
+++ b/examples/task_longrun/src/bpf/task_longrun.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __TASK_LONGRUN_H__
+#define __TASK_LONGRUN_H__
+
+#define __NR_STACKS__           32768
+#define __NR_BTS__              64
+#define PERF_MAX_STACK_DEPTH    127
+#define PF_KTHREAD		0x00200000
+#define TASK_COMM_LEN           16
+
+const volatile u64 runtime_thresh_ns = 0;
+const volatile u64 backtrace_interval_ns = 0;
+const volatile bool kthread_only = false;
+const volatile bool percpu_only = false;
+
+struct running_task {
+        u64             running_at;
+        u64             bt_at;
+        u32             bt[__NR_BTS__];
+        u32             bt_sample_cnt;
+        pid_t           pid;
+        u8            comm[TASK_COMM_LEN];
+        u64             ran_for;
+};
+
+struct event {
+        u8              comm[TASK_COMM_LEN];
+        pid_t           pid;
+        u32             bt_sample_cnt;
+        u64             duration;
+        u32             bt[__NR_BTS__];
+};
+
+#endif  /* __TASK_LONGRUN_H__ */

--- a/examples/task_longrun/src/main.rs
+++ b/examples/task_longrun/src/main.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+//! An example illustrating how to trace long running tasks using BPF.
+
+use std::mem::MaybeUninit;
+use std::str;
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use libbpf_rs::skel::OpenSkel;
+use libbpf_rs::skel::Skel;
+use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::MapCore;
+use libbpf_rs::MapFlags;
+use libbpf_rs::PerfBufferBuilder;
+use plain::Plain;
+
+use blazesym::symbolize::source::Kernel;
+use blazesym::symbolize::source::Source;
+use blazesym::symbolize::Input;
+use blazesym::symbolize::Sym;
+use blazesym::symbolize::Symbolized;
+use blazesym::symbolize::Symbolizer;
+
+mod task_longrun {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/task_longrun.skel.rs"
+    ));
+}
+
+#[allow(clippy::wildcard_imports)]
+use task_longrun::*;
+
+/// Trace high run queue latency
+#[derive(Debug, Parser)]
+struct Command {
+    /// Runtime threshold in ms
+    #[arg(short = 't', long, default_value = "100")]
+    thresh_ms: u64,
+    /// Backtrace capture interval in ms
+    #[arg(short = 'i', long, default_value = "10")]
+    backtrace_interval_ms: u64,
+    /// Only consider kernel threads
+    #[arg(short = 'k', long)]
+    kthread_only: bool,
+    /// Only consider percpu threads
+    #[arg(short = 'p', long)]
+    percpu_only: bool,
+}
+
+unsafe impl Plain for task_longrun::types::event {}
+
+fn main() -> Result<()> {
+    let opts = Command::parse();
+
+    let skel_builder = TaskLongrunSkelBuilder::default();
+
+    let mut open_object = MaybeUninit::uninit();
+    let mut open_skel = skel_builder.open(&mut open_object)?;
+    let rodata = open_skel
+        .maps
+        .rodata_data
+        .as_deref_mut()
+        .expect("`rodata` is not memory mapped");
+
+    // Write arguments into prog
+    rodata.runtime_thresh_ns = opts.thresh_ms * 1000000;
+    rodata.backtrace_interval_ns = opts.backtrace_interval_ms * 1000000;
+    rodata.kthread_only = opts.kthread_only;
+    rodata.percpu_only = opts.percpu_only;
+
+    // Begin tracing
+    let mut skel = open_skel.load()?;
+    skel.attach()?;
+    println!("Tracing tasks running longer than {} ms", opts.thresh_ms);
+
+    let stacks = &skel.maps.stacks;
+    let src = Source::Kernel(Kernel::default());
+    let symbolizer = Symbolizer::new();
+
+    let handle_event = move |_cpu: i32, data: &[u8]| {
+        let mut event = task_longrun::types::event::default();
+        plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
+
+        let task = str::from_utf8(&event.comm).unwrap();
+        let duration_ms = event.duration as f64 / 1_000_000.0;
+
+        println!(
+            "{}[{}]  ran_for={:.2}ms  bt_samples={}",
+            task.trim_end_matches(char::from(0)),
+            event.pid,
+            duration_ms,
+            event.bt_sample_cnt
+        );
+        let bt_start = event.bt_sample_cnt.saturating_sub(64) as usize;
+        for bti in bt_start..event.bt_sample_cnt as usize {
+            let stkid = event.bt[bti % 64];
+            match stacks.lookup(&stkid.to_ne_bytes(), MapFlags::empty()) {
+                Ok(Some(stack)) => {
+                    let valid_addrs = stack
+                        .chunks_exact(8)
+                        .map(|chunk| u64::from_ne_bytes(chunk.try_into().unwrap()))
+                        .filter(|&addr| addr != 0)
+                        .collect::<Vec<_>>();
+                    match symbolizer.symbolize(&src, Input::AbsAddr(&valid_addrs)) {
+                        Ok(syms) => {
+                            for sym in syms {
+                                match sym {
+                                    Symbolized::Sym(Sym { name, .. }) => {
+                                        println!("  {name}");
+                                    }
+                                    Symbolized::Unknown(reason) => {
+                                        println!("<no-symbol> ({reason})")
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            println!("Failed to symbolize addresses: {e}");
+                        }
+                    }
+                }
+                Ok(None) => {
+                    println!("  Stack id {stkid} not found");
+                }
+                Err(e) => {
+                    println!("Failed to lookup stack id {stkid}: {e}");
+                }
+            }
+            println!();
+        }
+        println!();
+    };
+
+    let handle_lost_events = move |cpu: i32, count: u64| {
+        eprintln!("Lost {count} events on CPU {cpu}");
+    };
+
+    let perf = PerfBufferBuilder::new(&skel.maps.events)
+        .sample_cb(handle_event)
+        .lost_cb(handle_lost_events)
+        .build()?;
+
+    loop {
+        perf.poll(Duration::from_millis(100))?;
+    }
+}


### PR DESCRIPTION
Cover [the BCC python binding](https://gist.github.com/danielocfb/a294ed6125ac2140d36cad2b6f67a8af) to Rust and libbpf-rs.

The BCC python binding output:
```bash
$ sudo python3 bcc-example.py
...
python3[65497] ran_for=326.51ms bt_seq=17

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  widen_string
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  number
  pointer
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  number
  pointer
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  number
  pointer
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  __lruvec_stat_mod_folio
  do_anonymous_page
  handle_pte_fault
  __handle_mm_fault
  handle_mm_fault
  do_user_addr_fault
  exc_page_fault
  asm_exc_page_fault

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  bsearch
  module_get_kallsym
  update_iter_mod
  update_iter
  s_start
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  clear_page_erms
  get_page_from_freelist
  __alloc_pages
  alloc_pages_mpol
  vma_alloc_folio
  alloc_anon_folio
  do_anonymous_page
  handle_pte_fault
  __handle_mm_fault
  handle_mm_fault
  do_user_addr_fault
  exc_page_fault
  asm_exc_page_fault

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  number
  pointer
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  number
  pointer
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  vsnprintf
  seq_printf
  s_show
  seq_read_iter
  seq_read
  proc_reg_read
  vfs_read
  ksys_read
  __x64_sys_read
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  do_user_addr_fault
  exc_page_fault
  asm_exc_page_fault
...
```

The `task_longrun` output:
```bash
$ sudo ./task_longrun -t 10
...
sh[95413] ran_for=11.79ms bt_samples=1
  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  up_write
  __mmap_region
  mmap_region
  do_mmap
  vm_mmap_pgoff
  ksys_mmap_pgoff
  __x64_sys_mmap
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe


sed[95415] ran_for=21.59ms bt_samples=2
  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  __mmap_region
  mmap_region
  do_mmap
  vm_mmap_pgoff
  ksys_mmap_pgoff
  __x64_sys_mmap
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe

  scheduler_tick
  tick_sched_handle
  tick_nohz_highres_handler
  __hrtimer_run_queues
  hrtimer_interrupt
  __sysvec_apic_timer_interrupt
  sysvec_apic_timer_interrupt
  asm_sysvec_apic_timer_interrupt
  cgroup_exit
  do_exit
  do_group_exit
  __x64_sys_exit_group
  x64_sys_call
  do_syscall_64
  entry_SYSCALL_64_after_hwframe
...
```

Closes: #1125

Thank you for considering a contribution!

In order to streamline review experience for contributors and reviewers, please
be sure to *read* and *follow* the [Contributor's Guide][cont-guide]. It
lays out basic best practices, which, if followed will reduce unnecessary back
and forth and, ultimately, minimize the time it takes to get your change into
the library.

[cont-guide]: https://github.com/libbpf/libbpf-rs/blob/master/CONTRIBUTING.md
