### PR TITLE
Introduce IterType::Unknown for unrecognized iterator targets

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -658,7 +658,7 @@ pub struct IterLinkInfo {
     /// The `bpf_iter__*` target name.
     pub target_name: Option<CString>,
     /// Specific BPF iterator information.
-    pub iter_type: Option<IterType>,
+    pub iter_type: IterType,
 }
 
 /// Specific BPF iterator types with decoded information.
@@ -683,6 +683,11 @@ pub enum IterType {
         /// Specific process that is iterated over.
         pid: u32,
     },
+    /// An unknown or unsupported iterator type.
+    ///
+    /// The [`target_name`](IterLinkInfo::target_name) can still be used to
+    /// identify the iterator.
+    Unknown,
 }
 
 /// Information about a network namespace link.
@@ -980,9 +985,9 @@ impl LinkInfo {
                     };
 
                     let iter_type = match target_name.as_bytes() {
-                        b"bpf_map_elem" | b"bpf_sk_storage_map" => Some(IterType::Map {
+                        b"bpf_map_elem" | b"bpf_sk_storage_map" => IterType::Map {
                             map_id: unsafe { iter_info.__bindgen_anon_1.map.map_id },
-                        }),
+                        },
                         b"cgroup" => {
                             let order = match unsafe { iter_info.__bindgen_anon_2.cgroup.order } {
                                 libbpf_sys::BPF_CGROUP_ITER_SELF_ONLY => CgroupIterOrder::SelfOnly,
@@ -997,21 +1002,21 @@ impl LinkInfo {
                                 }
                                 _ => CgroupIterOrder::Default,
                             };
-                            Some(IterType::Cgroup {
+                            IterType::Cgroup {
                                 cgroup_id: unsafe { iter_info.__bindgen_anon_2.cgroup.cgroup_id },
                                 order,
-                            })
+                            }
                         }
-                        b"task" | b"task_file" | b"task_vma" => Some(IterType::Task {
+                        b"task" | b"task_file" | b"task_vma" => IterType::Task {
                             tid: unsafe { iter_info.__bindgen_anon_2.task.tid },
                             pid: unsafe { iter_info.__bindgen_anon_2.task.pid },
-                        }),
-                        _ => None,
+                        },
+                        _ => IterType::Unknown,
                     };
 
                     (Some(target_name), iter_type)
                 } else {
-                    (None, None)
+                    (None, IterType::Unknown)
                 };
 
                 LinkTypeInfo::Iter(IterLinkInfo {

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1634,7 +1634,7 @@ fn test_object_task_iter() {
         } = iter_info;
         assert_eq!(target_name, CString::new("task").ok());
 
-        let Some(IterType::Task { tid, pid }) = iter_type else {
+        let IterType::Task { tid, pid } = iter_type else {
             panic!("Expected IterType::Task, got: {iter_type:?}");
         };
         assert_eq!(tid, 0); // all threads
@@ -1716,7 +1716,7 @@ fn test_object_map_iter() {
     } = iter_info;
     assert_eq!(target_name, CString::new("bpf_map_elem").ok());
 
-    let Some(IterType::Map { map_id }) = iter_type else {
+    let IterType::Map { map_id } = iter_type else {
         panic!("Expected IterType::Map, got: {iter_type:?}");
     };
     assert_eq!(map_id, map.info().unwrap().info.id);


### PR DESCRIPTION
IterLinkInfo::iter_type is an Option<IterType> that ends up None both when an iterator's target_name is recognized but carries no decoded information and when the target is not known to us. That is at odds with the sibling enums in this module: PerfEventType and LinkTypeInfo each provide an Unknown variant for the latter case, and their containing infos store the enum directly instead of wrapping it in an Option (see PerfEventLinkInfo::event_type). IterType thus has no idiomatic way to represent an unrecognized target, and the Option adds a second, redundant "no type" state on top of it.
Add an IterType::Unknown variant and store it as a plain IterType, mirroring PerfEventLinkInfo. Unrecognized targets, as well as links without a target name, now map to IterType::Unknown, while the target_name field remains available to identify the iterator. Adjust the tests accordingly.