### PR TITLE
map: Add lookup_into() method

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
 - Added `Program::{stdout,stderr}` for accessing BPF stdout and stderr
   streams
 - Added `OpenProgram::autoload` getter
+- Added `MapCore::lookup_into` for looking up values into preallocated
+  buffers
 
 
 0.26.0-beta.0


### PR DESCRIPTION
Allows looking up into a preallocated buffer.

This API is just a proposal - lmk what you think?
