### PR TITLE
query: add kprobe_multi & uprobe_multi link info fields that require second info call

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `KprobeMultiLinkInfo` fields that required a second info call.
+
+
 0.26.2
 ------
 - Added `ProgramMut::assoc_struct_ops` for associating non-struct_ops programs

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
-- Added `KprobeMultiLinkInfo` fields that required a second info call.
+- Added `KprobeMultiLinkInfo` & `UprobeMultiLinkInfo` fields that required a
+  second info call.
 
 
 0.26.2

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -13,6 +13,7 @@
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::ffi::OsStr;
 use std::io;
 use std::mem::size_of_val;
 use std::mem::zeroed;
@@ -22,6 +23,8 @@ use std::os::fd::BorrowedFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 use std::os::raw::c_char;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
 use std::ptr;
 use std::time::Duration;
 
@@ -731,12 +734,20 @@ pub struct KprobeMultiLinkInfo {
 pub struct UprobeMultiLinkInfo {
     /// Size of the path.
     pub path_size: u32,
+    /// The absolute file path of the binary being probed.
+    pub path: Option<PathBuf>,
     /// Count of uprobe targets.
     pub count: u32,
     /// Flags for the link.
     pub flags: u32,
     /// PID to which the uprobe is attached.
     pub pid: u32,
+    /// Offsets from the binary.
+    pub offsets: Vec<u64>,
+    /// Offsets of kernel reference counted USDT semaphore.
+    pub ref_ctr_offsets: Vec<u64>,
+    /// Cookies corresponding to the attach addresses.
+    pub cookies: Vec<u64>,
 }
 
 /// Information about a perf event link.
@@ -968,11 +979,45 @@ impl LinkInfo {
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_UPROBE_MULTI => {
+                let mut buf = [0u8; libc::PATH_MAX as usize];
+                let count = unsafe { s.__bindgen_anon_1.uprobe_multi.count } as usize;
+                let mut offsets = vec![0; count];
+                let mut ref_ctr_offsets = vec![0; count];
+                let mut cookies = vec![0; count];
+
+                s.__bindgen_anon_1.uprobe_multi.path = buf.as_mut_ptr() as u64;
+                s.__bindgen_anon_1.uprobe_multi.path_size = buf.len() as u32;
+                s.__bindgen_anon_1.uprobe_multi.offsets = offsets.as_mut_ptr() as u64;
+                s.__bindgen_anon_1.uprobe_multi.ref_ctr_offsets =
+                    ref_ctr_offsets.as_mut_ptr() as u64;
+                s.__bindgen_anon_1.uprobe_multi.cookies = cookies.as_mut_ptr() as u64;
+                let item_ptr: *mut libbpf_sys::bpf_link_info = &mut s;
+                let mut len = size_of_val(&s) as u32;
+                let ret = unsafe {
+                    libbpf_sys::bpf_obj_get_info_by_fd(fd.as_raw_fd(), item_ptr.cast(), &mut len)
+                };
+                if ret != 0 {
+                    return None;
+                }
+
+                let path_size = unsafe { s.__bindgen_anon_1.uprobe_multi.path_size };
+                let path = if path_size != 0 {
+                    let path_ptr = unsafe { s.__bindgen_anon_1.uprobe_multi.path } as *const c_char;
+                    let c_str = unsafe { CStr::from_ptr(path_ptr) };
+                    Some(PathBuf::from(OsStr::from_bytes(c_str.to_bytes())))
+                } else {
+                    None
+                };
+
                 LinkTypeInfo::UprobeMulti(UprobeMultiLinkInfo {
-                    path_size: unsafe { s.__bindgen_anon_1.uprobe_multi.path_size },
+                    path_size,
+                    path,
                     count: unsafe { s.__bindgen_anon_1.uprobe_multi.count },
                     flags: unsafe { s.__bindgen_anon_1.uprobe_multi.flags },
                     pid: unsafe { s.__bindgen_anon_1.uprobe_multi.pid },
+                    offsets,
+                    ref_ctr_offsets,
+                    cookies,
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_SOCKMAP => LinkTypeInfo::SockMap(SockMapLinkInfo {

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -720,6 +720,10 @@ pub struct KprobeMultiLinkInfo {
     pub flags: u32,
     /// Missed probes count.
     pub missed: u64,
+    /// Addresses of the probe.
+    pub addrs: Vec<u64>,
+    /// Cookies corresponding to the attach addresses.
+    pub cookies: Vec<u64>,
 }
 
 /// Information about a multi-uprobe link.
@@ -940,10 +944,27 @@ impl LinkInfo {
                 map_id: unsafe { s.__bindgen_anon_1.struct_ops.map_id },
             }),
             libbpf_sys::BPF_LINK_TYPE_KPROBE_MULTI => {
+                let count = unsafe { s.__bindgen_anon_1.kprobe_multi.count } as usize;
+                let mut addrs = vec![0; count];
+                let mut cookies = vec![0; count];
+
+                s.__bindgen_anon_1.kprobe_multi.addrs = addrs.as_mut_ptr() as u64;
+                s.__bindgen_anon_1.kprobe_multi.cookies = cookies.as_mut_ptr() as u64;
+                let item_ptr: *mut libbpf_sys::bpf_link_info = &mut s;
+                let mut len = size_of_val(&s) as u32;
+                let ret = unsafe {
+                    libbpf_sys::bpf_obj_get_info_by_fd(fd.as_raw_fd(), item_ptr.cast(), &mut len)
+                };
+                if ret != 0 {
+                    return None;
+                }
+
                 LinkTypeInfo::KprobeMulti(KprobeMultiLinkInfo {
                     count: unsafe { s.__bindgen_anon_1.kprobe_multi.count },
                     flags: unsafe { s.__bindgen_anon_1.kprobe_multi.flags },
                     missed: unsafe { s.__bindgen_anon_1.kprobe_multi.missed },
+                    addrs,
+                    cookies,
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_UPROBE_MULTI => {

--- a/libbpf-rs/tests/common/mod.rs
+++ b/libbpf-rs/tests/common/mod.rs
@@ -143,3 +143,28 @@ fn check_symbol_offset(elf: &Elf, sym: &sym::Sym) -> Option<usize> {
     }
     None
 }
+
+pub(crate) fn resolve_ksym_addr(sym_name: &str) -> Option<u64> {
+    let kallsyms = fs::read_to_string("/proc/kallsyms").ok()?;
+
+    for line in kallsyms.split('\n') {
+        let mut parts = line.split_whitespace();
+        let Some(addr) = parts.next() else {
+            continue;
+        };
+        if parts.next().is_none() {
+            continue;
+        }
+        let Some(sym) = parts.next() else {
+            continue;
+        };
+
+        if sym_name == sym {
+            return Some(
+                u64::from_str_radix(addr, 16).expect("ksym found but could not resolve addr"),
+            );
+        }
+    }
+
+    None
+}

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -19,6 +19,7 @@ use std::fs;
 use std::hint;
 use std::io;
 use std::io::Read;
+use std::iter::zip;
 use std::mem::size_of;
 use std::mem::size_of_val;
 use std::os::unix::io::AsFd;
@@ -37,6 +38,7 @@ use std::sync::mpsc::channel;
 use std::time::Duration;
 
 use libbpf_rs::num_possible_cpus;
+use libbpf_rs::query::KprobeMultiLinkInfo;
 use libbpf_rs::query::LinkTypeInfo;
 use libbpf_rs::query::PerfEventType;
 use libbpf_rs::query::ProgInfoIter;
@@ -1854,16 +1856,47 @@ fn test_object_kprobe_multi_with_opts() {
     let mut obj = open_obj.load().expect("failed to load object");
     let prog = get_prog_mut(&mut obj, "handle__kprobe");
 
+    let syms_opt = vec![
+        "bpf_fentry_test1".to_string(),
+        "bpf_fentry_test2".to_string(),
+    ];
+    let cookies_opt = vec![6, 7];
     let opts = KprobeMultiOpts {
-        symbols: vec![
-            "bpf_fentry_test1".to_string(),
-            "bpf_fentry_test2".to_string(),
-        ],
+        symbols: syms_opt.clone(),
+        cookies: cookies_opt.clone(),
         ..Default::default()
     };
-    let _link = prog
+
+    let link = prog
         .attach_kprobe_multi_with_opts(opts)
         .expect("failed to attach prog");
+
+    let link_info = link.info().expect("failed to get kprobe_multi link info");
+    let LinkTypeInfo::KprobeMulti(kprobe_multi) = link_info.info else {
+        panic!(
+            "Expected LinkTypeInfo::KprobeMulti for kprobe_multi, got: {:?}",
+            link_info.info
+        );
+    };
+
+    let KprobeMultiLinkInfo {
+        count,
+        addrs,
+        cookies,
+        ..
+    } = kprobe_multi;
+    assert_eq!(count, syms_opt.len() as u32);
+    for (actual, sym) in zip(addrs, syms_opt) {
+        let Some(expected) = common::resolve_ksym_addr(&sym) else {
+            // requires reading `/proc/kallsyms`
+            break;
+        };
+
+        assert_eq!(actual, expected);
+    }
+    for (actual, expected) in zip(cookies, cookies_opt) {
+        assert_eq!(actual, expected);
+    }
 }
 
 /// Check that we can attach a BPF program to a kernel tracepoint.

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -42,6 +42,7 @@ use libbpf_rs::query::KprobeMultiLinkInfo;
 use libbpf_rs::query::LinkTypeInfo;
 use libbpf_rs::query::PerfEventType;
 use libbpf_rs::query::ProgInfoIter;
+use libbpf_rs::query::UprobeMultiLinkInfo;
 use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::Iter;
 use libbpf_rs::KprobeMultiOpts;
@@ -2088,18 +2089,23 @@ fn test_object_uprobe_multi_with_non_default_opts() {
     let prog = get_prog_mut(&mut obj, "handle__uprobe_multi_with_non_default_opts");
     let func_pattern = "";
 
-    let pid = unsafe { libc::getpid() };
-    let path = current_exe().expect("failed to find executable name");
+    let current_pid = unsafe { libc::getpid() };
+    let current_path = current_exe().expect("failed to find executable name");
+    let syms_opt = vec![
+        "non_default_opts_multi_uprobe_func_with_opts_func_1".to_string(),
+        "non_default_opts_multi_uprobe_func_with_opts_func_2".to_string(),
+    ];
+    let ref_ctr_offsets_opt = vec![2, 4];
+    let cookies_opt = vec![5, 2];
     let opts = UprobeMultiOpts {
-        syms: vec![
-            "non_default_opts_multi_uprobe_func_with_opts_func_1".to_string(),
-            "non_default_opts_multi_uprobe_func_with_opts_func_2".to_string(),
-        ],
+        syms: syms_opt.clone(),
+        ref_ctr_offsets: ref_ctr_offsets_opt.clone(),
+        cookies: cookies_opt.clone(),
         ..Default::default()
     };
 
-    let _link = prog
-        .attach_uprobe_multi_with_opts(pid, path, func_pattern, opts)
+    let link = prog
+        .attach_uprobe_multi_with_opts(current_pid, &current_path, func_pattern, opts)
         .expect("failed to attach uprobe multi");
 
     non_default_opts_multi_uprobe_func_with_opts_func_1();
@@ -2119,6 +2125,37 @@ fn test_object_uprobe_multi_with_non_default_opts() {
     );
 
     assert_eq!(result, 2);
+
+    let link_info = link.info().expect("failed to get uprobe_multi link info");
+    let LinkTypeInfo::UprobeMulti(uprobe_multi) = link_info.info else {
+        panic!(
+            "Expected LinkTypeInfo::UprobeMulti for uprobe_multi, got: {:?}",
+            link_info.info
+        );
+    };
+
+    let UprobeMultiLinkInfo {
+        path,
+        count,
+        pid,
+        offsets,
+        ref_ctr_offsets,
+        cookies,
+        ..
+    } = uprobe_multi;
+    assert_eq!(path.as_ref(), Some(&current_path));
+    assert_eq!(pid, current_pid as u32);
+    assert_eq!(count, syms_opt.len() as u32);
+    for (actual, sym) in zip(offsets, syms_opt) {
+        let expected = get_symbol_offset(&current_path, &sym).unwrap();
+        assert_eq!(actual, expected as u64);
+    }
+    for (actual, expected) in zip(ref_ctr_offsets, ref_ctr_offsets_opt) {
+        assert_eq!(actual, expected as u64);
+    }
+    for (actual, expected) in zip(cookies, cookies_opt) {
+        assert_eq!(actual, expected);
+    }
 }
 
 #[tag(root)]


### PR DESCRIPTION
Added `KprobeMultiLinkInfo` & `UprobeMultiLinkInfo` fields that required a second info call.