### PR TITLE
Lint .bpf.c source code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,17 @@ jobs:
           sed -i 's@resolver = "2"@resolver = "1"@' Cargo.toml
           cargo clippy --locked --no-deps --all-targets --tests --features=dont-generate-test-files -- -D warnings
 
+  lint-bpf-c:
+    name: Lint .bpf.c files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: find . -iname '*.bpf.c' > bpf.c.files
+      - name: Linter action test
+        uses: d-e-s-o/lint-bpf@v0.1.1
+        with:
+          args: '@bpf.c.files'
+
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest

--- a/examples/capable/src/bpf/capable.bpf.c
+++ b/examples/capable/src/bpf/capable.bpf.c
@@ -28,16 +28,15 @@ struct unique_key {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 } events
 SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 10240);
-	__type(key,
-	struct unique_key);
+	__type(key, struct unique_key);
 	__type(value, u64);
 } seen
 SEC(".maps");
@@ -97,8 +96,8 @@ static __always_inline int record_cap(void *ctx, const struct cred *cred,
 	return 0;
 }
 
+/* bpflint: disable=unstable-attach-point */
 SEC("kprobe/cap_capable")
-
 int BPF_KPROBE(kprobe__cap_capable, const struct cred *cred,
                struct user_namespace *targ_ns, int cap, int cap_opt) {
 	return record_cap(ctx, cred, targ_ns, cap, cap_opt);

--- a/examples/runqslower/src/bpf/runqslower.bpf.c
+++ b/examples/runqslower/src/bpf/runqslower.bpf.c
@@ -28,8 +28,8 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 } events SEC(".maps");
 
 /* record enqueue timestamp */

--- a/libbpf-rs/tests/bin/src/kprobe.bpf.c
+++ b/libbpf-rs/tests/bin/src/kprobe.bpf.c
@@ -3,6 +3,7 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
+/* bpflint: disable=unstable-attach-point */
 SEC("kprobe/bpf_fentry_test1")
 int handle__kprobe(void *ctx)
 {

--- a/libbpf-rs/tests/bin/src/map_auto_pin.bpf.c
+++ b/libbpf-rs/tests/bin/src/map_auto_pin.bpf.c
@@ -5,8 +5,8 @@
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 	__uint(max_entries, 1);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } auto_pin_map SEC(".maps");

--- a/libbpf-rs/tests/bin/src/percpu_map.bpf.c
+++ b/libbpf-rs/tests/bin/src/percpu_map.bpf.c
@@ -5,8 +5,8 @@
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 	__uint(max_entries, 1);
 } percpu_map SEC(".maps");
 

--- a/libbpf-rs/tests/bin/src/run_prog.bpf.c
+++ b/libbpf-rs/tests/bin/src/run_prog.bpf.c
@@ -8,8 +8,8 @@ char _license[] SEC("license") = "GPL";
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 	__uint(max_entries, 1);
 } test_counter_map SEC(".maps");
 

--- a/libbpf-rs/tests/bin/src/runqslower.bpf.c
+++ b/libbpf-rs/tests/bin/src/runqslower.bpf.c
@@ -28,8 +28,8 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
+	__type(key, u32);
+	__type(value, u32);
 } events SEC(".maps");
 
 /* record enqueue timestamp */

--- a/libbpf-rs/tests/bin/src/tracepoint.bpf.c
+++ b/libbpf-rs/tests/bin/src/tracepoint.bpf.c
@@ -46,8 +46,8 @@ int handle__tracepoint_with_cookie(void *ctx)
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__uint(key_size, sizeof(int));
-	__uint(value_size, sizeof(int));
+	__type(key, int);
+	__type(value, int);
 } pb SEC(".maps");
 
 SEC("tracepoint/syscalls/sys_enter_getpid")


### PR DESCRIPTION
Run [bpflinter](https://github.com/d-e-s-o/bpflint/tree/main/cli) on all our .bpf.c files as part of CI and fix all pre-existing issues. Doing so should help us keep up with general BPF C coding pattern recommendations.