### PR TITLE
example: fix compilation of task_longrun

### DIFF
--- a/examples/task_longrun/src/bpf/task_longrun.bpf.c
+++ b/examples/task_longrun/src/bpf/task_longrun.bpf.c
@@ -66,7 +66,7 @@ int handle__sched_switch(u64 *ctx)
 }
 
 /* bpflint: disable=unstable-attach-point */
-SEC("kprobe/scheduler_tick")
+SEC("kprobe/sched_tick")
 void handle__sched_tick(struct pt_regs *ctx)
 {
     s32 cpu = bpf_get_smp_processor_id();


### PR DESCRIPTION
The following [commit](https://github.com/torvalds/linux/commit/86dd6c04ef9f213e14d60c9f64bce1cc019f816e) renamed the `scheduler_tick` function to `sched_tick`. We should probably update the example accordingly.