### PR TITLE
Release 0.26.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.0-beta.0"
+version = "0.26.0-beta.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.0-beta.0"
+version = "0.26.0-beta.1"
 dependencies = [
  "bitflags 2.9.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.26.0-beta.0"
+version = "0.26.0-beta.1"
 edition = "2021"
 rust-version = "1.82"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-0.26-beta.0
------------
+0.26.0-beta.0
+-------------
 - Moved BPF object content in generated skeletons into `.bpf.objs` section
   allowing easy extraction from the final binary
 - Bumped minimum Rust version to `1.82`

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ default = ["libbpf-rs/default"]
 anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
 clap = { version = "4.0.32", features = ["derive"] }
-libbpf-rs = { version = "=0.26.0-beta.0", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "=0.26.0-beta.1", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -12,7 +12,7 @@ Helps you build and develop BPF programs with standard Rust tooling.
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [build-dependencies]
-libbpf-cargo = "=0.26.0-beta.0"
+libbpf-cargo = "=0.26.0-beta.1"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,10 @@
-0.26-beta.0
------------
+0.26.0-beta.1
+-------------
+- Allowlisted `libbpf-sys` `1.6.1`
+
+
+0.26.0-beta.0
+-------------
 - Added `target_obj_id` and `target_btf_id` fields to `TracingLinkInfo`
   to expose BTF information directly from kernel queries
 - Removed previously deprecated `Program::get_id_by_fd` method

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -12,7 +12,7 @@ Idiomatic Rust wrapper around [libbpf](https://github.com/libbpf/libbpf).
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [dependencies]
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).


### PR DESCRIPTION
Prepare for release of `0.26.0-beta.1` by bumping both `libbpf-rs` and `libbpf-cargo` versions accordingly.