### PR TITLE
Fix attach_uprobe_multi_with_opts opts

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -1107,7 +1107,11 @@ impl<'obj> ProgramMut<'obj> {
         } = opts;
 
         let pattern = util::str_to_cstring(func_pattern.as_ref())?;
-        let pattern_ptr = pattern.as_ptr();
+        let pattern_ptr = if pattern.is_empty() {
+            ptr::null()
+        } else {
+            pattern.as_ptr()
+        };
 
         let syms_cstrings = syms
             .iter()

--- a/libbpf-rs/tests/bin/src/uprobe_multi.bpf.c
+++ b/libbpf-rs/tests/bin/src/uprobe_multi.bpf.c
@@ -42,4 +42,21 @@ int handle__uprobe_multi_with_opts(void *ctx)
     return 0;
 }
 
+SEC("uprobe.multi")
+int handle__uprobe_multi_with_non_default_opts(void *ctx)
+{
+    const int key = 1, init_val = 1;
+
+    int *val = bpf_map_lookup_elem(&hash_map, &key);
+    if (val) {
+        __sync_fetch_and_add(val, 1);
+        bpf_printk("handle__uprobe_multi_with_non_default_opts: val=%d\n",
+                   *val);
+    } else {
+        bpf_map_update_elem(&hash_map, &key, &init_val, BPF_ANY);
+    }
+
+    return 0;
+}
+
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
Currently `func_pattern` is mandatory in `attach_uprobe_multi_with_opts` Although in the C api it is optional, and mutually exclusive with some other options. The rust api didn't allow passing null pointer, which made it impossible to use `syms`/`offsets`/`ref_ctr_offsets`/`cookies` from `opts` because of the following check -
https://github.com/libbpf/libbpf/blob/3b4f0ef5a6fa247ce1958d909c0e85e760249840/src/libbpf.c#L12172

Thank you for considering a contribution!

In order to streamline review experience for contributors and reviewers, please
be sure to *read* and *follow* the [Contributor's Guide][cont-guide]. It
lays out basic best practices, which, if followed will reduce unnecessary back
and forth and, ultimately, minimize the time it takes to get your change into
the library.

[cont-guide]: https://github.com/libbpf/libbpf-rs/blob/master/CONTRIBUTING.md
