### PR TITLE
fix: Remove .o extension check in libbpf-cargo

### DIFF
--- a/libbpf-cargo/src/gen/mod.rs
+++ b/libbpf-cargo/src/gen/mod.rs
@@ -1274,14 +1274,7 @@ pub(crate) fn gen_single(
         name
     } else {
         match filename.to_str() {
-            Some(n) => {
-                ensure!(
-                    n.ends_with(".o"),
-                    "Object file does not have `.o` suffix: {n}"
-                );
-
-                n.split('.').next().unwrap()
-            }
+            Some(n) => n.split('.').next().unwrap(),
             None => bail!(
                 "Object file name is not valid unicode: {}",
                 filename.to_string_lossy()


### PR DESCRIPTION
The rationale for this change is the following: I have a bpf program written in rust and built by `cargo build` and linked by the `bpf-linker` under the hood, and resulting artifact doesn't have a `.o` extension. Later on I generate a skeleton from the resulting linked file using `libbpf-cargo`, and, as a workaround, I have to rename it beforehand. Skipping the link step is not an option for me as I use kfuncs that are, to the best of my knowledge, not yet supported by the Rust compiler, so I have a separate translation unit written in C which provides necessary shims.

Other than this rename step, everything works fine, which suggests that current check is too restrictive, could you please consider removing it? Thanks in advance!