### PR TITLE
Add CHANGELOG entry for #1274

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
   additional options
 - Added `Program::attach_uprobe_multi` & `Program::attach_uprobe_multi_opts`
   to enable attachments of multi uprobes at once
+- Added `OpenProgram::autoload` getter
 
 
 0.26.0-beta.0


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1274, which added the `autoload` getter to the `OpenProgram` type.