### PR TITLE
Document private items in documentation CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,7 +316,7 @@ jobs:
           components: rustfmt
       - run: cargo fmt -- --check
 
-  cargo-doc:
+  rustdoc:
     name: Check documentation
     runs-on: ubuntu-latest
     env:
@@ -331,7 +331,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo doc --locked --no-deps
+      - run: cargo doc --locked --workspace --no-deps --document-private-items
 
   required-checks:
     needs: [
@@ -340,7 +340,7 @@ jobs:
       build-capable,
       build-features,
       build-minimum,
-      cargo-doc,
+      rustdoc,
       clippy,
       run-examples,
       rustfmt,

--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -295,9 +295,9 @@ pub enum ErrorKind {
 /// assert!(inner_err.to_string().starts_with("No such file or directory"));
 /// ```
 ///
-/// For convenient reporting, the [`Display`][std::fmt::Display]
-/// representation takes care of reporting the complete error chain when
-/// the alternate flag is set:
+/// For convenient reporting, the [`Display`] representation takes care
+/// of reporting the complete error chain when the alternate flag is
+/// set:
 /// ```
 /// # use std::fs::File;
 /// # use std::error::Error as _;
@@ -309,8 +309,8 @@ pub enum ErrorKind {
 /// println!("{err:#}");
 /// ```
 ///
-/// The [`Debug`][std::fmt::Debug] representation similarly will print
-/// the entire error chain, but will do so in a multi-line format:
+/// The [`Debug`] representation similarly will print the entire error
+/// chain, but will do so in a multi-line format:
 /// ```
 /// # use std::fs::File;
 /// # use std::error::Error as _;

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -1754,11 +1754,11 @@ impl Iterator for BatchedMapIter<'_> {
     }
 }
 
-/// A convenience wrapper for [`bpf_map_info`][libbpf_sys::bpf_map_info]. It
-/// provides the ability to retrieve the details of a certain map.
+/// A convenience wrapper for [`bpf_map_info`]. It provides the ability
+/// to retrieve the details of a certain map.
 #[derive(Debug)]
 pub struct MapInfo {
-    /// The inner [`bpf_map_info`][libbpf_sys::bpf_map_info] object.
+    /// The inner [`bpf_map_info`] object.
     pub info: bpf_map_info,
 }
 


### PR DESCRIPTION
We use rustdoc style documentation for both public and private items. By default, however, rustdoc only generates documentation for public ones, completely ignoring anything private. As a result, a bunch of unresolved references and other issues snug into the documentation of private bits.
Fix those, and adjust the CI job to actually document private items as well to catch these digressions in the future.