### PR TITLE
libbpf-rs: Add helper APIs and tests for `OpenMap`

### DIFF
--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -115,6 +115,26 @@ impl<'obj> OpenMap<'obj> {
     pub fn autocreate(&self) -> bool {
         unsafe { libbpf_sys::bpf_map__autocreate(self.ptr.as_ptr()) }
     }
+
+    /// Retrieve the map flags.
+    pub fn map_flags(&self) -> u32 {
+        unsafe { libbpf_sys::bpf_map__map_flags(self.ptr.as_ptr()) }
+    }
+
+    /// Retrieve the map numa node.
+    pub fn numa_node(&self) -> u32 {
+        unsafe { libbpf_sys::bpf_map__numa_node(self.ptr.as_ptr()) }
+    }
+
+    /// Retrieve the key size of the map in bytes.
+    pub fn key_size(&self) -> u32 {
+        unsafe { libbpf_sys::bpf_map__key_size(self.ptr.as_ptr()) }
+    }
+
+    /// Retrieve the value size of the map in bytes.
+    pub fn value_size(&self) -> u32 {
+        unsafe { libbpf_sys::bpf_map__value_size(self.ptr.as_ptr()) }
+    }
 }
 
 impl<'obj> OpenMapMut<'obj> {

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -2712,6 +2712,26 @@ fn test_map_query_fdinfo() {
     assert_eq!(fdinfo.owner_jited, None);
 }
 
+/// Check that `OpenMap` gets information correctly.
+#[tag(root)]
+#[test]
+fn test_map_get_info() {
+    let obj = open_test_object("runqslower.bpf.o");
+
+    let start = obj
+        .maps()
+        .find(|map| map.name() == OsStr::new("start"))
+        .expect("failed to find `start` map");
+
+    assert!(start.autocreate());
+    assert_eq!(start.key_size(), size_of::<u32>() as _);
+    assert_eq!(start.value_size(), size_of::<u64>() as _);
+    assert_eq!(start.map_flags(), 0);
+    assert_eq!(start.map_type(), MapType::Hash);
+    assert_eq!(start.max_entries(), 10240);
+    assert_eq!(start.numa_node(), 0);
+}
+
 /// Check that we can adjust a map's value size.
 #[tag(root)]
 #[test]


### PR DESCRIPTION
Add apis `key_size`, `value_size`, `map_flags` and `numa_node` for `OpenMap` , along with tests covering these APIs.
For more details, see https://github.com/libbpf/libbpf-rs/issues/1382