### PR TITLE
Update task_longrun example to use blazesym 0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --verbose --workspace --exclude runqslower
+        run: cargo build --verbose --workspace --exclude runqslower --exclude task_longrun
 
   build-capable:
     name: Build capable example with static libelf and libz

--- a/examples/task_longrun/Cargo.toml
+++ b/examples/task_longrun/Cargo.toml
@@ -11,10 +11,10 @@ vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc
 
 [dependencies]
 anyhow = "1.0"
+blazesym = "0.2"
+clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
 libbpf-rs = { path = "../../libbpf-rs" }
 plain = "0.2"
-clap = { version = "4.0.32", default-features = false, features = ["std", "derive", "help", "usage"] }
-blazesym = "0.2.0-rc.3"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Update the `task_longrun` example to use `blazesym` version `0.2`, in order to get the latest and greatest.