### PR TITLE
Reorganize test code

### DIFF
--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -11,6 +11,7 @@ description = "libbpf-rs is a safe, idiomatic, and opinionated wrapper around li
 readme = "README.md"
 authors = ["Daniel Xu <dxu@dxuuu.xyz>", "Daniel Müller <deso@posteo.net>"]
 keywords = ["bpf", "ebpf", "libbpf"]
+autotests = false
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -33,6 +34,9 @@ generate-test-files = ["libbpf-sys/vendored-libbpf", "dep:tempfile"]
 # Disable generation of test files. This feature takes preference over
 # `generate-test-files`.
 dont-generate-test-files = []
+
+[[test]]
+name = "test"
 
 [dependencies]
 bitflags = "2.0"

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -2,6 +2,12 @@
 
 mod common;
 
+mod test_netfilter;
+mod test_print;
+mod test_streams;
+mod test_tc;
+mod test_xdp;
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env::current_exe;

--- a/libbpf-rs/tests/test_netfilter.rs
+++ b/libbpf-rs/tests/test_netfilter.rs
@@ -1,8 +1,5 @@
 //! Tests for the NetFilter functionality.
 
-#[allow(dead_code)]
-mod common;
-
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;

--- a/libbpf-rs/tests/test_streams.rs
+++ b/libbpf-rs/tests/test_streams.rs
@@ -1,8 +1,5 @@
 //! Tests for BPF program streams (stdout/stderr).
 
-#[allow(dead_code)]
-mod common;
-
 use std::io::Read;
 
 use libbpf_rs::ProgramInput;

--- a/libbpf-rs/tests/test_tc.rs
+++ b/libbpf-rs/tests/test_tc.rs
@@ -1,8 +1,5 @@
 //! Tests for the TC functionality.
 
-#[allow(dead_code)]
-mod common;
-
 use std::os::unix::io::AsFd as _;
 use std::os::unix::io::BorrowedFd;
 

--- a/libbpf-rs/tests/test_xdp.rs
+++ b/libbpf-rs/tests/test_xdp.rs
@@ -1,8 +1,5 @@
 //! Tests for the XDP functionality.
 
-#[allow(dead_code)]
-mod common;
-
 use std::os::fd::AsFd;
 
 use scopeguard::defer;


### PR DESCRIPTION
Reorganize the test code a bit by having only a single binary for integration tests. That's beneficial for compile and test times, but most importantly eliminates the need for each integration test to import the 'common' module, which can be confusing.