### PR TITLE
Release 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "bitflags 2.13.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.26.2"
+version = "0.27.0"
 edition = "2021"
 rust-version = "1.82"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/Cargo.toml
+++ b/libbpf-cargo/Cargo.toml
@@ -33,7 +33,7 @@ default = ["libbpf-rs/default"]
 anyhow = "1.0.40"
 cargo_metadata = "0.19.1"
 clap = { version = "4.0.32", features = ["derive"] }
-libbpf-rs = { version = "0.26", default-features = false, path = "../libbpf-rs" }
+libbpf-rs = { version = "0.27", default-features = false, path = "../libbpf-rs" }
 memmap2 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.27.0
+------
 - Added `KprobeMultiLinkInfo` & `UprobeMultiLinkInfo` fields that required a
   second info call.
 - Added `key_size`, `value_size` and more getters to `OpenMap{,Mut}`


### PR DESCRIPTION
Prepare for release of 0.27.0 by bumping both libbpf-rs and libbpf-cargo versions accordingly.