### PR TITLE
Publicly export BatchedMapIter

### DIFF
--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -99,6 +99,7 @@ pub use crate::error::Result;
 pub use crate::iter::Iter;
 pub use crate::link::Link;
 pub use crate::linker::Linker;
+pub use crate::map::BatchedMapIter;
 pub use crate::map::Map;
 pub use crate::map::MapCore;
 pub use crate::map::MapFlags;

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -971,7 +971,7 @@ impl AsRawLibbpf for Map<'_> {
 
 /// A handle to a map. Handles can be duplicated and dropped.
 ///
-/// While possible to [created directly][MapHandle::create], in many cases it is
+/// While possible to [create directly][MapHandle::create], in many cases it is
 /// useful to create such a handle from an existing [`Map`]:
 /// ```no_run
 /// # use libbpf_rs::Map;


### PR DESCRIPTION
`BatchedMapIter` is a public type but was never exported via `lib.rs`. As a result, it was impossible to name, making it potentially awkward to use. Export it properly.