### PR TITLE
query: Support tracepoint & k(ret)probe in perf_event link infos

### DIFF
--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::ptr::NonNull;
 
+use crate::query::LinkInfo;
 use crate::util;
 use crate::util::validate_bpf_ret;
 use crate::AsRawLibbpf;
@@ -107,6 +108,11 @@ impl Link {
     pub fn detach(&self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__detach(self.ptr.as_ptr()) };
         util::parse_ret(ret)
+    }
+
+    /// Get information about this link.
+    pub fn info(&self) -> Result<LinkInfo> {
+        LinkInfo::from_fd(self.as_fd())
     }
 }
 

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -11,9 +11,11 @@
 //! ```
 
 use std::ffi::c_void;
+use std::ffi::CStr;
 use std::ffi::CString;
 use std::io;
 use std::mem::size_of_val;
+use std::mem::zeroed;
 use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
@@ -726,6 +728,44 @@ pub struct UprobeMultiLinkInfo {
     pub pid: u32,
 }
 
+/// Information about a perf event link.
+#[derive(Debug, Clone)]
+pub struct PerfEventLinkInfo {
+    /// The specific type of perf event with decoded information.
+    pub event_type: PerfEventType,
+}
+
+/// Specific types of perf events with decoded information.
+#[derive(Debug, Clone)]
+pub enum PerfEventType {
+    /// A tracepoint event.
+    Tracepoint {
+        /// The tracepoint name.
+        name: Option<CString>,
+        /// Attach cookie value for this link.
+        cookie: u64,
+    },
+    /// A kprobe event (includes both kprobe and kretprobe).
+    Kprobe {
+        /// The function being probed.
+        func_name: Option<CString>,
+        /// Whether this is a return probe (kretprobe).
+        is_retprobe: bool,
+        /// Address of the probe.
+        addr: u64,
+        /// Offset from the function.
+        offset: u32,
+        /// Number of missed events.
+        missed: u64,
+        /// Cookie value for the kprobe.
+        cookie: u64,
+    },
+    // TODO: Add support for `BPF_PERF_EVENT_EVENT`, `BPF_PERF_EVENT_UPROBE`
+    // `BPF_PERF_EVENT_URETPROBE`
+    /// An unknown or unsupported perf event type.
+    Unknown(u32),
+}
+
 /// Information about BPF link types. Maps to the anonymous union in `struct bpf_link_info` in
 /// kernel uapi.
 #[derive(Debug, Clone)]
@@ -767,7 +807,10 @@ pub enum LinkTypeInfo {
     /// Link type for sockmap programs.
     SockMap(SockMapLinkInfo),
     /// Link type for perf-event programs.
-    PerfEvent,
+    ///
+    /// Contains information about the perf event configuration including type and config
+    /// which can be used to identify tracepoints, kprobes, uprobes, etc.
+    PerfEvent(PerfEventLinkInfo),
     /// Unknown link type.
     Unknown,
 }
@@ -784,6 +827,22 @@ pub struct LinkInfo {
 }
 
 impl LinkInfo {
+    /// Create a `LinkInfo` object from a fd.
+    pub fn from_fd(fd: BorrowedFd<'_>) -> Result<Self> {
+        // See comment in gen_info_impl!() for why we use std::mem::zeroed()
+        let mut link_info: libbpf_sys::bpf_link_info = unsafe { zeroed() };
+        let item_ptr: *mut libbpf_sys::bpf_link_info = &mut link_info;
+        let mut len = size_of_val(&link_info) as u32;
+
+        let ret = unsafe {
+            libbpf_sys::bpf_obj_get_info_by_fd(fd.as_raw_fd(), item_ptr as *mut c_void, &mut len)
+        };
+        util::parse_ret(ret)?;
+
+        Self::from_uapi(fd, link_info)
+            .ok_or_else(|| crate::Error::with_invalid_data("failed to parse link info"))
+    }
+
     fn from_uapi(fd: BorrowedFd<'_>, mut s: libbpf_sys::bpf_link_info) -> Option<Self> {
         let type_info = match s.type_ {
             libbpf_sys::BPF_LINK_TYPE_RAW_TRACEPOINT => {
@@ -874,7 +933,119 @@ impl LinkInfo {
                     s.__bindgen_anon_1.sockmap.attach_type
                 }),
             }),
-            libbpf_sys::BPF_LINK_TYPE_PERF_EVENT => LinkTypeInfo::PerfEvent,
+            libbpf_sys::BPF_LINK_TYPE_PERF_EVENT => {
+                // Get the BPF perf event type (BPF_PERF_EVENT_*) from the link info.
+                let bpf_perf_event_type = unsafe { s.__bindgen_anon_1.perf_event.type_ };
+
+                // Handle two-phase call for perf event string data if needed (this mimics the
+                // behavior of bpftool):
+                // For tracepoints and kprobes, we need to pass in a buffer to get the name. So
+                // we initialize the struct with a buffer pointer, and call `bpf_obj_get_info_by_fd`
+                // again to populate the name.
+                let mut buf = [0u8; 256];
+                let call_get_info_again = match bpf_perf_event_type {
+                    libbpf_sys::BPF_PERF_EVENT_TRACEPOINT => {
+                        s.__bindgen_anon_1
+                            .perf_event
+                            .__bindgen_anon_1
+                            .tracepoint
+                            .tp_name = buf.as_mut_ptr() as u64;
+                        s.__bindgen_anon_1
+                            .perf_event
+                            .__bindgen_anon_1
+                            .tracepoint
+                            .name_len = buf.len() as u32;
+                        true
+                    }
+                    libbpf_sys::BPF_PERF_EVENT_KPROBE | libbpf_sys::BPF_PERF_EVENT_KRETPROBE => {
+                        s.__bindgen_anon_1
+                            .perf_event
+                            .__bindgen_anon_1
+                            .kprobe
+                            .func_name = buf.as_mut_ptr() as u64;
+                        s.__bindgen_anon_1
+                            .perf_event
+                            .__bindgen_anon_1
+                            .kprobe
+                            .name_len = buf.len() as u32;
+                        true
+                    }
+                    _ => false,
+                };
+
+                if call_get_info_again {
+                    let item_ptr: *mut libbpf_sys::bpf_link_info = &mut s;
+                    let mut len = size_of_val(&s) as u32;
+                    let ret = unsafe {
+                        libbpf_sys::bpf_obj_get_info_by_fd(
+                            fd.as_raw_fd(),
+                            item_ptr as *mut c_void,
+                            &mut len,
+                        )
+                    };
+                    if ret != 0 {
+                        return None;
+                    }
+                }
+
+                let event_type = match bpf_perf_event_type {
+                    libbpf_sys::BPF_PERF_EVENT_TRACEPOINT => {
+                        let tp_name = unsafe {
+                            s.__bindgen_anon_1
+                                .perf_event
+                                .__bindgen_anon_1
+                                .tracepoint
+                                .tp_name
+                        };
+                        let cookie = unsafe {
+                            s.__bindgen_anon_1
+                                .perf_event
+                                .__bindgen_anon_1
+                                .tracepoint
+                                .cookie
+                        };
+                        let name = (tp_name != 0).then(|| unsafe {
+                            CStr::from_ptr(tp_name as *const c_char).to_owned()
+                        });
+
+                        PerfEventType::Tracepoint { name, cookie }
+                    }
+                    libbpf_sys::BPF_PERF_EVENT_KPROBE | libbpf_sys::BPF_PERF_EVENT_KRETPROBE => {
+                        let func_name = unsafe {
+                            s.__bindgen_anon_1
+                                .perf_event
+                                .__bindgen_anon_1
+                                .kprobe
+                                .func_name
+                        };
+                        let addr =
+                            unsafe { s.__bindgen_anon_1.perf_event.__bindgen_anon_1.kprobe.addr };
+                        let offset =
+                            unsafe { s.__bindgen_anon_1.perf_event.__bindgen_anon_1.kprobe.offset };
+                        let missed =
+                            unsafe { s.__bindgen_anon_1.perf_event.__bindgen_anon_1.kprobe.missed };
+                        let cookie =
+                            unsafe { s.__bindgen_anon_1.perf_event.__bindgen_anon_1.kprobe.cookie };
+                        let func_name = (func_name != 0).then(|| unsafe {
+                            CStr::from_ptr(func_name as *const c_char).to_owned()
+                        });
+
+                        let is_retprobe =
+                            bpf_perf_event_type == libbpf_sys::BPF_PERF_EVENT_KRETPROBE;
+                        PerfEventType::Kprobe {
+                            func_name,
+                            is_retprobe,
+                            addr,
+                            offset,
+                            missed,
+                            cookie,
+                        }
+                    }
+                    ty => PerfEventType::Unknown(ty),
+                };
+
+                LinkTypeInfo::PerfEvent(PerfEventLinkInfo { event_type })
+            }
             _ => LinkTypeInfo::Unknown,
         };
 


### PR DESCRIPTION
heavily inspired by matching bpftool code

New PR created after https://github.com/libbpf/libbpf-rs/pull/1213 was closed due to staleness