### PR TITLE
Store IterLinkInfo::target_name as a plain CString

### DIFF
--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -656,7 +656,7 @@ pub struct CgroupLinkInfo {
 #[derive(Debug, Clone)]
 pub struct IterLinkInfo {
     /// The `bpf_iter__*` target name.
-    pub target_name: Option<CString>,
+    pub target_name: CString,
     /// Specific BPF iterator information.
     pub iter_type: IterType,
 }
@@ -979,44 +979,40 @@ impl LinkInfo {
                 }
 
                 let iter_info = unsafe { s.__bindgen_anon_1.iter };
-                let (target_name, iter_type) = if iter_info.target_name_len != 0 {
-                    let target_name = unsafe {
-                        CStr::from_ptr(iter_info.target_name as *const c_char).to_owned()
-                    };
+                // On a successful call the kernel always reports the target name
+                // (its length is `strlen(target) + 1`) and copies it into `buf`,
+                // so it is guaranteed to be present here.
+                let target_name =
+                    unsafe { CStr::from_ptr(iter_info.target_name as *const c_char).to_owned() };
 
-                    let iter_type = match target_name.as_bytes() {
-                        b"bpf_map_elem" | b"bpf_sk_storage_map" => IterType::Map {
-                            map_id: unsafe { iter_info.__bindgen_anon_1.map.map_id },
-                        },
-                        b"cgroup" => {
-                            let order = match unsafe { iter_info.__bindgen_anon_2.cgroup.order } {
-                                libbpf_sys::BPF_CGROUP_ITER_SELF_ONLY => CgroupIterOrder::SelfOnly,
-                                libbpf_sys::BPF_CGROUP_ITER_DESCENDANTS_PRE => {
-                                    CgroupIterOrder::DescendantsPre
-                                }
-                                libbpf_sys::BPF_CGROUP_ITER_DESCENDANTS_POST => {
-                                    CgroupIterOrder::DescendantsPost
-                                }
-                                libbpf_sys::BPF_CGROUP_ITER_ANCESTORS_UP => {
-                                    CgroupIterOrder::AncestorsUp
-                                }
-                                _ => CgroupIterOrder::Default,
-                            };
-                            IterType::Cgroup {
-                                cgroup_id: unsafe { iter_info.__bindgen_anon_2.cgroup.cgroup_id },
-                                order,
+                let iter_type = match target_name.as_bytes() {
+                    b"bpf_map_elem" | b"bpf_sk_storage_map" => IterType::Map {
+                        map_id: unsafe { iter_info.__bindgen_anon_1.map.map_id },
+                    },
+                    b"cgroup" => {
+                        let order = match unsafe { iter_info.__bindgen_anon_2.cgroup.order } {
+                            libbpf_sys::BPF_CGROUP_ITER_SELF_ONLY => CgroupIterOrder::SelfOnly,
+                            libbpf_sys::BPF_CGROUP_ITER_DESCENDANTS_PRE => {
+                                CgroupIterOrder::DescendantsPre
                             }
+                            libbpf_sys::BPF_CGROUP_ITER_DESCENDANTS_POST => {
+                                CgroupIterOrder::DescendantsPost
+                            }
+                            libbpf_sys::BPF_CGROUP_ITER_ANCESTORS_UP => {
+                                CgroupIterOrder::AncestorsUp
+                            }
+                            _ => CgroupIterOrder::Default,
+                        };
+                        IterType::Cgroup {
+                            cgroup_id: unsafe { iter_info.__bindgen_anon_2.cgroup.cgroup_id },
+                            order,
                         }
-                        b"task" | b"task_file" | b"task_vma" => IterType::Task {
-                            tid: unsafe { iter_info.__bindgen_anon_2.task.tid },
-                            pid: unsafe { iter_info.__bindgen_anon_2.task.pid },
-                        },
-                        _ => IterType::Unknown,
-                    };
-
-                    (Some(target_name), iter_type)
-                } else {
-                    (None, IterType::Unknown)
+                    }
+                    b"task" | b"task_file" | b"task_vma" => IterType::Task {
+                        tid: unsafe { iter_info.__bindgen_anon_2.task.tid },
+                        pid: unsafe { iter_info.__bindgen_anon_2.task.pid },
+                    },
+                    _ => IterType::Unknown,
                 };
 
                 LinkTypeInfo::Iter(IterLinkInfo {

--- a/libbpf-rs/tests/test.rs
+++ b/libbpf-rs/tests/test.rs
@@ -1632,7 +1632,7 @@ fn test_object_task_iter() {
             target_name,
             iter_type,
         } = iter_info;
-        assert_eq!(target_name, CString::new("task").ok());
+        assert_eq!(target_name, CString::new("task").unwrap());
 
         let IterType::Task { tid, pid } = iter_type else {
             panic!("Expected IterType::Task, got: {iter_type:?}");
@@ -1714,7 +1714,7 @@ fn test_object_map_iter() {
         target_name,
         iter_type,
     } = iter_info;
-    assert_eq!(target_name, CString::new("bpf_map_elem").ok());
+    assert_eq!(target_name, CString::new("bpf_map_elem").unwrap());
 
     let IterType::Map { map_id } = iter_type else {
         panic!("Expected IterType::Map, got: {iter_type:?}");


### PR DESCRIPTION
IterLinkInfo::target_name is an Option<CString>, but on the paths that construct it the name is always present. The kernel routine filling in iterator link info, bpf_iter_link_fill_link_info, unconditionally sets target_name_len to strlen(target) + 1 and copies the target name into the buffer we hand it; should that buffer be too small it fails with -ENOSPC, which LinkInfo::from_uapi already turns into None. By the time we build the IterLinkInfo, target_name_len is guaranteed to be non-zero and the name has been written. The Option never holds None, and the else branch yielding (None, IterType::Unknown) is dead code. Store target_name as a plain CString and read it unconditionally, dropping the target_name_len check and the now unreachable branch. Adjust the tests accordingly.