### PR TITLE
Release 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.0-beta.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.0-beta.1"
+version = "0.26.0"
 dependencies = [
  "bitflags 2.10.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.26.0-beta.1"
+version = "0.26.0"
 edition = "2021"
 rust-version = "1.82"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.26.0
+------
 - Fixed Rust type generation for trailing bitfields in composite C types
 - Fixed handling of `XxxSkelBuilder::obj_builder` customizations when
   using `open()` constructor

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ default = ["libbpf-rs/default"]
 anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
 clap = { version = "4.0.32", features = ["derive"] }
-libbpf-rs = { version = "=0.26.0-beta.1", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "0.26", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/libbpf-cargo/README.md
+++ b/libbpf-cargo/README.md
@@ -12,7 +12,7 @@ Helps you build and develop BPF programs with standard Rust tooling.
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [build-dependencies]
-libbpf-cargo = "=0.26.0-beta.1"
+libbpf-cargo = "0.26.0"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-cargo).

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.26.0
+------
 - Added `Link::info` method for retrieving `LinkInfo`
 - Extended `LinkTypeInfo::PerfEvent` variant to contain newly added
   `PerfEventLinkInfo` object

--- a/libbpf-rs/README.md
+++ b/libbpf-rs/README.md
@@ -12,7 +12,7 @@ Idiomatic Rust wrapper around [libbpf](https://github.com/libbpf/libbpf).
 To use in your project, add into your `Cargo.toml`:
 ```toml
 [dependencies]
-libbpf-rs = "=0.26.0-beta.1"
+libbpf-rs = "0.26.0"
 ```
 
 See [full documentation here](https://docs.rs/libbpf-rs).


### PR DESCRIPTION
Prepare for release of 0.26.0 by bumping both libbpf-rs and libbpf-cargo versions accordingly.