### PR TITLE
Add CHANGELOG entry for #1385

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added `KprobeMultiLinkInfo` & `UprobeMultiLinkInfo` fields that required a
   second info call.
+- Added `key_size`, `value_size` and more getters to `OpenMap{,Mut}`
 
 
 0.26.2


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1385, which added basic getters to the OpenMap and OpenMapMut types.
