### PR TITLE
libbpf-rs: BTF custom path setter in ObjectBuilder

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased
   buffers
 - Added `verified_insns` attribute to `query::ProgramInfo` type
 - Made `query::ProgramInfo` non-exhaustive
+- Added `ObjectBuilder::btf_custom_path` setter
 
 
 0.26.0-beta.0

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -142,6 +142,26 @@ fn test_object_name() {
 
 #[tag(root)]
 #[test]
+fn test_valid_btf_custom_path() {
+    let obj_path = get_test_object_path("runqslower.bpf.o");
+    let mut builder = ObjectBuilder::default();
+    builder.btf_custom_path("/sys/kernel/btf/vmlinux").unwrap();
+    let obj = builder.open_file(obj_path).expect("failed to build object");
+    obj.load().expect("failed to load object");
+}
+
+#[tag(root)]
+#[test]
+fn test_invalid_btf_custom_path() {
+    let obj_path = get_test_object_path("runqslower.bpf.o");
+    let mut builder = ObjectBuilder::default();
+    builder.btf_custom_path("/").unwrap();
+    let obj = builder.open_file(obj_path).expect("failed to build object");
+    assert!(obj.load().is_err());
+}
+
+#[tag(root)]
+#[test]
 fn test_object_maps() {
     let mut obj = get_test_object("runqslower.bpf.o");
     let _map = get_map_mut(&mut obj, "start");


### PR DESCRIPTION
Allowing to set a custom BTF path in the object builder will reduce the boilerplate that's currently necessary. Making libbpf use a separate BTF file is incredibly important in systems that don't ship it. Looking at you, Nvidia and Raspberry Pi official kernels.

It also can be very helpeful when testing for ABI changes in kernels and it would have been quite helpful for a few investigations where kernel changes have prevented the loading of BPF programs as they either exposed bugs in our code.

Several users libbpf-rs that set this option currently leak memory (which might not be a big deal since it's a one-off and not a lot of memory) but having this as a blessed, leak-free way to do it would be great.

Test Plan
=========

Updated https://github.com/javierhonduco/lightswitch/pull/367/commits with these changes and verified test pass (which exercise setting an alternative BTF path) and that ASAN reports no issues.
