### PR TITLE
Remove deprecated Program::get_id_from_fd() method

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added `target_obj_id` and `target_btf_id` fields to `TracingLinkInfo`
   to expose BTF information directly from kernel queries
+- Removed previously deprecated `Program::get_id_by_fd` method
 - Bumped minimum Rust version to `1.82`
 
 

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -703,14 +703,6 @@ impl<'obj> Program<'obj> {
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
-    // TODO: Remove once 0.25 is cut.
-    #[deprecated = "renamed to Program::id_from_fd"]
-    #[expect(missing_docs)]
-    #[inline]
-    pub fn get_id_by_fd(fd: BorrowedFd<'_>) -> Result<u32> {
-        Self::id_from_fd(fd)
-    }
-
     /// Returns program ID given a file descriptor.
     pub fn id_from_fd(fd: BorrowedFd<'_>) -> Result<u32> {
         let mut prog_info = libbpf_sys::bpf_prog_info::default();


### PR DESCRIPTION
Remove the `Program::get_id_from_fd()` method. This method has been deprecated a while back and can now safely be removed, as we are about to bump the crate's minor version.