### PR TITLE
libbpf-cargo: Improve handling of trailing bitfields

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Fixed Rust type generation for trailing bitfields in composite C types
 - Allowlisted `libbpf-sys` `1.6.2`
 
 


### PR DESCRIPTION
Improve the handling of trailing bitfields in struct types, for which we missed the emitting of padding bytes.

Closes: #1285