### PR TITLE
libbpf-cargo: use indoc in test strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +468,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "goblin",
+ "indoc",
  "libbpf-rs",
  "libbpf-sys",
  "memmap2",

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -46,6 +46,7 @@ libbpf-sys_restricted = { package = "libbpf-sys", version = ">=1.5.0, <=1.5.1", 
 
 [dev-dependencies]
 goblin = "0.9"
+indoc = "2"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
 


### PR DESCRIPTION
libbpf-cargo has a large number of test strings for both input and generated code. IMO this makes the test file very hard to read, especially given my vim has a really hard time syntax highlighting it - it's unclear whether the 0 indented code is test code or part of the test's Rust.

Use `indoc!` to allow us to indent this test text as we see fit, allowing them to look like part of a test case instead of jumping back to 0 indentation. It's purely stylistic.

Test plan:
- `cargo test -p libbpf-cargo` - passed before, passes after, with the same number of tests.
- CI

Signed-off-by: Jake Hillion <jake@hillion.co.uk>