### PR TITLE
Inline kernel build into test-coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,25 +10,9 @@ on:
   workflow_call:
 
 jobs:
-  build-linux-kernel:
-    name: Build Linux
-    runs-on: ubuntu-latest
-    outputs:
-      kernel-artifact-url: ${{ steps.build.outputs.kernel-artifact-url }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: d-e-s-o/build-linux@ec34a7ad2635733082b2bab63c62136a06d272e9
-        id: build
-        with:
-          # TODO: Bump to whatever gets tagged next that includes this
-          #       commit.
-          rev: 'b5709f6d26d65f6bb9711f4b5f98469fd507cb5b'
-          config: 'var/config'
-
   test:
     name: Test [${{ matrix.rust }}, ${{ matrix.profile }}]
     runs-on: ubuntu-24.04
-    needs: [build-linux-kernel]
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +46,13 @@ jobs:
         tc_var CFLAGS
         tc_var CXXFLAGS
     - uses: actions/checkout@v6
+    - uses: d-e-s-o/build-linux@a2c2581c6b44879b6070699618be648480a122c5
+      id: build
+      with:
+        # TODO: Bump to whatever gets tagged next that includes this
+        #       commit.
+        rev: 'b5709f6d26d65f6bb9711f4b5f98469fd507cb5b'
+        config: 'var/config'
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
@@ -81,8 +72,6 @@ jobs:
       # Skip tests which require sudo
       run: cargo test --profile=${{ matrix.profile }} --locked --verbose --workspace --exclude runqslower -- --skip ':root:'  --include-ignored
     - name: Build main.sh
-      env:
-        ARTIFACT_URL: ${{ needs.build-linux-kernel.outputs.kernel-artifact-url }}
       shell: bash
       run: |
         cargo test -p libbpf-rs --profile=${{ matrix.profile }} --locked --no-run 2>&1 | tee /tmp/cargo-build.log
@@ -91,21 +80,6 @@ jobs:
           sed 's@[()]@@g' |
           sed 's@.*@\0 --include-ignored -- :root:@'
         )
-        # Yes, there appears to be no way to just retrieve the
-        # uploaded artifact. One can't use actions/download-artifact
-        # and provide any of the outputs of actions/upload-artifact.
-        # Neither does it seem possible to just download the thing
-        # directly, because contents are unconditionally zipped. Good.
-        # Lord.
-        curl --location \
-          --fail-with-body \
-          --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-          --header "X-GitHub-Api-Version: 2022-11-28" \
-          --output artifact.zip \
-          "${ARTIFACT_URL}"
-        # This unzip will produce the kernel bzImage.
-        unzip artifact.zip
 
         cat <<EOF > main.sh
         #!/bin/sh
@@ -116,7 +90,7 @@ jobs:
     - name: Run root tests
       uses: d-e-s-o/vmsh@adcb371a90d9e8e9cc3e998399d3b00ad21f5b76
     - run: |
-        vmsh bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
+        vmsh ${{ steps.build.outputs.build-dir }}/bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
 
   run-examples:
     name: Run chosen examples


### PR DESCRIPTION
With recent changes, the build-linux action outputs the build directory path directly instead of uploading an artifact. Since it is a composite action, its steps run in the caller's job and the build directory is already on disk.
Inline the build-linux step into the test job, removing the separate build-linux-kernel job along with the artifact download via curl. Doing so simplifies things a bunch and eliminates the scheduling issues we have seen where build-linux-kernel, despite being on the critical path, was sometimes scheduled to run only after a bunch of other jobs, which artificially worsened total job runtime.