### PR TITLE
Fix sporadic test_print test failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "scopeguard",
  "serial_test",
  "tempfile",
+ "test-fork",
  "test-tag",
  "vsprintf",
 ]
@@ -1151,6 +1152,33 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "test-fork"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f0a9bb71b4a8a0f9c8d73babc8485fef8edbddcba52a6994f08010c817cf88"
+dependencies = [
+ "test-fork-core",
+ "test-fork-macros",
+]
+
+[[package]]
+name = "test-fork-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5ffda5a1ceaccc77ec98edbbb372e26d64fda679b3c5763e03f6d949be5cb99"
+
+[[package]]
+name = "test-fork-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89d30719f772502bbed7e1613f7613b7cfc16609708be2c4a8a0c236b2ec5d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/libbpf-rs/Cargo.toml
+++ b/libbpf-rs/Cargo.toml
@@ -59,6 +59,7 @@ probe = "0.3"
 scopeguard = "1.1"
 serial_test = { version = "3.0", default-features = false }
 tempfile = "3.3"
+test-fork = "0.1"
 test-tag = "0.1"
 
 # A set of unused dependencies that we require to force correct minimum versions

--- a/libbpf-rs/tests/test_print.rs
+++ b/libbpf-rs/tests/test_print.rs
@@ -1,9 +1,7 @@
-//! This test is in its own file because the underlying `libbpf_set_print` function used by
-//! `set_print()` and `ObjectBuilder::debug()` sets global state. The default is to run multiple
-//! tests in different threads, so this test will always race with the others unless its isolated to
-//! a different process.
-//!
-//! For the same reason, all tests here must run serially.
+// Note that the `libbpf_set_print` function underlying `set_print()`
+// and `ObjectBuilder::debug()` sets global state. To prevent issues
+// with tests loading objects and similar we run print tests in separate
+// processes.
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -13,10 +11,12 @@ use libbpf_rs::set_print;
 use libbpf_rs::ObjectBuilder;
 use libbpf_rs::PrintCallback;
 use libbpf_rs::PrintLevel;
-use serial_test::serial;
 
+use test_fork::fork;
+
+
+#[fork]
 #[test]
-#[serial]
 fn test_set_print() {
     static CORRECT_LEVEL: AtomicBool = AtomicBool::new(false);
     static CORRECT_MESSAGE: AtomicBool = AtomicBool::new(false);
@@ -42,8 +42,8 @@ fn test_set_print() {
     assert!(correct_message, "Did not capture the correct message");
 }
 
+#[fork]
 #[test]
-#[serial]
 fn test_set_restore_print() {
     fn callback1(_: PrintLevel, _: String) {
         println!("one");
@@ -61,8 +61,8 @@ fn test_set_restore_print() {
     assert_eq!(prev, Some((PrintLevel::Debug, callback2 as PrintCallback)));
 }
 
+#[fork]
 #[test]
-#[serial]
 fn test_set_and_save_print() {
     fn callback1(_: PrintLevel, _: String) {
         println!("one");


### PR DESCRIPTION
We have seen a few sporadic CI failures of the test_print tests. The reason is that these tests set process-global state that is also touched by ObjectBuilder::debug(). This is fallout of commit 1a8fe380070e ("Reorganize test code").
To fix the issue, make sure to run the test_print tests, which actively check correctness of set_print(), in separate processes.