### PR TITLE
Stop using tabs in .bpf.c code

### DIFF
--- a/examples/capable/src/bpf/capable.bpf.c
+++ b/examples/capable/src/bpf/capable.bpf.c
@@ -11,96 +11,95 @@
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 const volatile struct {
-	gid_t tgid; //PID to filter
-	bool verbose; // Include non audit logs
-	enum uniqueness unique_type; // Only unique info traces for same pid or cgroup
-
+    gid_t tgid; //PID to filter
+    bool verbose; // Include non audit logs
+    enum uniqueness unique_type; // Only unique info traces for same pid or cgroup
 } tool_config = {};
 
 
 struct event _event = {}; //Dummy instance for skeleton to generate definition
 
 struct unique_key {
-	int cap;
-	u32 tgid;
-	u64 cgroupid;
+    int cap;
+    u32 tgid;
+    u64 cgroupid;
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
 } events
 SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 10240);
-	__type(key, struct unique_key);
-	__type(value, u64);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, struct unique_key);
+    __type(value, u64);
 } seen
 SEC(".maps");
 
 static __always_inline int record_cap(void *ctx, const struct cred *cred,
                                       struct user_namespace *targ_ns, int cap, int cap_opt) {
-	u64 __pid_tgid = bpf_get_current_pid_tgid();
-	gid_t tgid = __pid_tgid >> 32;
-	pid_t pid = __pid_tgid;
-	int audit;
-	int insetid;
+    u64 __pid_tgid = bpf_get_current_pid_tgid();
+    gid_t tgid = __pid_tgid >> 32;
+    pid_t pid = __pid_tgid;
+    int audit;
+    int insetid;
 
-	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 1, 0)) {
-		// Field changed in v5.1.0
-		audit = (cap_opt & 0b10) == 0;
-		insetid = (cap_opt & 0b100) != 0;
-	} else {
-		audit = cap_opt;
-		insetid = -1;
-	}
+    if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 1, 0)) {
+        // Field changed in v5.1.0
+        audit = (cap_opt & 0b10) == 0;
+        insetid = (cap_opt & 0b100) != 0;
+    } else {
+        audit = cap_opt;
+        insetid = -1;
+    }
 
-	if (tool_config.tgid && tgid != tool_config.tgid) {
-		return 0;
-	}
+    if (tool_config.tgid && tgid != tool_config.tgid) {
+        return 0;
+    }
 
-	if (!tool_config.verbose && audit == 0) {
-		return 0;
-	}
+    if (!tool_config.verbose && audit == 0) {
+        return 0;
+    }
 
-	uid_t uid = bpf_get_current_uid_gid();
+    uid_t uid = bpf_get_current_uid_gid();
 
-	struct event event = {
-			.tgid = tgid,
-			.pid = pid,
-			.uid = uid,
-			.cap = cap,
-			.audit = audit,
-			.insetid = insetid};
+    struct event event = {
+            .tgid = tgid,
+            .pid = pid,
+            .uid = uid,
+            .cap = cap,
+            .audit = audit,
+            .insetid = insetid};
 
-	if (tool_config.unique_type) {
-		struct unique_key key = {.cap = cap};
-		if (tool_config.unique_type == UNQ_CGROUP) {
-			key.cgroupid = bpf_get_current_cgroup_id();
-		} else {
-			key.tgid = tgid;
-		}
+    if (tool_config.unique_type) {
+        struct unique_key key = {.cap = cap};
+        if (tool_config.unique_type == UNQ_CGROUP) {
+            key.cgroupid = bpf_get_current_cgroup_id();
+        } else {
+            key.tgid = tgid;
+        }
 
-		if (bpf_map_lookup_elem(&seen, &key) != NULL) {
-			return 0;
-		}
-		u64 zero = 0;
-		bpf_map_update_elem(&seen, &key, &zero, 0);
-	}
+        if (bpf_map_lookup_elem(&seen, &key) != NULL) {
+            return 0;
+        }
+        u64 zero = 0;
+        bpf_map_update_elem(&seen, &key, &zero, 0);
+    }
 
-	bpf_get_current_comm(&event.comm, sizeof(event.comm));
-	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
-	return 0;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+    return 0;
 }
 
 /* bpflint: disable=unstable-attach-point */
 SEC("kprobe/cap_capable")
 int BPF_KPROBE(kprobe__cap_capable, const struct cred *cred,
                struct user_namespace *targ_ns, int cap, int cap_opt) {
-	return record_cap(ctx, cred, targ_ns, cap, cap_opt);
+    return record_cap(ctx, cred, targ_ns, cap, cap_opt);
 
 }
 

--- a/examples/capable/src/bpf/capable.h
+++ b/examples/capable/src/bpf/capable.h
@@ -7,19 +7,19 @@
 #define BPF_MAX_STACK_DEPTH 127
 
 struct event {
-	gid_t tgid;
-	pid_t pid;
-	uid_t uid;
-	int cap;
-	int audit;
-	int insetid;
-	u8 comm[TASK_COMM_LEN];
-	int kernel_stack_id;
-	int user_stack_id;
+    gid_t tgid;
+    pid_t pid;
+    uid_t uid;
+    int cap;
+    int audit;
+    int insetid;
+    u8 comm[TASK_COMM_LEN];
+    int kernel_stack_id;
+    int user_stack_id;
 };
 
 enum uniqueness {
-	UNQ_OFF, UNQ_PID, UNQ_CGROUP
+    UNQ_OFF, UNQ_PID, UNQ_CGROUP
 };
 
 #endif //CAPABLE_CAPABLE_H

--- a/examples/ringbuf_multi/src/bpf/ringbuf_multi.bpf.c
+++ b/examples/ringbuf_multi/src/bpf/ringbuf_multi.bpf.c
@@ -7,40 +7,40 @@
 char _license[] SEC("license") = "GPL";
 
 struct sample {
-	int pid;
-	int seq;
-	long value;
-	char comm[16];
+    int pid;
+    int seq;
+    long value;
+    char comm[16];
 };
 
 struct ringbuf_map {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	/* libbpf will adjust to valid page size */
-	__uint(max_entries, 1000);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    /* libbpf will adjust to valid page size */
+    __uint(max_entries, 1000);
 } ringbuf1 SEC(".maps"),
   ringbuf2 SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
-	__uint(max_entries, 4);
-	__type(key, int);
-	__array(values, struct ringbuf_map);
+    __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+    __uint(max_entries, 4);
+    __type(key, int);
+    __array(values, struct ringbuf_map);
 } ringbuf_arr SEC(".maps") = {
-	.values = {
-		[0] = &ringbuf1,
-		[2] = &ringbuf2,
-	},
+    .values = {
+        [0] = &ringbuf1,
+        [2] = &ringbuf2,
+    },
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__array(values, struct ringbuf_map);
+    __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+    __uint(max_entries, 1);
+    __type(key, int);
+    __array(values, struct ringbuf_map);
 } ringbuf_hash SEC(".maps") = {
-	.values = {
-		[0] = &ringbuf1,
-	},
+    .values = {
+        [0] = &ringbuf1,
+    },
 };
 
 struct sample nosample = {};
@@ -58,33 +58,33 @@ long skipped = 0;
 SEC("tp/syscalls/sys_enter_getpgid")
 int test_ringbuf(void *ctx)
 {
-	int cur_pid = bpf_get_current_pid_tgid() >> 32;
-	struct sample *sample;
-	void *rb;
+    int cur_pid = bpf_get_current_pid_tgid() >> 32;
+    struct sample *sample;
+    void *rb;
 
-	if (cur_pid != pid)
-		return 0;
+    if (cur_pid != pid)
+        return 0;
 
-	rb = bpf_map_lookup_elem(&ringbuf_arr, &target_ring);
-	if (!rb) {
-		skipped += 1;
-		return 1;
-	}
+    rb = bpf_map_lookup_elem(&ringbuf_arr, &target_ring);
+    if (!rb) {
+        skipped += 1;
+        return 1;
+    }
 
-	sample = bpf_ringbuf_reserve(rb, sizeof(*sample), 0);
-	if (!sample) {
-		dropped += 1;
-		return 1;
-	}
+    sample = bpf_ringbuf_reserve(rb, sizeof(*sample), 0);
+    if (!sample) {
+        dropped += 1;
+        return 1;
+    }
 
-	sample->pid = pid;
-	bpf_get_current_comm(sample->comm, sizeof(sample->comm));
-	sample->value = value;
+    sample->pid = pid;
+    bpf_get_current_comm(sample->comm, sizeof(sample->comm));
+    sample->value = value;
 
-	sample->seq = total;
-	total += 1;
+    sample->seq = total;
+    total += 1;
 
-	bpf_ringbuf_submit(sample, 0);
+    bpf_ringbuf_submit(sample, 0);
 
-	return 0;
+    return 0;
 }

--- a/examples/runqslower/src/bpf/runqslower.bpf.c
+++ b/examples/runqslower/src/bpf/runqslower.bpf.c
@@ -5,7 +5,7 @@
 #include <bpf/bpf_helpers.h>
 #include "runqslower.h"
 
-#define TASK_RUNNING	0
+#define TASK_RUNNING    0
 
 const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
@@ -16,104 +16,104 @@ struct event _event = {0};
 
 // Kernel 5.14 changed the state field to __state
 struct task_struct___pre_5_14 {
-	long int state;
+    long int state;
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 10240);
-	__type(key, u32);
-	__type(value, u64);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, u32);
+    __type(value, u64);
 } start SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
 } events SEC(".maps");
 
 /* record enqueue timestamp */
 static __always_inline
 int trace_enqueue(u32 tgid, u32 pid)
 {
-	u64 ts;
+    u64 ts;
 
-	if (!pid)
-		return 0;
-	if (targ_tgid && targ_tgid != tgid)
-		return 0;
-	if (targ_pid && targ_pid != pid)
-		return 0;
+    if (!pid)
+        return 0;
+    if (targ_tgid && targ_tgid != tgid)
+        return 0;
+    if (targ_pid && targ_pid != pid)
+        return 0;
 
-	ts = bpf_ktime_get_ns();
-	bpf_map_update_elem(&start, &pid, &ts, 0);
-	return 0;
+    ts = bpf_ktime_get_ns();
+    bpf_map_update_elem(&start, &pid, &ts, 0);
+    return 0;
 }
 
 SEC("tp_btf/sched_wakeup")
 int handle__sched_wakeup(u64 *ctx)
 {
-	/* TP_PROTO(struct task_struct *p) */
-	struct task_struct *p = (void *)ctx[0];
+    /* TP_PROTO(struct task_struct *p) */
+    struct task_struct *p = (void *)ctx[0];
 
-	return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(p->tgid, p->pid);
 }
 
 SEC("tp_btf/sched_wakeup_new")
 int handle__sched_wakeup_new(u64 *ctx)
 {
-	/* TP_PROTO(struct task_struct *p) */
-	struct task_struct *p = (void *)ctx[0];
+    /* TP_PROTO(struct task_struct *p) */
+    struct task_struct *p = (void *)ctx[0];
 
-	return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(p->tgid, p->pid);
 }
 
 static inline long get_task_state(struct task_struct *t)
 {
-	if (bpf_core_field_exists(t->__state))
-		return t->__state;
+    if (bpf_core_field_exists(t->__state))
+        return t->__state;
 
-	return ((struct task_struct___pre_5_14*)t)->state;
+    return ((struct task_struct___pre_5_14*)t)->state;
 }
 
 SEC("tp_btf/sched_switch")
 int handle__sched_switch(u64 *ctx)
 {
-	/* TP_PROTO(bool preempt, struct task_struct *prev,
-	 *	    struct task_struct *next)
-	 */
-	struct task_struct *prev = (struct task_struct *)ctx[1];
-	struct task_struct *next = (struct task_struct *)ctx[2];
-	struct event event = {};
-	u64 *tsp, delta_us;
-	long state = get_task_state(prev);
-	u32 pid;
+    /* TP_PROTO(bool preempt, struct task_struct *prev,
+     *        struct task_struct *next)
+     */
+    struct task_struct *prev = (struct task_struct *)ctx[1];
+    struct task_struct *next = (struct task_struct *)ctx[2];
+    struct event event = {};
+    u64 *tsp, delta_us;
+    long state = get_task_state(prev);
+    u32 pid;
 
-	/* ivcsw: treat like an enqueue event and store timestamp */
-	if (state == TASK_RUNNING)
-		trace_enqueue(prev->tgid, prev->pid);
+    /* ivcsw: treat like an enqueue event and store timestamp */
+    if (state == TASK_RUNNING)
+        trace_enqueue(prev->tgid, prev->pid);
 
-	pid = next->pid;
+    pid = next->pid;
 
-	/* fetch timestamp and calculate delta */
-	tsp = bpf_map_lookup_elem(&start, &pid);
-	if (!tsp)
-		return 0;   /* missed enqueue */
+    /* fetch timestamp and calculate delta */
+    tsp = bpf_map_lookup_elem(&start, &pid);
+    if (!tsp)
+        return 0;   /* missed enqueue */
 
-	delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
-	if (min_us && delta_us <= min_us)
-		return 0;
+    delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
+    if (min_us && delta_us <= min_us)
+        return 0;
 
-	event.pid = pid;
-	event.delta_us = delta_us;
-	bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
+    event.pid = pid;
+    event.delta_us = delta_us;
+    bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
 
-	/* output */
-	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
-			      &event, sizeof(event));
+    /* output */
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+                  &event, sizeof(event));
 
-	bpf_map_delete_elem(&start, &pid);
-	return 0;
+    bpf_map_delete_elem(&start, &pid);
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/examples/runqslower/src/bpf/runqslower.h
+++ b/examples/runqslower/src/bpf/runqslower.h
@@ -5,9 +5,9 @@
 #define TASK_COMM_LEN 16
 
 struct event {
-	u8 task[TASK_COMM_LEN];
-	__u64 delta_us;
-	pid_t pid;
+    u8 task[TASK_COMM_LEN];
+    __u64 delta_us;
+    pid_t pid;
 };
 
 #endif /* __RUNQSLOWER_H */

--- a/examples/task_longrun/src/bpf/task_longrun.h
+++ b/examples/task_longrun/src/bpf/task_longrun.h
@@ -5,7 +5,7 @@
 #define __NR_STACKS__           32768
 #define __NR_BTS__              64
 #define PERF_MAX_STACK_DEPTH    127
-#define PF_KTHREAD		0x00200000
+#define PF_KTHREAD        0x00200000
 #define TASK_COMM_LEN           16
 
 const volatile u64 runtime_thresh_ns = 0;
@@ -14,21 +14,21 @@ const volatile bool kthread_only = false;
 const volatile bool percpu_only = false;
 
 struct running_task {
-        u64             running_at;
-        u64             bt_at;
-        u32             bt[__NR_BTS__];
-        u32             bt_sample_cnt;
-        pid_t           pid;
-        u8            comm[TASK_COMM_LEN];
-        u64             ran_for;
+    u64             running_at;
+    u64             bt_at;
+    u32             bt[__NR_BTS__];
+    u32             bt_sample_cnt;
+    pid_t           pid;
+    u8            comm[TASK_COMM_LEN];
+    u64             ran_for;
 };
 
 struct event {
-        u8              comm[TASK_COMM_LEN];
-        pid_t           pid;
-        u32             bt_sample_cnt;
-        u64             duration;
-        u32             bt[__NR_BTS__];
+    u8              comm[TASK_COMM_LEN];
+    pid_t           pid;
+    u32             bt_sample_cnt;
+    u64             duration;
+    u32             bt[__NR_BTS__];
 };
 
 #endif  /* __TASK_LONGRUN_H__ */

--- a/examples/tc_port_whitelist/src/bpf/tc.bpf.c
+++ b/examples/tc_port_whitelist/src/bpf/tc.bpf.c
@@ -8,8 +8,8 @@
 #define ETH_P_IPV6  0x86DD
 
 //#include <linux/pkt_cls.h>
-#define TC_ACT_UNSPEC	(-1)
-#define TC_ACT_SHOT		2
+#define TC_ACT_UNSPEC    (-1)
+#define TC_ACT_SHOT        2
 
 u8 rc_allow = TC_ACT_UNSPEC;
 u8 rc_disallow = TC_ACT_SHOT;
@@ -100,7 +100,7 @@ int handle_tc(struct __sk_buff *skb)
 
     if (proto == IPPROTO_TCP)  {
         struct tcphdr *tcph = (struct tcphdr *)trans_data;
-        
+
         if ((void*)(trans_data + sizeof(*tcph)) > data_end) {
             return TC_ACT_SHOT;
         }
@@ -130,7 +130,7 @@ int handle_tc(struct __sk_buff *skb)
         bpf_printk("b  egress on -- src %d dst %d",
             bpf_ntohs(src), bpf_ntohs(dst));
     }
-        
+
     return rc;
 found_unknown:
     rc = TC_ACT_UNSPEC;

--- a/examples/tcp_ca/src/bpf/tcp_ca.bpf.c
+++ b/examples/tcp_ca/src/bpf/tcp_ca.bpf.c
@@ -12,13 +12,13 @@ bool cong_control = false;
 
 static inline struct tcp_sock *tcp_sk(const struct sock *sk)
 {
-	return (struct tcp_sock *)sk;
+    return (struct tcp_sock *)sk;
 }
 
 SEC("struct_ops/ca_update_init")
 void BPF_PROG(ca_update_init, struct sock *sk)
 {
-	ca_cnt++;
+    ca_cnt++;
 }
 
 SEC("struct_ops/ca_update_2_init")
@@ -28,48 +28,48 @@ void BPF_PROG(ca_update_2_init, struct sock *sk)
 
 SEC("struct_ops/ca_update_cong_control")
 void BPF_PROG(ca_update_cong_control, struct sock *sk,
-	      const struct rate_sample *rs)
+          const struct rate_sample *rs)
 {
 }
 
 SEC("struct_ops/ca_update_cong_control2")
 void BPF_PROG(ca_update_cong_control2, struct sock *sk,
-	      const struct rate_sample *rs)
+          const struct rate_sample *rs)
 {
-  cong_control = true;
+    cong_control = true;
 }
 
 SEC("struct_ops/ca_update_ssthresh")
 __u32 BPF_PROG(ca_update_ssthresh, struct sock *sk)
 {
-	return tcp_sk(sk)->snd_ssthresh;
+    return tcp_sk(sk)->snd_ssthresh;
 }
 
 SEC("struct_ops/ca_update_undo_cwnd")
 __u32 BPF_PROG(ca_update_undo_cwnd, struct sock *sk)
 {
-	return tcp_sk(sk)->snd_cwnd;
+    return tcp_sk(sk)->snd_cwnd;
 }
 
 SEC(".struct_ops.link")
 struct tcp_congestion_ops ca_update = {
-	.init = (void *)ca_update_init,
-	.cong_control = (void *)ca_update_cong_control,
-	.ssthresh = (void *)ca_update_ssthresh,
-	.undo_cwnd = (void *)ca_update_undo_cwnd,
-	.name = "tcp_ca_update",
+    .init = (void *)ca_update_init,
+    .cong_control = (void *)ca_update_cong_control,
+    .ssthresh = (void *)ca_update_ssthresh,
+    .undo_cwnd = (void *)ca_update_undo_cwnd,
+    .name = "tcp_ca_update",
 };
 
 SEC(".struct_ops")
 struct tcp_congestion_ops ca_update_2 = {
-	.init = (void *)ca_update_2_init,
-	.cong_control = (void *)ca_update_cong_control2,
-	.ssthresh = (void *)ca_update_ssthresh,
-	.undo_cwnd = (void *)ca_update_undo_cwnd,
-	.name = "tcp_ca_update_2",
+    .init = (void *)ca_update_2_init,
+    .cong_control = (void *)ca_update_cong_control2,
+    .ssthresh = (void *)ca_update_ssthresh,
+    .undo_cwnd = (void *)ca_update_undo_cwnd,
+    .name = "tcp_ca_update_2",
 };
 
 SEC(".struct_ops.link")
 struct tcp_congestion_ops ca_wrong = {
-	.cong_control = (void *)ca_update_cong_control,
+    .cong_control = (void *)ca_update_cong_control,
 };

--- a/examples/tproxy/src/bpf/tproxy.bpf.c
+++ b/examples/tproxy/src/bpf/tproxy.bpf.c
@@ -3,10 +3,10 @@
 #include <bpf/bpf_endian.h>
 
 /* Define constants not captured by BTF */
-#define BPF_F_CURRENT_NETNS	(-1L)
-#define TC_ACT_OK		0
-#define TC_ACT_SHOT		2
-#define ETH_P_IP		(0x0800)
+#define BPF_F_CURRENT_NETNS    (-1L)
+#define TC_ACT_OK        0
+#define TC_ACT_SHOT        2
+#define ETH_P_IP        (0x0800)
 
 volatile const __be16 target_port = 0;
 volatile const __be32 proxy_addr = 0;
@@ -15,96 +15,96 @@ volatile const __be16 proxy_port = 0;
 /* Fill 'tuple' with L3 info, and attempt to find L4. On fail, return NULL. */
 static inline struct bpf_sock_tuple *get_tuple(struct __sk_buff *skb)
 {
-	void *data_end = (void *)(long)skb->data_end;
-	void *data = (void *)(long)skb->data;
-	struct bpf_sock_tuple *result;
-	struct ethhdr *eth;
-	__u64 tuple_len;
-	__u8 proto = 0;
-	__u64 ihl_len;
+    void *data_end = (void *)(long)skb->data_end;
+    void *data = (void *)(long)skb->data;
+    struct bpf_sock_tuple *result;
+    struct ethhdr *eth;
+    __u64 tuple_len;
+    __u8 proto = 0;
+    __u64 ihl_len;
 
-	eth = (struct ethhdr *)(data);
-	if (eth + 1 > data_end)
-		return NULL;
+    eth = (struct ethhdr *)(data);
+    if (eth + 1 > data_end)
+        return NULL;
 
         /* Only support ipv4 */
-	if (eth->h_proto != bpf_htons(ETH_P_IP))
-                return NULL;
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+        return NULL;
 
-        struct iphdr *iph = (struct iphdr *)(data + sizeof(*eth));
-        if (iph + 1 > data_end)
-                return NULL;
-        if (iph->ihl != 5)
-                /* Options are not supported */
-                return NULL;
-        ihl_len = iph->ihl * 4;
-        proto = iph->protocol;
-        result = (struct bpf_sock_tuple *)&iph->saddr;
+    struct iphdr *iph = (struct iphdr *)(data + sizeof(*eth));
+    if (iph + 1 > data_end)
+            return NULL;
+    if (iph->ihl != 5)
+            /* Options are not supported */
+            return NULL;
+    ihl_len = iph->ihl * 4;
+    proto = iph->protocol;
+    result = (struct bpf_sock_tuple *)&iph->saddr;
 
         /* Only support TCP */
-	if (proto != IPPROTO_TCP)
-		return NULL;
+    if (proto != IPPROTO_TCP)
+        return NULL;
 
-	return result;
+    return result;
 }
 
 static inline int
 handle_tcp(struct __sk_buff *skb, struct bpf_sock_tuple *tuple)
 {
         struct bpf_sock_tuple server = {};
-	struct bpf_sock *sk;
-	const int zero = 0;
-	size_t tuple_len;
-	int ret;
+    struct bpf_sock *sk;
+    const int zero = 0;
+    size_t tuple_len;
+    int ret;
 
-        tuple_len = sizeof(tuple->ipv4);
-	if ((void *)tuple + tuple_len > (void *)(long)skb->data_end)
-		return TC_ACT_SHOT;
+    tuple_len = sizeof(tuple->ipv4);
+    if ((void *)tuple + tuple_len > (void *)(long)skb->data_end)
+        return TC_ACT_SHOT;
 
         /* Only proxy packets destined for the target port */
-	if (tuple->ipv4.dport != target_port)
-		return TC_ACT_OK;
+    if (tuple->ipv4.dport != target_port)
+        return TC_ACT_OK;
 
         /* Reuse existing connection if it exists */
-	sk = bpf_skc_lookup_tcp(skb, tuple, tuple_len, BPF_F_CURRENT_NETNS, 0);
-	if (sk) {
-		if (sk->state != BPF_TCP_LISTEN)
-			goto assign;
-		bpf_sk_release(sk);
-	}
+    sk = bpf_skc_lookup_tcp(skb, tuple, tuple_len, BPF_F_CURRENT_NETNS, 0);
+    if (sk) {
+        if (sk->state != BPF_TCP_LISTEN)
+            goto assign;
+        bpf_sk_release(sk);
+    }
 
-        /* Lookup port server is listening on */
-        server.ipv4.saddr = tuple->ipv4.saddr;
-        server.ipv4.daddr = proxy_addr;
-        server.ipv4.sport = tuple->ipv4.sport;
-        server.ipv4.dport = proxy_port;
-	sk = bpf_skc_lookup_tcp(skb, &server, tuple_len, BPF_F_CURRENT_NETNS, 0);
-	if (!sk)
-                return TC_ACT_SHOT;
-        if (sk->state != BPF_TCP_LISTEN) {
-                bpf_sk_release(sk);
-                return TC_ACT_SHOT;
-        }
+    /* Lookup port server is listening on */
+    server.ipv4.saddr = tuple->ipv4.saddr;
+    server.ipv4.daddr = proxy_addr;
+    server.ipv4.sport = tuple->ipv4.sport;
+    server.ipv4.dport = proxy_port;
+    sk = bpf_skc_lookup_tcp(skb, &server, tuple_len, BPF_F_CURRENT_NETNS, 0);
+    if (!sk)
+        return TC_ACT_SHOT;
+    if (sk->state != BPF_TCP_LISTEN) {
+        bpf_sk_release(sk);
+        return TC_ACT_SHOT;
+    }
 
 assign:
-	ret = bpf_sk_assign(skb, sk, 0);
-	bpf_sk_release(sk);
-	return ret;
+    ret = bpf_sk_assign(skb, sk, 0);
+    bpf_sk_release(sk);
+    return ret;
 }
 
 SEC("tc")
 int tproxy(struct __sk_buff *skb)
 {
-	struct bpf_sock_tuple *tuple;
-	int tuple_len;
-	int ret = 0;
+    struct bpf_sock_tuple *tuple;
+    int tuple_len;
+    int ret = 0;
 
-	tuple = get_tuple(skb);
-	if (!tuple)
-		return TC_ACT_SHOT;
+    tuple = get_tuple(skb);
+    if (!tuple)
+        return TC_ACT_SHOT;
 
-        ret = handle_tcp(skb, tuple);
-	return ret == 0 ? TC_ACT_OK : TC_ACT_SHOT;
+    ret = handle_tcp(skb, tuple);
+    return ret == 0 ? TC_ACT_OK : TC_ACT_SHOT;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/kprobe.bpf.c
+++ b/libbpf-rs/tests/bin/src/kprobe.bpf.c
@@ -7,7 +7,7 @@
 SEC("kprobe/bpf_fentry_test1")
 int handle__kprobe(void *ctx)
 {
-	return 0;
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/ksyscall.bpf.c
+++ b/libbpf-rs/tests/bin/src/ksyscall.bpf.c
@@ -4,26 +4,26 @@
 #include <bpf/bpf_helpers.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf SEC(".maps");
 
 SEC("ksyscall/kill")
 int handle__ksyscall(pid_t pid, int sig)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__ksyscall: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__ksyscall: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = 1;
-	bpf_ringbuf_submit(value, 0);
-	bpf_printk("handle__ksyscall: submitted ringbuf value");
-	return 0;
+    *value = 1;
+    bpf_ringbuf_submit(value, 0);
+    bpf_printk("handle__ksyscall: submitted ringbuf value");
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/map_auto_pin.bpf.c
+++ b/libbpf-rs/tests/bin/src/map_auto_pin.bpf.c
@@ -4,11 +4,11 @@
 #include <bpf/bpf_helpers.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries, 1);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
 } auto_pin_map SEC(".maps");
 
 u64 resizable_data[1] SEC(".data.resizable_data");

--- a/libbpf-rs/tests/bin/src/mapiter.bpf.c
+++ b/libbpf-rs/tests/bin/src/mapiter.bpf.c
@@ -6,26 +6,26 @@
 SEC("iter/bpf_map_elem")
 int map_iter(struct bpf_iter__bpf_map_elem *ctx)
 {
-	struct seq_file *seq = ctx->meta->seq;
-	__u32 seq_num = ctx->meta->seq_num;
-	struct bpf_map *map = ctx->map;
-	__u32 *key = ctx->key;
-	__u64 *value = ctx->value;
-	__u32 tmp_key = 0;
-	__u64 tmp_val = 0;
+    struct seq_file *seq = ctx->meta->seq;
+    __u32 seq_num = ctx->meta->seq_num;
+    struct bpf_map *map = ctx->map;
+    __u32 *key = ctx->key;
+    __u64 *value = ctx->value;
+    __u32 tmp_key = 0;
+    __u64 tmp_val = 0;
 
-	if (seq_num == 0) {
-		bpf_printk("map dump starts");
-	}
+    if (seq_num == 0) {
+        bpf_printk("map dump starts");
+    }
 
-	if (key == (void *)0 || value == (void *)0) {
-		bpf_printk("map dump end");
-		return 0;
-	}
+    if (key == (void *)0 || value == (void *)0) {
+        bpf_printk("map dump end");
+        return 0;
+    }
 
-	bpf_printk("test map iter, target map: %s, key: %d", map->name, (*key));
-	bpf_seq_write(seq, key, sizeof(__u32));
-	return 0;
+    bpf_printk("test map iter, target map: %s, key: %d", map->name, (*key));
+    bpf_seq_write(seq, key, sizeof(__u32));
+    return 0;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/netfilter.bpf.c
+++ b/libbpf-rs/tests/bin/src/netfilter.bpf.c
@@ -4,27 +4,27 @@
 #define NF_ACCEPT 1
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf SEC(".maps");
 
 SEC("netfilter")
 int handle_netfilter(struct bpf_nf_ctx *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle_netfilter: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle_netfilter: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = 1;
-	bpf_ringbuf_submit(value, 0);
+    *value = 1;
+    bpf_ringbuf_submit(value, 0);
 
-	bpf_printk("handle_netfilter: submitted ringbuf value");
-	return NF_ACCEPT;
+    bpf_printk("handle_netfilter: submitted ringbuf value");
+    return NF_ACCEPT;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/percpu_map.bpf.c
+++ b/libbpf-rs/tests/bin/src/percpu_map.bpf.c
@@ -4,10 +4,10 @@
 #include <bpf/bpf_helpers.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries, 1);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1);
 } percpu_map SEC(".maps");
 
 char _license[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/ringbuf.bpf.c
+++ b/libbpf-rs/tests/bin/src/ringbuf.bpf.c
@@ -4,33 +4,33 @@
 #include <bpf/bpf_helpers.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf1 SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf2 SEC(".maps");
 
 SEC("tp/syscalls/sys_enter_getpid")
 int handle__sys_enter_getpid(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf1, sizeof(int), 0);
-	if (value) {
-		*value = 1;
-		bpf_ringbuf_submit(value, 0);
-	}
+    value = bpf_ringbuf_reserve(&ringbuf1, sizeof(int), 0);
+    if (value) {
+        *value = 1;
+        bpf_ringbuf_submit(value, 0);
+    }
 
-	value = bpf_ringbuf_reserve(&ringbuf2, sizeof(int), 0);
-	if (value) {
-		*value = 2;
-		bpf_ringbuf_submit(value, 0);
-	}
+    value = bpf_ringbuf_reserve(&ringbuf2, sizeof(int), 0);
+    if (value) {
+        *value = 2;
+        bpf_ringbuf_submit(value, 0);
+    }
 
-	return 0;
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/run_prog.bpf.c
+++ b/libbpf-rs/tests/bin/src/run_prog.bpf.c
@@ -7,53 +7,53 @@
 char _license[] SEC("license") = "GPL";
 
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries, 1);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1);
 } test_counter_map SEC(".maps");
 
 SEC("struct_ops/test_1")
 int BPF_PROG(test_1, struct bpf_dummy_ops_state *state)
 {
-	int ret;
+    int ret;
 
-	if (!state)
-		return 0xf2f3f4f5;
+    if (!state)
+        return 0xf2f3f4f5;
 
-	ret = state->val;
-	state->val = 0x5a;
-	return ret;
+    ret = state->val;
+    state->val = 0x5a;
+    return ret;
 }
 
 __u64 test_2_args[5];
 
 SEC("struct_ops/test_2")
 int BPF_PROG(test_2, struct bpf_dummy_ops_state *state, int a1,
-	     unsigned short a2, char a3, unsigned long a4)
+         unsigned short a2, char a3, unsigned long a4)
 {
-	test_2_args[0] = (unsigned long)state;
-	test_2_args[1] = a1;
-	test_2_args[2] = a2;
-	test_2_args[3] = a3;
-	test_2_args[4] = a4;
-	return 0;
+    test_2_args[0] = (unsigned long)state;
+    test_2_args[1] = a1;
+    test_2_args[2] = a2;
+    test_2_args[3] = a3;
+    test_2_args[4] = a4;
+    return 0;
 }
 
 SEC("xdp")
 int xdp_counter(struct xdp_md *ctx)
 {
-	u32 key = 0;
-	u32 *value = bpf_map_lookup_elem(&test_counter_map, &key);
-	if (value) {
-		*value += 1;
-		return XDP_PASS;
-	}
-	return XDP_DROP;
+    u32 key = 0;
+    u32 *value = bpf_map_lookup_elem(&test_counter_map, &key);
+    if (value) {
+        *value += 1;
+        return XDP_PASS;
+    }
+    return XDP_DROP;
 }
 
 SEC(".struct_ops")
 struct bpf_dummy_ops dummy_1 = {
-	.test_1 = (void *)test_1,
-	.test_2 = (void *)test_2,
+    .test_1 = (void *)test_1,
+    .test_2 = (void *)test_2,
 };

--- a/libbpf-rs/tests/bin/src/runqslower.bpf.c
+++ b/libbpf-rs/tests/bin/src/runqslower.bpf.c
@@ -16,103 +16,103 @@ struct event _event = { 0 };
 
 // Kernel 5.14 changed the state field to __state
 struct task_struct___pre_5_14 {
-	long int state;
+    long int state;
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 10240);
-	__type(key, u32);
-	__type(value, u64);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, u32);
+    __type(value, u64);
 } start SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
 } events SEC(".maps");
 
 /* record enqueue timestamp */
 static __always_inline int trace_enqueue(u32 tgid, u32 pid)
 {
-	u64 ts;
+    u64 ts;
 
-	if (!pid)
-		return 0;
-	if (targ_tgid && targ_tgid != tgid)
-		return 0;
-	if (targ_pid && targ_pid != pid)
-		return 0;
+    if (!pid)
+        return 0;
+    if (targ_tgid && targ_tgid != tgid)
+        return 0;
+    if (targ_pid && targ_pid != pid)
+        return 0;
 
-	ts = bpf_ktime_get_ns();
-	bpf_map_update_elem(&start, &pid, &ts, 0);
-	return 0;
+    ts = bpf_ktime_get_ns();
+    bpf_map_update_elem(&start, &pid, &ts, 0);
+    return 0;
 }
 
 SEC("tp_btf/sched_wakeup")
 int handle__sched_wakeup(u64 *ctx)
 {
-	/* TP_PROTO(struct task_struct *p) */
-	struct task_struct *p = (void *)ctx[0];
+    /* TP_PROTO(struct task_struct *p) */
+    struct task_struct *p = (void *)ctx[0];
 
-	return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(p->tgid, p->pid);
 }
 
 SEC("tp_btf/sched_wakeup_new")
 int handle__sched_wakeup_new(u64 *ctx)
 {
-	/* TP_PROTO(struct task_struct *p) */
-	struct task_struct *p = (void *)ctx[0];
+    /* TP_PROTO(struct task_struct *p) */
+    struct task_struct *p = (void *)ctx[0];
 
-	return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(p->tgid, p->pid);
 }
 
 static inline long get_task_state(struct task_struct *t)
 {
-	if (bpf_core_field_exists(t->__state))
-		return t->__state;
+    if (bpf_core_field_exists(t->__state))
+        return t->__state;
 
-	return ((struct task_struct___pre_5_14 *)t)->state;
+    return ((struct task_struct___pre_5_14 *)t)->state;
 }
 
 SEC("tp_btf/sched_switch")
 int handle__sched_switch(u64 *ctx)
 {
-	/* TP_PROTO(bool preempt, struct task_struct *prev,
-	 *	    struct task_struct *next)
-	 */
-	struct task_struct *prev = (struct task_struct *)ctx[1];
-	struct task_struct *next = (struct task_struct *)ctx[2];
-	struct event event = {};
-	u64 *tsp, delta_us;
-	long state = get_task_state(prev);
-	u32 pid;
+    /* TP_PROTO(bool preempt, struct task_struct *prev,
+     *        struct task_struct *next)
+     */
+    struct task_struct *prev = (struct task_struct *)ctx[1];
+    struct task_struct *next = (struct task_struct *)ctx[2];
+    struct event event = {};
+    u64 *tsp, delta_us;
+    long state = get_task_state(prev);
+    u32 pid;
 
-	/* ivcsw: treat like an enqueue event and store timestamp */
-	if (state == TASK_RUNNING)
-		trace_enqueue(prev->tgid, prev->pid);
+    /* ivcsw: treat like an enqueue event and store timestamp */
+    if (state == TASK_RUNNING)
+        trace_enqueue(prev->tgid, prev->pid);
 
-	pid = next->pid;
+    pid = next->pid;
 
-	/* fetch timestamp and calculate delta */
-	tsp = bpf_map_lookup_elem(&start, &pid);
-	if (!tsp)
-		return 0; /* missed enqueue */
+    /* fetch timestamp and calculate delta */
+    tsp = bpf_map_lookup_elem(&start, &pid);
+    if (!tsp)
+        return 0; /* missed enqueue */
 
-	delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
-	if (min_us && delta_us <= min_us)
-		return 0;
+    delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
+    if (min_us && delta_us <= min_us)
+        return 0;
 
-	event.pid = pid;
-	event.delta_us = delta_us;
-	bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
+    event.pid = pid;
+    event.delta_us = delta_us;
+    bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
 
-	/* output */
-	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
-			      sizeof(event));
+    /* output */
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+                  sizeof(event));
 
-	bpf_map_delete_elem(&start, &pid);
-	return 0;
+    bpf_map_delete_elem(&start, &pid);
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/runqslower.h
+++ b/libbpf-rs/tests/bin/src/runqslower.h
@@ -7,9 +7,9 @@
 #define TASK_COMM_LEN 16
 
 struct event {
-	u8 task[TASK_COMM_LEN];
-	__u64 delta_us;
-	pid_t pid;
+    u8 task[TASK_COMM_LEN];
+    __u64 delta_us;
+    pid_t pid;
 };
 
 #endif /* __RUNQSLOWER_H */

--- a/libbpf-rs/tests/bin/src/taskiter.bpf.c
+++ b/libbpf-rs/tests/bin/src/taskiter.bpf.c
@@ -4,8 +4,8 @@
 #include <bpf/bpf_helpers.h>
 
 struct index_pid_pair {
-	uint32_t i;
-	pid_t pid;
+    uint32_t i;
+    pid_t pid;
 };
 
 static uint32_t i = 0;
@@ -13,18 +13,18 @@ static uint32_t i = 0;
 SEC("iter/task")
 int dump_pid(struct bpf_iter__task *ctx)
 {
-	struct seq_file *seq = ctx->meta->seq;
-	struct task_struct *task = ctx->task;
-	struct index_pid_pair p;
+    struct seq_file *seq = ctx->meta->seq;
+    struct task_struct *task = ctx->task;
+    struct index_pid_pair p;
 
-	if (!task)
-		return 0;
+    if (!task)
+        return 0;
 
-	p.i = i++;
-	p.pid = task->tgid;
+    p.i = i++;
+    p.pid = task->tgid;
 
-	bpf_seq_write(seq, &p, sizeof(p));
-	return 0;
+    bpf_seq_write(seq, &p, sizeof(p));
+    return 0;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/tc-unit.bpf.c
+++ b/libbpf-rs/tests/bin/src/tc-unit.bpf.c
@@ -7,5 +7,5 @@
 SEC("tc")
 int handle_tc(struct __sk_buff *skb)
 {
-	return TC_ACT_UNSPEC;
+    return TC_ACT_UNSPEC;
 }

--- a/libbpf-rs/tests/bin/src/tracepoint.bpf.c
+++ b/libbpf-rs/tests/bin/src/tracepoint.bpf.c
@@ -4,80 +4,80 @@
 #include <bpf/bpf_helpers.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf SEC(".maps");
 
 SEC("tracepoint/syscalls/sys_enter_getpid")
 int handle__tracepoint(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__tracepoint: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__tracepoint: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = 1;
-	bpf_ringbuf_submit(value, 0);
-	bpf_printk("handle__tracepoint: submitted ringbuf value");
-	return 0;
+    *value = 1;
+    bpf_ringbuf_submit(value, 0);
+    bpf_printk("handle__tracepoint: submitted ringbuf value");
+    return 0;
 }
 
 SEC("tracepoint/syscalls/sys_enter_getpid")
 int handle__tracepoint_with_cookie(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__tracepoint_with_cookie: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__tracepoint_with_cookie: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = bpf_get_attach_cookie(ctx);
-	bpf_printk("handle__tracepoint_with_cookie: cookie=%d", *value);
-	bpf_ringbuf_submit(value, 0);
-	return 0;
+    *value = bpf_get_attach_cookie(ctx);
+    bpf_printk("handle__tracepoint_with_cookie: cookie=%d", *value);
+    bpf_ringbuf_submit(value, 0);
+    return 0;
 }
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__type(key, int);
-	__type(value, int);
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __type(key, int);
+    __type(value, int);
 } pb SEC(".maps");
 
 SEC("tracepoint/syscalls/sys_enter_getpid")
 int handle__tracepoint_with_cookie_pb(void *ctx)
 {
-	int value = bpf_get_attach_cookie(ctx);
-	bpf_perf_event_output(ctx, &pb, BPF_F_CURRENT_CPU, &value,
-			      sizeof(value));
+    int value = bpf_get_attach_cookie(ctx);
+    bpf_perf_event_output(ctx, &pb, BPF_F_CURRENT_CPU, &value,
+                  sizeof(value));
 
-	return 0;
+    return 0;
 }
 
 struct {
-	__uint(type, BPF_MAP_TYPE_QUEUE);
-	__uint(max_entries, 10);
-	__uint(key, 0);
-	__type(value, __u32);
+    __uint(type, BPF_MAP_TYPE_QUEUE);
+    __uint(max_entries, 10);
+    __uint(key, 0);
+    __type(value, __u32);
 } queue SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_STACK);
-	__uint(max_entries, 10);
-	__uint(key, 0);
-	__type(value, __u32);
+    __uint(type, BPF_MAP_TYPE_STACK);
+    __uint(max_entries, 10);
+    __uint(key, 0);
+    __type(value, __u32);
 } stack SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_BLOOM_FILTER);
-	__uint(max_entries, 5);
-	__type(value, __u32);
+    __uint(type, BPF_MAP_TYPE_BLOOM_FILTER);
+    __uint(max_entries, 5);
+    __type(value, __u32);
 } bloom_filter SEC(".maps");
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/uprobe.bpf.c
+++ b/libbpf-rs/tests/bin/src/uprobe.bpf.c
@@ -5,44 +5,44 @@
 #include <bpf/usdt.bpf.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf SEC(".maps");
 
 SEC("uprobe")
 int handle__uprobe(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__uprobe: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__uprobe: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = 1;
-	bpf_ringbuf_submit(value, 0);
-	bpf_printk("handle__uprobe: submitted ringbuf value");
-	return 0;
+    *value = 1;
+    bpf_ringbuf_submit(value, 0);
+    bpf_printk("handle__uprobe: submitted ringbuf value");
+    return 0;
 }
 
 SEC("uprobe")
 int handle__uprobe_with_cookie(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__uprobe_with_cookie: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__uprobe_with_cookie: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = bpf_get_attach_cookie(ctx);
-	bpf_printk("handle__uprobe_with_cookie: cookie=%d", *value);
-	bpf_ringbuf_submit(value, 0);
-	return 0;
+    *value = bpf_get_attach_cookie(ctx);
+    bpf_printk("handle__uprobe_with_cookie: cookie=%d", *value);
+    bpf_ringbuf_submit(value, 0);
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/usdt.bpf.c
+++ b/libbpf-rs/tests/bin/src/usdt.bpf.c
@@ -5,43 +5,43 @@
 #include <bpf/usdt.bpf.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } ringbuf SEC(".maps");
 
 SEC("usdt")
 int handle__usdt(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk("handle__usdt: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk("handle__usdt: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = 1;
-	bpf_ringbuf_submit(value, 0);
-	bpf_printk("handle__usdt: submitted ringbuf value");
-	return 0;
+    *value = 1;
+    bpf_ringbuf_submit(value, 0);
+    bpf_printk("handle__usdt: submitted ringbuf value");
+    return 0;
 }
 
 SEC("usdt")
 int handle__usdt_with_cookie(void *ctx)
 {
-	int *value;
+    int *value;
 
-	value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
-	if (!value) {
-		bpf_printk(
-			"handle__usdt_with_cookie: failed to reserve ring buffer space");
-		return 1;
-	}
+    value = bpf_ringbuf_reserve(&ringbuf, sizeof(int), 0);
+    if (!value) {
+        bpf_printk(
+            "handle__usdt_with_cookie: failed to reserve ring buffer space");
+        return 1;
+    }
 
-	*value = bpf_usdt_cookie(ctx);
-	bpf_printk("handle__usdt_with_cookie: cookie=%d", *value);
-	bpf_ringbuf_submit(value, 0);
-	return 0;
+    *value = bpf_usdt_cookie(ctx);
+    bpf_printk("handle__usdt_with_cookie: cookie=%d", *value);
+    bpf_ringbuf_submit(value, 0);
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/user_ringbuf.bpf.c
+++ b/libbpf-rs/tests/bin/src/user_ringbuf.bpf.c
@@ -6,41 +6,41 @@
 #include <bpf/bpf_tracing.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_USER_RINGBUF);
-	__uint(max_entries, 4096 /* one page */);
+    __uint(type, BPF_MAP_TYPE_USER_RINGBUF);
+    __uint(max_entries, 4096 /* one page */);
 } user_ringbuf SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries, 100);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 100);
 } samples SEC(".maps");
 
 struct my_struct_t {
-	u32 key;
-	u32 value;
+    u32 key;
+    u32 value;
 };
 
 static long user_ringbuf_callback(struct bpf_dynptr *dynptr, void *context)
 {
-	const struct my_struct_t *data;
+    const struct my_struct_t *data;
 
-	data = bpf_dynptr_data(dynptr, 0, sizeof(*data));
-	if (!data)
-		return 0;
+    data = bpf_dynptr_data(dynptr, 0, sizeof(*data));
+    if (!data)
+        return 0;
 
-	bpf_map_update_elem(&samples, &data->key, &data->value, BPF_ANY);
+    bpf_map_update_elem(&samples, &data->key, &data->value, BPF_ANY);
 
-	return 0;
+    return 0;
 }
 
 SEC("tp/syscalls/sys_enter_getpid")
 int handle__sys_enter_getpid(void *ctx)
 {
-	bpf_user_ringbuf_drain(&user_ringbuf, user_ringbuf_callback, NULL, 0);
+    bpf_user_ringbuf_drain(&user_ringbuf, user_ringbuf_callback, NULL, 0);
 
-	return 0;
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-rs/tests/bin/src/xdp.bpf.c
+++ b/libbpf-rs/tests/bin/src/xdp.bpf.c
@@ -4,5 +4,5 @@
 SEC("xdp")
 int xdp_filter(struct xdp_md *ctx)
 {
-	return XDP_PASS;
+    return XDP_PASS;
 }


### PR DESCRIPTION
Replace all tabs with spaces in .bpf.c code. Ultimately we should get clangfmt set up for these bits, but for now this was accomplished using a dumb string replace.