### PR TITLE
libbpf-cargo: fix clippy warnings in generated code

### DIFF
--- a/libbpf-cargo/src/gen/btf.rs
+++ b/libbpf-cargo/src/gen/btf.rs
@@ -992,7 +992,7 @@ impl<'s> GenBtf<'s> {
 
             writeln!(
                 def,
-                r#"    pub const {name}: {enum_name} = {enum_name}({value});"#,
+                r#"    pub const {name}: Self = Self({value});"#,
                 name = value.name.unwrap().to_string_lossy(),
                 value = value.value,
             )?;
@@ -1004,7 +1004,7 @@ impl<'s> GenBtf<'s> {
             writeln!(def, r#"impl Default for {enum_name} {{"#)?;
             writeln!(
                 def,
-                r#"    fn default() -> Self {{ {enum_name}::{name} }}"#,
+                r#"    fn default() -> Self {{ Self::{name} }}"#,
                 name = first_field.name.unwrap().to_string_lossy()
             )?;
             writeln!(def, r#"}}"#)?;

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -2019,14 +2019,14 @@ fn test_btf_dump_definition_enum() {
         pub struct Foo(pub u32);
         #[allow(non_upper_case_globals)]
         impl Foo {
-            pub const Zero: Foo = Foo(0);
-            pub const One: Foo = Foo(1);
-            pub const Seven: Foo = Foo(7);
-            pub const ZeroDup: Foo = Foo(0);
-            pub const Infinite: Foo = Foo(4294967295);
+            pub const Zero: Self = Self(0);
+            pub const One: Self = Self(1);
+            pub const Seven: Self = Self(7);
+            pub const ZeroDup: Self = Self(0);
+            pub const Infinite: Self = Self(4294967295);
         }
         impl Default for Foo {
-            fn default() -> Self { Foo::Zero }
+            fn default() -> Self { Self::Zero }
         }
     "#};
 
@@ -2066,11 +2066,11 @@ fn test_btf_dump_definition_enum_signed() {
         pub struct Foo(pub i32);
         #[allow(non_upper_case_globals)]
         impl Foo {
-            pub const Zero: Foo = Foo(0);
-            pub const Infinite: Foo = Foo(-1);
+            pub const Zero: Self = Self(0);
+            pub const Infinite: Self = Self(-1);
         }
         impl Default for Foo {
-            fn default() -> Self { Foo::Zero }
+            fn default() -> Self { Self::Zero }
         }
     "#};
 
@@ -2110,11 +2110,11 @@ fn test_btf_dump_definition_enum64() {
         pub struct Foo(pub u64);
         #[allow(non_upper_case_globals)]
         impl Foo {
-            pub const Zero: Foo = Foo(0);
-            pub const Infinite: Foo = Foo(18446744073709551615);
+            pub const Zero: Self = Self(0);
+            pub const Infinite: Self = Self(18446744073709551615);
         }
         impl Default for Foo {
-            fn default() -> Self { Foo::Zero }
+            fn default() -> Self { Self::Zero }
         }
     "#};
 
@@ -2154,11 +2154,11 @@ fn test_btf_dump_definition_enum64_signed() {
         pub struct Foo(pub i64);
         #[allow(non_upper_case_globals)]
         impl Foo {
-            pub const Zero: Foo = Foo(0);
-            pub const Whatevs: Foo = Foo(-922337854775808);
+            pub const Zero: Self = Self(0);
+            pub const Whatevs: Self = Self(-922337854775808);
         }
         impl Default for Foo {
-            fn default() -> Self { Foo::Zero }
+            fn default() -> Self { Self::Zero }
         }
     "#};
 
@@ -3018,10 +3018,10 @@ fn test_btf_dump_definition_anon_enum() {
         pub struct __anon_Foo_1(pub u32);
         #[allow(non_upper_case_globals)]
         impl __anon_Foo_1 {
-            pub const FOO: __anon_Foo_1 = __anon_Foo_1(1);
+            pub const FOO: Self = Self(1);
         }
         impl Default for __anon_Foo_1 {
-            fn default() -> Self { __anon_Foo_1::FOO }
+            fn default() -> Self { Self::FOO }
         }
     "#};
 


### PR DESCRIPTION
This PR fixes "unnecessary structure name repetition" warnings in generated code.

```
warning: unnecessary structure name repetition
    --> /home/kxxt/repos/tracexec/src/bpf/tracexec_system.skel.rs:5085:77
     |
5085 |       pub const FTRACE_OPS_CMD_ENABLE_SHARE_IPMODIFY_PEER: ftrace_ops_cmd = ftrace_ops_cmd(1);
     |                                                                             ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self
```