### PR TITLE
Add CHANGELOG entry for #1336

### DIFF
--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Added `SkeletonBuilder::reference_obj` for enabling generate skeleton
+  to reference an object file instead of embedding it
+
+
 0.26.0
 ------
 - Fixed Rust type generation for trailing bitfields in composite C types

--- a/libbpf-cargo/src/test.rs
+++ b/libbpf-cargo/src/test.rs
@@ -1215,7 +1215,6 @@ fn test_skeleton_builder_reference_obj() {
 
 /// Check that the default skeleton inlines bytes rather than using `include_bytes!`.
 #[test]
-#[ignore = "may fail on some systems; depends on kernel headers that have been seen to be broken"]
 fn test_skeleton_builder_default_inlines_bytes() {
     let (_dir, proj_dir, _cargo_toml) = setup_temp_project();
 


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1336, which added added the SkeletonBuilder::reference_obj() method to enable generated skeletons to only reference instead of embed an object file. Doing so can reduce the size of the skeleton potentially dramatically, and improve compilation times along the way.