### PR TITLE
Move 0.26.0-beta.1 CHANGELOG items

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.26.0-beta.1
+-------------
+- Allowlisted `libbpf-sys` `1.6.1`
+
+
 0.26.0-beta.0
 -------------
 - Moved BPF object content in generated skeletons into `.bpf.objs` section

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,8 +1,3 @@
-0.26.0-beta.1
--------------
-- Allowlisted `libbpf-sys` `1.6.1`
-
-
 0.26.0-beta.0
 -------------
 - Added `target_obj_id` and `target_btf_id` fields to `TracingLinkInfo`


### PR DESCRIPTION
The CHANGELOG entry for `0.26.0-beta.1` was for `libbpf-cargo`, not `libbpf-rs`. Fix it.