### PR TITLE
Fix compilation issue of netfilter_blocklist example

### DIFF
--- a/examples/netfilter_blocklist/src/bpf/netfilter_blocklist.bpf.c
+++ b/examples/netfilter_blocklist/src/bpf/netfilter_blocklist.bpf.c
@@ -28,7 +28,7 @@ int netfilter_local_in(struct bpf_nf_ctx *ctx)
     struct lpm_key key;
     __u32 *match_value;
 
-    if (skb->len <= 20 || bpf_dynptr_from_skb(skb, 0, &ptr))
+    if (skb->len <= 20 || bpf_dynptr_from_skb((void *)skb, 0, &ptr))
         return NF_ACCEPT;
     p = bpf_dynptr_slice(&ptr, 0, &iph, sizeof(iph));
     if (!p)


### PR DESCRIPTION
Fix a compilation issue of the netfilter_blocklist example:

> netfilter_blocklist.bpf.c:31:47: error: incompatible pointer types passing 'struct sk_buff *' to parameter of type 'struct __sk_buff *' [-Wincompatible-pointer-types]
>   if (skb->len <= 20 || bpf_dynptr_from_skb(skb, 0, &ptr))
>                                             ^~~