### PR TITLE
Introduce Linker::add_buf()

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Added `Link::info` method for retrieving `LinkInfo`
 - Extended `LinkTypeInfo::PerfEvent` variant to contain newly added
   `PerfEventLinkInfo` object
+- Added `Linker::add_buf` method for adding in-memory ELF files to
+  the set of objects to link
 
 
 0.26.0-beta.0

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -52,6 +52,25 @@ impl Linker {
         }
     }
 
+    /// Add a buffer to the set of objects to link.
+    pub fn add_buf(&mut self, buf: &[u8]) -> Result<()> {
+        let opts = null_mut();
+        // SAFETY: `linker` and `buf` are valid pointers.
+        let err = unsafe {
+            libbpf_sys::bpf_linker__add_buf(
+                self.linker.as_ptr(),
+                buf.as_ptr() as *mut _,
+                buf.len() as _,
+                opts,
+            )
+        };
+        if err != 0 {
+            Err(Error::from_raw_os_error(err)).context("bpf_linker__add_buf failed")
+        } else {
+            Ok(())
+        }
+    }
+
     /// Link all BPF object files [added](Self::add_file) to this object into
     /// a single one.
     pub fn link(&self) -> Result<()> {


### PR DESCRIPTION
Add the method to the linker so that in-memory ELF files can be also added to the Linker.