### PR TITLE
Retain full program name when converting Program to ProgramHandle

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -7,7 +7,6 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::fmt::Debug;
 use std::fs::remove_file;
 use std::io::Read;
 use std::marker::PhantomData;
@@ -1825,15 +1824,21 @@ impl AsFd for ProgramHandle {
     }
 }
 
-impl<T: Debug> TryFrom<&ProgramImpl<'_, T>> for ProgramHandle {
+impl<'obj, T> TryFrom<&ProgramImpl<'obj, T>> for ProgramHandle
+where
+    ProgramImpl<'obj, T>: Deref<Target = Program<'obj>>,
+{
     type Error = Error;
 
-    fn try_from(prog: &ProgramImpl<'_, T>) -> Result<Self> {
+    fn try_from(prog: &ProgramImpl<'obj, T>) -> Result<Self> {
         let fd = prog
             .as_fd()
             .try_clone_to_owned()
             .context("failed to duplicate program file descriptor")?;
-        Self::from_fd(fd)
+        Ok(Self {
+            name: prog.name().to_os_string(),
+            ..Self::from_fd(fd)?
+        })
     }
 }
 

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -3174,7 +3174,8 @@ fn test_program_handle_try_from_program() {
     let prog = get_prog_mut(&mut obj, "handle__sched_switch");
 
     let handle = ProgramHandle::try_from(&prog).expect("failed to create handle from program");
-    assert_eq!(handle.name(), "handle__sched_s");
+    assert_eq!(handle.name(), "handle__sched_switch");
+    assert_eq!(handle.name(), prog.name());
     assert_eq!(handle.prog_type(), prog.prog_type());
 }
 


### PR DESCRIPTION
ProgramHandle::from_fd() derives the program name from bpf_prog_info.name, which the kernel truncates to BPF_OBJ_NAME_LEN, i.e., 15 usable characters. The TryFrom<&Program> conversion uses this constructor, so turning a loaded Program into a ProgramHandle silently shortens the name. That is both surprising and inconsistent with MapHandle, whose conversion copies the full name.
Prefer libbpf's full program name whenever a live Program is at hand, by deferring to the Deref impl provided.
