### PR TITLE
Introduce ErrorKind::TooBig for E2BIG errors

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
   second info call.
 - Added `key_size`, `value_size` and more getters to `OpenMap{,Mut}`
 - Added specific `IterLinkInfo` fields for `LinkTypeInfo::Iter`.
+- Added `ErrorKind::TooBig` variant, surfaced when the underlying
+  operation fails with `E2BIG` (e.g., a map reaching `max_entries`).
 
 
 0.26.2

--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -128,6 +128,9 @@ impl ErrorImpl {
                 io::ErrorKind::Unsupported => ErrorKind::Unsupported,
                 io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
                 io::ErrorKind::OutOfMemory => ErrorKind::OutOfMemory,
+                // TODO: Use `io::ErrorKind::ArgumentListTooLong` once
+                //       stable.
+                _ if error.raw_os_error() == Some(libc::E2BIG) => ErrorKind::TooBig,
                 _ => ErrorKind::Other,
             },
             Self::ContextOwned { source, .. } | Self::ContextStatic { source, .. } => {
@@ -255,6 +258,14 @@ pub enum ErrorKind {
     /// An operation could not be completed, because it failed
     /// to allocate enough memory.
     OutOfMemory,
+    /// An argument exceeded a size limit imposed by the kernel.
+    ///
+    /// Corresponds to `E2BIG` from the underlying syscall. For BPF map
+    /// operations such as [`MapCore::update`][crate::MapCore::update]
+    /// this typically means the map has reached its `max_entries`
+    /// limit. The same code can also indicate that a BPF program is too
+    /// large to load.
+    TooBig,
     /// A custom error that does not fall under any other I/O error
     /// kind.
     Other,
@@ -617,5 +628,15 @@ Caused by:
     some invalid data"#;
         assert_eq!(format!("{err:?}"), expected);
         assert_ne!(format!("{err:#?}"), "");
+    }
+
+    /// Check that `E2BIG` is reported as [`ErrorKind::TooBig`].
+    #[test]
+    fn e2big_maps_to_too_big() {
+        let err = Error::from_raw_os_error(libc::E2BIG);
+        assert_eq!(err.kind(), ErrorKind::TooBig);
+
+        let err = err.context("inserting key into map");
+        assert_eq!(err.kind(), ErrorKind::TooBig);
     }
 }

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -46,6 +46,7 @@ use libbpf_rs::query::PerfEventType;
 use libbpf_rs::query::ProgInfoIter;
 use libbpf_rs::query::UprobeMultiLinkInfo;
 use libbpf_rs::AsRawLibbpf;
+use libbpf_rs::ErrorKind;
 use libbpf_rs::Iter;
 use libbpf_rs::KprobeMultiOpts;
 use libbpf_rs::KprobeOpts;
@@ -428,6 +429,29 @@ pub fn test_map_info() {
     assert_eq!(map_info.btf_vmlinux_value_type_id, 0);
     assert_eq!(map_info.map_extra, 0);
     assert_eq!(map_info.ifindex, 0);
+}
+
+/// Check that inserting elements beyond a map's `max_entries` should
+/// surface as [`ErrorKind::TooBig`].
+#[tag(root)]
+#[test]
+fn test_map_update_max_entries_exceeded() {
+    let opts = libbpf_sys::bpf_map_create_opts {
+        sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        ..Default::default()
+    };
+    let max_entries = 1;
+    let map = MapHandle::create(MapType::Hash, Some("full_map"), 4, 4, max_entries, &opts).unwrap();
+
+    let value = 0u32.to_ne_bytes();
+    let () = map
+        .update(&1u32.to_ne_bytes(), &value, MapFlags::ANY)
+        .unwrap();
+
+    let err = map
+        .update(&2u32.to_ne_bytes(), &value, MapFlags::ANY)
+        .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::TooBig, "{err:?}");
 }
 
 #[tag(root)]


### PR DESCRIPTION
The conversion from std::io::ErrorKind to our own ErrorKind in ErrorImpl::kind does not handle io::ErrorKind::ArgumentListTooLong, which is what the standard library maps E2BIG to. As a result, any underlying E2BIG error from the kernel ends up classified as ErrorKind::Other, and callers of MapCore::update() (and other paths) have problems telling that a failure was caused by the map having reached its max_entries limit.
Add a new TooBig variant to the ErrorKind enum and map io::ErrorKind::ArgumentListTooLong to it. This way, users are able to handle this case fairly easily.