### PR TITLE
Add CHANGELOG entry for #1246

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+- Added `Link::info` method for retrieving `LinkInfo`
+- Extended `LinkTypeInfo::PerfEvent` variant to contain newly added
+  `PerfEventLinkInfo` object
+
+
 0.26.0-beta.0
 -------------
 - Added `target_obj_id` and `target_btf_id` fields to `TracingLinkInfo`

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -760,9 +760,9 @@ pub enum PerfEventType {
         /// Cookie value for the kprobe.
         cookie: u64,
     },
+    /// An unknown or unsupported perf event type.
     // TODO: Add support for `BPF_PERF_EVENT_EVENT`, `BPF_PERF_EVENT_UPROBE`
     // `BPF_PERF_EVENT_URETPROBE`
-    /// An unknown or unsupported perf event type.
     Unknown(u32),
 }
 


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1246, which introduced the PerfEventType enum and exposed it via LinkTypeInfo's PerfEvent variant.