### PR TITLE
fix: Update flag comment in netfilter.rs to BPF_F_NETFILTER_IP_DEFRAG

### DIFF
--- a/libbpf-rs/src/netfilter.rs
+++ b/libbpf-rs/src/netfilter.rs
@@ -38,7 +38,7 @@ pub struct NetfilterOpts {
     pub priority: i32,
 
     /// Bitmask of flags for the netfilter hook.
-    /// - `NF_IP_PRI_CONNTRACK_DEFRAG` - Enables defragmentation of IP fragments. This hook will
+    /// - `BPF_F_NETFILTER_IP_DEFRAG` - Enables defragmentation of IP fragments. This hook will
     ///   only see defragmented packets.
     pub flags: u32,
     #[doc(hidden)]


### PR DESCRIPTION
## Context (What?)

Updating inline documentation to reflect correct flag usage for NetfilterOpts.


#### Which issue(s) this pull request fixes:
https://github.com/libbpf/libbpf-rs/issues/1369
