### PR TITLE
Make query::{Kprobe,Uprobe}MultiLinkInfo non-exhaustive

### DIFF
--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -10,6 +10,8 @@ Unreleased
   with custom file flags.
 - Changed name members of `query` info types to be `OsString` instead of
   `CString`
+- Made `query::KprobeMultiLinkInfo` and `query::UprobeMultiLinkInfo`
+  non-exhaustive
 
 
 0.26.2

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -771,6 +771,9 @@ pub struct KprobeMultiLinkInfo {
     pub addrs: Vec<u64>,
     /// Cookies corresponding to the attach addresses.
     pub cookies: Vec<u64>,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
 }
 
 /// Information about a multi-uprobe link.
@@ -792,6 +795,9 @@ pub struct UprobeMultiLinkInfo {
     pub ref_ctr_offsets: Vec<u64>,
     /// Cookies corresponding to the attach addresses.
     pub cookies: Vec<u64>,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
 }
 
 /// Information about a perf event link.
@@ -1076,6 +1082,7 @@ impl LinkInfo {
                     missed: unsafe { s.__bindgen_anon_1.kprobe_multi.missed },
                     addrs,
                     cookies,
+                    _non_exhaustive: (),
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_UPROBE_MULTI => {
@@ -1118,6 +1125,7 @@ impl LinkInfo {
                     offsets,
                     ref_ctr_offsets,
                     cookies,
+                    _non_exhaustive: (),
                 })
             }
             libbpf_sys::BPF_LINK_TYPE_SOCKMAP => LinkTypeInfo::SockMap(SockMapLinkInfo {


### PR DESCRIPTION
KprobeMultiLinkInfo and UprobeMultiLinkInfo are all-public structs. As such, they are constructible and exhaustively matchable by downstream code, meaning that extending them in the future would constitute a breaking change.
Add a _non_exhaustive field to both types to be more friendly to future extension.