### PR TITLE
Support opening read-only maps

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
 - Added specific `IterLinkInfo` fields for `LinkTypeInfo::Iter`.
 - Added `ErrorKind::TooBig` variant, surfaced when the underlying
   operation fails with `E2BIG` (e.g., a map reaching `max_entries`).
+- Added `MapHandle::from_pinned_path_with_file_flags` for opening maps 
+  with custom file flags.
 
 
 0.26.2

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1175,12 +1175,31 @@ impl MapHandle {
     /// # Panics
     /// If the path contains null bytes.
     pub fn from_pinned_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        fn inner(path: &Path) -> Result<MapHandle> {
+        Self::from_pinned_path_with_file_flags(path, 0)
+    }
+
+    /// Open a previously pinned map from its path with the provided file flags.
+    ///
+    /// For example, pass [`libbpf_sys::BPF_F_RDONLY`] to open a map as
+    /// read-only from user space.
+    ///
+    /// # Panics
+    /// If the path contains null bytes.
+    pub fn from_pinned_path_with_file_flags<P: AsRef<Path>>(
+        path: P,
+        file_flags: u32,
+    ) -> Result<Self> {
+        fn inner(path: &Path, file_flags: u32) -> Result<MapHandle> {
             let p = CString::new(path.as_os_str().as_bytes()).expect("path contained null bytes");
+            let opts = libbpf_sys::bpf_obj_get_opts {
+                sz: size_of::<libbpf_sys::bpf_obj_get_opts>() as libbpf_sys::size_t,
+                file_flags,
+                ..Default::default()
+            };
             let fd = parse_ret_i32(unsafe {
                 // SAFETY
                 // p is never null since we allocated ourselves.
-                libbpf_sys::bpf_obj_get(p.as_ptr())
+                libbpf_sys::bpf_obj_get_opts(p.as_ptr(), &opts)
             })?;
             MapHandle::from_fd(unsafe {
                 // SAFETY
@@ -1190,7 +1209,7 @@ impl MapHandle {
             })
         }
 
-        inner(path.as_ref())
+        inner(path.as_ref(), file_flags)
     }
 
     /// Open a loaded map from its map id.

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -971,6 +971,39 @@ fn test_object_loading_pinned_map_from_path() {
 
 #[tag(root)]
 #[test]
+fn test_object_loading_pinned_map_from_path_read_only() {
+    let mut obj = get_test_object("runqslower.bpf.o");
+    let mut map = get_map_mut(&mut obj, "start");
+    let path = "/sys/fs/bpf/mymap_test_pin_to_load_from_path_read_only";
+    let key = 1u32.to_ne_bytes();
+    let value = 42u64.to_ne_bytes();
+
+    map.update(&key, &value, MapFlags::ANY)
+        .expect("failed to update map before pinning");
+    map.pin(path).expect("pinning map failed");
+    defer! {
+        map.unpin(path).expect("unpinning map failed");
+    }
+
+    let pinned_map = MapHandle::from_pinned_path_with_file_flags(path, libbpf_sys::BPF_F_RDONLY)
+        .expect("loading a read-only map from a path failed");
+
+    assert_eq!(
+        pinned_map
+            .lookup(&key, MapFlags::ANY)
+            .expect("failed to lookup key")
+            .as_deref(),
+        Some(value.as_slice())
+    );
+
+    let err = pinned_map
+        .update(&key, &43u64.to_ne_bytes(), MapFlags::ANY)
+        .expect_err("read-only map handle allowed update");
+    assert_eq!(err.kind(), ErrorKind::PermissionDenied, "{err:?}");
+}
+
+#[tag(root)]
+#[test]
 fn test_program_loading_fd_from_pinned_path() {
     let path = "/sys/fs/bpf/myprog_test_pin_to_load_from_path";
     let prog_name = "handle__sched_switch";


### PR DESCRIPTION
## What

Adds a new method `MapHandle::from_pinned_path_with_file_flags(path, file_flags)` that uses `bpf_obj_get_opts()`.

## Why

It is currently impossible to open a pinned map that has read-only file permissions because `bpf_obj_get()` uses the default file flags.

```
Permission denied (os error 13)
```

After this change it is possible to use:

```rust
MapHandle::from_pinned_path_with_file_flags(path, libbpf_sys::BPF_F_RDONLY)
```