### PR TITLE
Add CHANGELOG entry for #1345

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added `MapCore::query_fdinfo` for querying map fdinfo
+- Adjusted `Program::attach_uprobe_multi_with_opts` to work with empty
+  `func_pattern`
 
 
 0.26.0

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -1107,6 +1107,7 @@ impl<'obj> ProgramMut<'obj> {
         } = opts;
 
         let pattern = util::str_to_cstring(func_pattern.as_ref())?;
+        // TODO: We should push optionality into method signature.
         let pattern_ptr = if pattern.is_empty() {
             ptr::null()
         } else {


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1345, which adjusted Program::attach_uprobe_multi_with_opts() to map an empty `func_pattern` to a NULL pointer input to the underlying libbpf API, to enable additional use cases.