### PR TITLE
libbpf-rs: Fix BTF int offset extraction from aux word

### DIFF
--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -394,7 +394,7 @@ impl<'btf> TryFrom<BtfType<'btf>> for Int<'btf> {
             Ok(Self {
                 source: t,
                 encoding,
-                offset: ((int & 0x00_ff_00_00) >> 24) as u8,
+                offset: ((int & 0x00_ff_00_00) >> 16) as u8,
                 bits: (int & 0x00_00_00_ff) as u8,
             })
         } else {


### PR DESCRIPTION
## What

Correct the shift applied after masking bits 16–23 of the BTF `KIND_INT` auxiliary `u32` when building `Int::offset`. The mask `0x00_ff_00_00` must be paired with a shift of 16, not 24, so the field matches the layout used by `BTF_INT_ENCODING` in the kernel UAPI.

## Why

With shift 24, the masked value was decoded from the wrong bit positions, so `Int::offset` did not reflect the encoded offset.