### PR TITLE
Fix Result::Ok link in ErrorKind documentation

### DIFF
--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -241,7 +241,7 @@ pub enum ErrorKind {
     /// The I/O operation's timeout expired, causing it to be canceled.
     TimedOut,
     /// An error returned when an operation could not be completed
-    /// because a call to [`write`] returned [`Ok(0)`].
+    /// because a call to [`write`] returned [`Ok(0)`][Result::Ok].
     WriteZero,
     /// This operation was interrupted.
     ///


### PR DESCRIPTION
Fix a link to the `Result::Ok` variant in the documentation of the `ErrorKind` enum, which is being flagged as broken in more recent versions of Rust.