### PR TITLE
Update vmlinux.h snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "phf",
  "plain",
  "time",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ dependencies = [
  "libbpf-rs",
  "tracing",
  "tracing-subscriber",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ dependencies = [
  "test-log",
  "tracing",
  "tracing-subscriber",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "plain",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=8f91e9fd5b488ff57074e589e3960940f3387830)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "plain",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -896,7 +896,7 @@ dependencies = [
  "libc",
  "plain",
  "time",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1106,7 +1106,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "plain",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1119,7 +1119,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "nix 0.28.0",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1264,7 +1264,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "nix 0.28.0",
- "vmlinux 0.0.0 (git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94)",
+ "vmlinux",
 ]
 
 [[package]]
@@ -1338,12 +1338,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vmlinux"
 version = "0.0.0"
-source = "git+https://github.com/libbpf/vmlinux.h.git?rev=83a228cf37fc65f2d14e4896a04922b5ee531a94#83a228cf37fc65f2d14e4896a04922b5ee531a94"
-
-[[package]]
-name = "vmlinux"
-version = "0.0.0"
-source = "git+https://github.com/libbpf/vmlinux.h.git?rev=8f91e9fd5b488ff57074e589e3960940f3387830#8f91e9fd5b488ff57074e589e3960940f3387830"
+source = "git+https://github.com/libbpf/vmlinux.h.git?rev=991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52#991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52"
 
 [[package]]
 name = "vsprintf"

--- a/examples/capable/Cargo.toml
+++ b/examples/capable/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0.4"

--- a/examples/compiler_warnings/Cargo.toml
+++ b/examples/compiler_warnings/Cargo.toml
@@ -9,7 +9,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 libbpf-cargo = { path = "../../libbpf-cargo" }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = {version = "0.3", features = ["ansi", "chrono", "env-filter", "fmt"]}
-vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { version = "0.0", git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }

--- a/examples/netfilter_blocklist/Cargo.toml
+++ b/examples/netfilter_blocklist/Cargo.toml
@@ -6,7 +6,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "8f91e9fd5b488ff57074e589e3960940f3387830" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [[bin]]
 name = "netfilter_blocklist"

--- a/examples/ringbuf_multi/Cargo.toml
+++ b/examples/ringbuf_multi/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 libbpf-rs = { path = "../../libbpf-rs" }

--- a/examples/runqslower/Cargo.toml
+++ b/examples/runqslower/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/task_longrun/Cargo.toml
+++ b/examples/task_longrun/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tc_port_whitelist/Cargo.toml
+++ b/examples/tc_port_whitelist/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tcp_ca/Cargo.toml
+++ b/examples/tcp_ca/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 clap = { version = "4.0.32", features = ["derive"] }

--- a/examples/tcp_option/Cargo.toml
+++ b/examples/tcp_option/Cargo.toml
@@ -6,7 +6,7 @@ license = "LGPL-2.1-only OR BSD-2-Clause"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/tproxy/Cargo.toml
+++ b/examples/tproxy/Cargo.toml
@@ -10,7 +10,7 @@ name = "proxy"
 
 [build-dependencies]
 libbpf-cargo = { path = "../../libbpf-cargo" }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dependencies]
 anyhow = "1.0"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -48,7 +48,7 @@ libbpf-sys_restricted = { package = "libbpf-sys", version = ">=1.5.0, <=1.6.2", 
 goblin = "0.9"
 indoc = "2"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [lints]
 workspace = true

--- a/libbpf-rs/dev/Cargo.toml
+++ b/libbpf-rs/dev/Cargo.toml
@@ -21,7 +21,7 @@ dont-generate-test-files = []
 [build-dependencies]
 libbpf-sys = { version = "1.5.0", default-features = false, optional = true }
 tempfile = { version = "3.15", optional = true }
-vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "83a228cf37fc65f2d14e4896a04922b5ee531a94" }
+vmlinux = { git = "https://github.com/libbpf/vmlinux.h.git", rev = "991dd4b8dfd8c9d62ce8999521b24f61d9b7fc52" }
 
 [dev-dependencies]
 # A set of unused dependencies that we require to force correct minimum versions


### PR DESCRIPTION
Update the vmlinux.h snapshot we use, suitable for kernel 6.18. Also make sure we only consume a single vmlinux.h version.