### PR TITLE
Mark ProgramHandle accessor methods as #[inline]

### DIFF
--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -1783,21 +1783,25 @@ impl ProgramHandle {
     }
 
     /// The program's name.
+    #[inline]
     pub fn name(&self) -> &OsStr {
         &self.name
     }
 
     /// The `ProgramType` of this handle.
+    #[inline]
     pub fn prog_type(&self) -> ProgramType {
         self.ty
     }
 
     /// The 8-byte tag (instruction hash) of the program.
+    #[inline]
     pub fn tag(&self) -> [u8; 8] {
         self.tag
     }
 
     /// The kernel ID of this program.
+    #[inline]
     pub fn id(&self) -> u32 {
         self.id
     }


### PR DESCRIPTION
The ProgramHandle getters are trivial accessors returning cached fields, but unlike the equivalent MapHandle methods they were not annotated with
 #[inline].
Mark all these getters as #[inline] so they can be inlined across crate boundaries, matching the MapHandle accessors.