### PR TITLE
Correctly annotate return lifetimes

### DIFF
--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -293,7 +293,7 @@ impl<'btf> Btf<'btf> {
     /// Gets a string at a given offset.
     ///
     /// Returns [`None`] when the offset is out of bounds or if the name is empty.
-    fn name_at(&self, offset: u32) -> Option<&OsStr> {
+    fn name_at(&self, offset: u32) -> Option<&'btf OsStr> {
         let name = unsafe {
             // SAFETY:
             // Assuming that btf is a valid pointer, this is always okay to call.

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -68,7 +68,7 @@ impl<'obj> OpenMap<'obj> {
     }
 
     /// Retrieve the [`OpenMap`]'s name.
-    pub fn name(&self) -> &OsStr {
+    pub fn name(&self) -> &'obj OsStr {
         // SAFETY: We ensured `ptr` is valid during construction.
         let name_ptr = unsafe { libbpf_sys::bpf_map__name(self.ptr.as_ptr()) };
         // SAFETY: `bpf_map__name` can return NULL but only if it's passed

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -313,7 +313,7 @@ impl<'obj> OpenProgram<'obj> {
     }
 
     /// Retrieve the name of this `OpenProgram`.
-    pub fn name(&self) -> &OsStr {
+    pub fn name(&self) -> &'obj OsStr {
         let name_ptr = unsafe { libbpf_sys::bpf_program__name(self.ptr.as_ptr()) };
         let name_c_str = unsafe { CStr::from_ptr(name_ptr) };
         // SAFETY: `bpf_program__name` always returns a non-NULL pointer.
@@ -321,7 +321,7 @@ impl<'obj> OpenProgram<'obj> {
     }
 
     /// Retrieve the name of the section this `OpenProgram` belongs to.
-    pub fn section(&self) -> &OsStr {
+    pub fn section(&self) -> &'obj OsStr {
         // SAFETY: The program is always valid.
         let p = unsafe { libbpf_sys::bpf_program__section_name(self.ptr.as_ptr()) };
         // SAFETY: `bpf_program__section_name` will always return a non-NULL
@@ -349,7 +349,7 @@ impl<'obj> OpenProgram<'obj> {
     /// instructions will be CO-RE-relocated, BPF subprograms instructions will be appended, ldimm64
     /// instructions will have FDs embedded, etc. So instructions returned before load and after it
     /// might be quite different.
-    pub fn insns(&self) -> &[libbpf_sys::bpf_insn] {
+    pub fn insns(&self) -> &'obj [libbpf_sys::bpf_insn] {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
         unsafe { slice::from_raw_parts(ptr, count) }
@@ -789,7 +789,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Retrieve the name of this `Program`.
-    pub fn name(&self) -> &OsStr {
+    pub fn name(&self) -> &'obj OsStr {
         let name_ptr = unsafe { libbpf_sys::bpf_program__name(self.ptr.as_ptr()) };
         let name_c_str = unsafe { CStr::from_ptr(name_ptr) };
         // SAFETY: `bpf_program__name` always returns a non-NULL pointer.
@@ -797,7 +797,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Retrieve the name of the section this `Program` belongs to.
-    pub fn section(&self) -> &OsStr {
+    pub fn section(&self) -> &'obj OsStr {
         // SAFETY: The program is always valid.
         let p = unsafe { libbpf_sys::bpf_program__section_name(self.ptr.as_ptr()) };
         // SAFETY: `bpf_program__section_name` will always return a non-NULL
@@ -905,7 +905,7 @@ impl<'obj> Program<'obj> {
     /// Gives read-only access to BPF program's underlying BPF instructions.
     ///
     /// Please see note in [`OpenProgram::insns`].
-    pub fn insns(&self) -> &[libbpf_sys::bpf_insn] {
+    pub fn insns(&self) -> &'obj [libbpf_sys::bpf_insn] {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
         unsafe { slice::from_raw_parts(ptr, count) }


### PR DESCRIPTION
These references are borrowed from the underlying object, not the &self
reference.
