### PR TITLE
Add CHANGELOG entry for #1349

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added `MapCore::query_fdinfo` for querying map fdinfo
+- Added `ProgramType::Netfilter` variant
 - Adjusted `Program::attach_uprobe_multi_with_opts` to work with empty
   `func_pattern`
 


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1349, which added the `ProgramType::Netfilter` variant.