### PR TITLE
map: Add MapCore::query_fdinfo

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `MapCore::query_fdinfo` for querying map fdinfo
+
+
 0.26.0
 ------
 - Added `Link::info` method for retrieving `LinkInfo`

--- a/libbpf-rs/src/lib.rs
+++ b/libbpf-rs/src/lib.rs
@@ -102,6 +102,7 @@ pub use crate::linker::Linker;
 pub use crate::map::BatchedMapIter;
 pub use crate::map::Map;
 pub use crate::map::MapCore;
+pub use crate::map::MapFdInfo;
 pub use crate::map::MapFlags;
 pub use crate::map::MapHandle;
 pub use crate::map::MapImpl;

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -464,7 +464,7 @@ impl<T> AsRawLibbpf for OpenProgramImpl<'_, T> {
 /// Type of a [`Program`]. Maps to `enum bpf_prog_type` in kernel uapi.
 #[non_exhaustive]
 #[repr(u32)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 // TODO: Document variants.
 #[expect(missing_docs)]
 pub enum ProgramType {


### PR DESCRIPTION
There's the same concept for programs too, there it seems that the only field not present in `bpf_prog_info` is `memlock`. I can add it too later