### PR TITLE
Increase vmsh resources in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Run root tests
       uses: d-e-s-o/vmsh@adcb371a90d9e8e9cc3e998399d3b00ad21f5b76
     - run: |
-        vmsh ${{ steps.build.outputs.build-dir }}/bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
+        vmsh --cpus=$(nproc) --memory=8192 ${{ steps.build.outputs.build-dir }}/bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
 
   run-examples:
     name: Run chosen examples


### PR DESCRIPTION
Adjust the resources we provide to the vmsh VM which we use for running tests in CI. In so doing we maximize what we can get out of the virtual hardware at hand.