### PR TITLE
Bump vmsh action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         #       commit.
         rev: 'b5709f6d26d65f6bb9711f4b5f98469fd507cb5b'
         config: 'var/config'
+        vmlinux: 'true'
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
@@ -88,9 +89,9 @@ jobs:
         EOF
         chmod a+x main.sh
     - name: Run root tests
-      uses: d-e-s-o/vmsh@adcb371a90d9e8e9cc3e998399d3b00ad21f5b76
+      uses: d-e-s-o/vmsh@2dbf4f434b14f75b860f5550f289ac1ecde6d438
     - run: |
-        vmsh --cpus=$(nproc) --memory=8192 ${{ steps.build.outputs.build-dir }}/bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
+        vmsh --cpus=$(nproc) --memory=8192 --kernel ${{ steps.build.outputs.build-dir }}/boot/vmlinux-6.18.0+ --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
 
   run-examples:
     name: Run chosen examples


### PR DESCRIPTION
Update the vmsh to get the latest and greatest. In this version, vmsh requires a vmlinux image as opposed to a bzImage and it expects the kernel to be provided via an explicit -k/--kernel named argument, as opposed to a position one.