### PR TITLE
libbpf-cargo: Allowlist libbpf-sys 1.6.3

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased
 - Fixed Rust type generation for trailing bitfields in composite C types
 - Fixed handling of `XxxSkelBuilder::obj_builder` customizations when
   using `open()` constructor
-- Allowlisted `libbpf-sys` `1.6.2`
+- Allowlisted `libbpf-sys` `1.6.3`
 
 
 0.26.0-beta.1

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -42,7 +42,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "chrono", "fmt"] }
 # `libbpf` is unable to provide necessary backwards compatibility
 # guarantees so we have to explicitly opt-in to newer versions...
-libbpf-sys_restricted = { package = "libbpf-sys", version = ">=1.5.0, <=1.6.2", default-features = false }
+libbpf-sys_restricted = { package = "libbpf-sys", version = ">=1.5.0, <=1.6.3", default-features = false }
 
 [dev-dependencies]
 goblin = "0.9"


### PR DESCRIPTION
libbpf 1.6.3 seems fine to use with our library. Allow list it accordingly.