### PR TITLE
libbpf-cargo: Honor ObjectBuilder in skeleton infrastructure

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Fixed Rust type generation for trailing bitfields in composite C types
+- Fixed handling of `XxxSkelBuilder::obj_builder` customizations when
+  using `open()` constructor
 - Allowlisted `libbpf-sys` `1.6.2`
 
 


### PR DESCRIPTION
With commit d105bf230cc7 ("libbpf-cargo: Open skeleton without options by default") we changed the default behavior of the generated SkelBuilder to only use open options if explicitly provided to the newly added open_opts() constructor. What wasn't handled correctly was the existing options present in the obj_builder member.

Fix this by trying to be more clever and auto detect whether the ObjectBuilder has had any changes over its default representation.

Closes: #1309
Reported-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>