### PR TITLE
Make query::ProgramInfo non-exhaustive

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -16,6 +16,7 @@ Unreleased
 - Added `MapCore::lookup_into` for looking up values into preallocated
   buffers
 - Added `verified_insns` attribute to `query::ProgramInfo` type
+- Made `query::ProgramInfo` non-exhaustive
 
 
 0.26.0-beta.0

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -182,6 +182,9 @@ pub struct ProgramInfo {
     pub recursion_misses: u64,
     /// Number of instructions that were verified by the verifier.
     pub verified_insns: u32,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
 }
 
 /// An iterator for the information of loaded bpf programs.
@@ -423,6 +426,7 @@ impl ProgramInfo {
             run_cnt: item.run_cnt,
             recursion_misses: item.recursion_misses,
             verified_insns: item.verified_insns,
+            _non_exhaustive: (),
         })
     }
 }


### PR DESCRIPTION
Make the `query::ProgramInfo` type non-exhaustive, to be more friendly to future extension.