### PR TITLE
Use byte-sized buffers when querying link target names

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -922,7 +922,7 @@ impl LinkInfo {
     fn from_uapi(fd: BorrowedFd<'_>, mut s: libbpf_sys::bpf_link_info) -> Option<Self> {
         let type_info = match s.type_ {
             libbpf_sys::BPF_LINK_TYPE_RAW_TRACEPOINT => {
-                let mut buf = [0; 256];
+                let mut buf = [0u8; 256];
                 s.__bindgen_anon_1.raw_tracepoint.tp_name = buf.as_mut_ptr() as u64;
                 s.__bindgen_anon_1.raw_tracepoint.tp_name_len = buf.len() as u32;
                 let item_ptr: *mut libbpf_sys::bpf_link_info = &mut s;
@@ -960,7 +960,7 @@ impl LinkInfo {
                 }),
             }),
             libbpf_sys::BPF_LINK_TYPE_ITER => {
-                let mut buf = [0; 256];
+                let mut buf = [0u8; 256];
                 s.__bindgen_anon_1.iter.target_name = buf.as_mut_ptr() as u64;
                 s.__bindgen_anon_1.iter.target_name_len = buf.len() as u32;
                 let item_ptr: *mut libbpf_sys::bpf_link_info = &mut s;


### PR DESCRIPTION
The raw tracepoint and iterator arms of LinkInfo::from_uapi allocate a scratch buffer with `let mut buf = [0; 256]` and pass it to the kernel to be filled with the tracepoint or iterator target name. Absent a type annotation, the array's element type falls back to i32, so buf is really a [i32; 256] occupying 1024 bytes. The length handed to the kernel is buf.len(), i.e., 256, so we describe a 256 byte buffer that is in fact backed by 1024 bytes. The names in question are short enough that this never produced wrong results, but the allocation is four times larger than the length we report and buf.len() counts elements rather than the intended bytes.
Annotate both buffers as [0u8; 256] so that the element type is a byte and the reported length matches the actual capacity, mirroring the [0u8; _] buffer already used in the multi-uprobe arm.