### PR TITLE
Add doc aliases for C library types

### DIFF
--- a/libbpf-rs/src/btf/mod.rs
+++ b/libbpf-rs/src/btf/mod.rs
@@ -49,6 +49,7 @@ use self::types::Composite;
 /// The various btf types.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
+#[doc(alias = "btf_kind")]
 pub enum BtfKind {
     /// [Void](types::Void)
     Void = 0,
@@ -159,6 +160,7 @@ enum DropPolicy {
 /// was derived from an [`Object`](super::Object), which owns the data this structs points too. When
 /// instead the [`Btf::from_path`] method is used, the lifetime will be `'static` since it doesn't
 /// borrow from anything.
+#[doc(alias = "btf")]
 pub struct Btf<'source> {
     ptr: NonNull<libbpf_sys::btf>,
     drop_policy: DropPolicy,
@@ -167,6 +169,7 @@ pub struct Btf<'source> {
 
 impl Btf<'static> {
     /// Load the btf information from specified path.
+    #[doc(alias = "btf__parse")]
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         fn inner(path: &Path) -> Result<Btf<'static>> {
             let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
@@ -184,6 +187,7 @@ impl Btf<'static> {
     }
 
     /// Load the vmlinux btf information from few well-known locations.
+    #[doc(alias = "btf__load_vmlinux_btf")]
     pub fn from_vmlinux() -> Result<Self> {
         let ptr = unsafe { libbpf_sys::btf__load_vmlinux_btf() };
         let ptr = validate_bpf_ret(ptr).context("failed to load BTF from vmlinux")?;
@@ -196,6 +200,7 @@ impl Btf<'static> {
     }
 
     /// Load the btf information of an bpf object from a program id.
+    #[doc(alias = "btf__load_from_kernel_by_id")]
     pub fn from_prog_id(id: u32) -> Result<Self> {
         let fd = parse_ret_i32(unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) })?;
         let fd = unsafe {
@@ -224,6 +229,7 @@ impl Btf<'static> {
 
 impl<'btf> Btf<'btf> {
     /// Create a new `Btf` instance from the given [`libbpf_sys::bpf_object`].
+    #[doc(alias = "bpf_object__btf")]
     pub fn from_bpf_object(obj: &'btf libbpf_sys::bpf_object) -> Result<Option<Self>> {
         Self::from_bpf_object_raw(obj)
     }
@@ -313,6 +319,7 @@ impl<'btf> Btf<'btf> {
     }
 
     /// The number of [`BtfType`]s in this object.
+    #[doc(alias = "btf__type_cnt")]
     pub fn len(&self) -> usize {
         unsafe {
             // SAFETY: the btf pointer is valid.
@@ -321,6 +328,7 @@ impl<'btf> Btf<'btf> {
     }
 
     /// The btf pointer size.
+    #[doc(alias = "btf__pointer_size")]
     pub fn ptr_size(&self) -> Result<NonZeroUsize> {
         let sz = unsafe { libbpf_sys::btf__pointer_size(self.ptr.as_ptr()) as usize };
         NonZeroUsize::new(sz).ok_or_else(|| {
@@ -332,6 +340,7 @@ impl<'btf> Btf<'btf> {
     ///
     /// # Panics
     /// If `name` has null bytes.
+    #[doc(alias = "btf__find_by_name")]
     pub fn type_by_name<'s, K>(&'s self, name: &str) -> Option<K>
     where
         K: TryFrom<BtfType<'s>>,
@@ -352,6 +361,7 @@ impl<'btf> Btf<'btf> {
     }
 
     /// Find a type by its [`TypeId`].
+    #[doc(alias = "btf__type_by_id")]
     pub fn type_by_id<'s, K>(&'s self, type_id: TypeId) -> Option<K>
     where
         K: TryFrom<BtfType<'s>>,
@@ -426,6 +436,7 @@ impl Debug for Btf<'_> {
 }
 
 impl Drop for Btf<'_> {
+    #[doc(alias = "btf__free")]
     fn drop(&mut self) {
         match self.drop_policy {
             DropPolicy::Nothing => {}
@@ -453,6 +464,7 @@ impl Drop for Btf<'_> {
 ///
 /// You can also use the [`TryFrom`] trait to convert to any of the possible [`types`].
 #[derive(Clone, Copy)]
+#[doc(alias = "btf_type")]
 pub struct BtfType<'btf> {
     type_id: TypeId,
     name: Option<&'btf OsStr>,
@@ -480,6 +492,7 @@ impl<'btf> BtfType<'btf> {
 
     /// This type's name.
     #[inline]
+    #[doc(alias = "btf__name_by_offset")]
     pub fn name(&'_ self) -> Option<&'btf OsStr> {
         self.name
     }

--- a/libbpf-rs/src/btf/types.rs
+++ b/libbpf-rs/src/btf/types.rs
@@ -276,6 +276,7 @@ impl MemberAttr {
 /// The kind of linkage a variable of function can have.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
+#[doc(alias = "btf_func_linkage")]
 pub enum Linkage {
     /// Static linkage
     Static = 0,
@@ -324,6 +325,7 @@ impl Display for Linkage {
 // Void
 gen_fieldless_concrete_type! {
     /// The representation of the [`c_void`][std::ffi::c_void] type.
+    #[doc(alias = "BTF_KIND_UNKN")]
     Void
 }
 
@@ -333,6 +335,7 @@ gen_fieldless_concrete_type! {
 ///
 /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-int)
 #[derive(Clone, Copy, Debug)]
+#[doc(alias = "BTF_KIND_INT")]
 pub struct Int<'btf> {
     source: BtfType<'btf>,
     /// The encoding of the number.
@@ -419,6 +422,7 @@ gen_fieldless_concrete_type! {
     /// A pointer.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-ptr)
+    #[doc(alias = "BTF_KIND_PTR")]
     Ptr with ReferencesType
 }
 
@@ -427,6 +431,8 @@ gen_concrete_type! {
     /// An array.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-array)
+    #[doc(alias = "BTF_KIND_ARRAY")]
+    #[doc(alias = "btf_array")]
     btf_array as Array
 }
 
@@ -464,9 +470,11 @@ gen_collection_concrete_type! {
     /// A struct.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-struct)
+    #[doc(alias = "BTF_KIND_STRUCT")]
     btf_member as Struct with HasSize;
 
     /// A member of a [Struct]
+    #[doc(alias = "btf_member")]
     struct StructMember<'btf> {
         /// The member's name
         pub name: Option<&'btf OsStr>,
@@ -488,9 +496,11 @@ gen_collection_concrete_type! {
     /// A Union.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-union)
+    #[doc(alias = "BTF_KIND_UNION")]
     btf_member as Union with HasSize;
 
     /// A member of an [Union]
+    #[doc(alias = "btf_member")]
     struct UnionMember<'btf> {
         /// The member's name
         pub name: Option<&'btf OsStr>,
@@ -612,9 +622,11 @@ gen_collection_concrete_type! {
     /// An Enum of at most 32 bits.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-enum)
+    #[doc(alias = "BTF_KIND_ENUM")]
     btf_enum as Enum with HasSize;
 
     /// A member of an [Enum]
+    #[doc(alias = "btf_enum")]
     struct EnumMember<'btf> {
         /// The name of this enum variant.
         pub name: Option<&'btf OsStr>,
@@ -648,6 +660,7 @@ gen_fieldless_concrete_type! {
     /// A forward declared C type.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-fwd)
+    #[doc(alias = "BTF_KIND_FWD")]
     Fwd
 }
 
@@ -678,6 +691,7 @@ gen_fieldless_concrete_type! {
     /// References the original type.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-typedef)
+    #[doc(alias = "BTF_KIND_TYPEDEF")]
     Typedef with ReferencesType
 }
 
@@ -686,6 +700,7 @@ gen_fieldless_concrete_type! {
     /// The volatile modifier.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-volatile)
+    #[doc(alias = "BTF_KIND_VOLATILE")]
     Volatile with ReferencesType
 }
 
@@ -694,6 +709,7 @@ gen_fieldless_concrete_type! {
     /// The const modifier.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-const)
+    #[doc(alias = "BTF_KIND_CONST")]
     Const with ReferencesType
 }
 
@@ -702,6 +718,7 @@ gen_fieldless_concrete_type! {
     /// The restrict modifier.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-restrict)
+    #[doc(alias = "BTF_KIND_RESTRICT")]
     Restrict with ReferencesType
 }
 
@@ -710,6 +727,7 @@ gen_fieldless_concrete_type! {
     /// A function.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-func)
+    #[doc(alias = "BTF_KIND_FUNC")]
     Func with ReferencesType
 }
 
@@ -726,9 +744,11 @@ gen_collection_concrete_type! {
     /// A function prototype.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-func-proto)
+    #[doc(alias = "BTF_KIND_FUNC_PROTO")]
     btf_param as FuncProto with ReferencesType;
 
     /// A parameter of a [`FuncProto`].
+    #[doc(alias = "btf_param")]
     struct FuncProtoParam<'btf> {
         /// The parameter's name
         pub name: Option<&'btf OsStr>,
@@ -747,6 +767,8 @@ gen_concrete_type! {
     /// A global variable.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-var)
+    #[doc(alias = "BTF_KIND_VAR")]
+    #[doc(alias = "btf_var")]
     btf_var as Var with ReferencesType
 }
 
@@ -763,11 +785,13 @@ gen_collection_concrete_type! {
     /// An ELF's data section, such as `.data`, `.bss` or `.rodata`.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-datasec)
+    #[doc(alias = "BTF_KIND_DATASEC")]
     btf_var_secinfo as DataSec with HasSize;
 
     /// Describes the btf var in a section.
     ///
     /// See [`DataSec`].
+    #[doc(alias = "btf_var_secinfo")]
     struct VarSecInfo {
         /// The type id of the var
         pub ty: TypeId,
@@ -789,6 +813,7 @@ gen_fieldless_concrete_type! {
     /// A floating point number.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-float)
+    #[doc(alias = "BTF_KIND_FLOAT")]
     Float with HasSize
 }
 
@@ -801,6 +826,8 @@ gen_concrete_type! {
     /// See the [clang docs](https://clang.llvm.org/docs/AttributeReference.html#btf-decl-tag) on
     /// it.
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-decl-tag)
+    #[doc(alias = "BTF_KIND_DECL_TAG")]
+    #[doc(alias = "btf_decl_tag")]
     btf_decl_tag as DeclTag with ReferencesType
 }
 
@@ -819,6 +846,7 @@ gen_fieldless_concrete_type! {
     /// A type tag.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-type-tag)
+    #[doc(alias = "BTF_KIND_TYPE_TAG")]
     TypeTag with ReferencesType
 }
 
@@ -827,9 +855,11 @@ gen_collection_concrete_type! {
     /// An Enum of 64 bits.
     ///
     /// See also [libbpf docs](https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-kind-enum64)
+    #[doc(alias = "BTF_KIND_ENUM64")]
     btf_enum64 as Enum64 with HasSize;
 
     /// A member of an [Enum64].
+    #[doc(alias = "btf_enum64")]
     struct Enum64Member<'btf> {
         /// The name of this enum variant.
         pub name: Option<&'btf OsStr>,

--- a/libbpf-rs/src/error.rs
+++ b/libbpf-rs/src/error.rs
@@ -330,6 +330,7 @@ pub enum ErrorKind {
 // fallible (i.e., returns a `Result<T, Error>` which would be penalized
 // by a large `Err` variant).
 #[repr(transparent)]
+#[doc(alias = "libbpf_get_error")]
 pub struct Error {
     /// The top-most error of the chain.
     error: Box<ErrorImpl>,

--- a/libbpf-rs/src/iter.rs
+++ b/libbpf-rs/src/iter.rs
@@ -15,6 +15,7 @@ use crate::Result;
 /// Methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
 #[derive(Debug)]
+#[doc(alias = "bpf_iter_create")]
 pub struct Iter {
     fd: OwnedFd,
 }

--- a/libbpf-rs/src/link.rs
+++ b/libbpf-rs/src/link.rs
@@ -19,6 +19,7 @@ use crate::Result;
 /// when this object is dropped if nothing else is holding a reference count.
 #[derive(Debug)]
 #[must_use = "not using this `Link` will detach the underlying program immediately"]
+#[doc(alias = "bpf_link")]
 pub struct Link {
     ptr: NonNull<libbpf_sys::bpf_link>,
 }
@@ -34,6 +35,7 @@ impl Link {
     }
 
     /// Create link from BPF FS file.
+    #[doc(alias = "bpf_link__open")]
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -53,6 +55,7 @@ impl Link {
     }
 
     /// Replace the underlying prog with `prog`.
+    #[doc(alias = "bpf_link__update_program")]
     pub fn update_prog(&mut self, prog: &Program<'_>) -> Result<()> {
         let ret =
             unsafe { libbpf_sys::bpf_link__update_program(self.ptr.as_ptr(), prog.ptr.as_ptr()) };
@@ -68,12 +71,14 @@ impl Link {
     /// additional steps (like pinning BPF program in BPF FS) necessary to ensure
     /// exit of userspace program doesn't trigger automatic detachment and clean up
     /// inside the kernel.
+    #[doc(alias = "bpf_link__disconnect")]
     pub fn disconnect(&mut self) {
         unsafe { libbpf_sys::bpf_link__disconnect(self.ptr.as_ptr()) }
     }
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this link to bpffs.
+    #[doc(alias = "bpf_link__pin")]
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -84,12 +89,14 @@ impl Link {
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// from bpffs
+    #[doc(alias = "bpf_link__unpin")]
     pub fn unpin(&mut self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__unpin(self.ptr.as_ptr()) };
         util::parse_ret(ret)
     }
 
     /// Returns path to BPF FS file or `None` if not pinned.
+    #[doc(alias = "bpf_link__pin_path")]
     pub fn pin_path(&self) -> Option<PathBuf> {
         let path_ptr = unsafe { libbpf_sys::bpf_link__pin_path(self.ptr.as_ptr()) };
         if path_ptr.is_null() {
@@ -105,6 +112,7 @@ impl Link {
     }
 
     /// Detach the link.
+    #[doc(alias = "bpf_link__detach")]
     pub fn detach(&self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_link__detach(self.ptr.as_ptr()) };
         util::parse_ret(ret)
@@ -132,6 +140,7 @@ unsafe impl Sync for Link {}
 
 impl AsFd for Link {
     #[inline]
+    #[doc(alias = "bpf_link__fd")]
     fn as_fd(&self) -> BorrowedFd<'_> {
         let fd = unsafe { libbpf_sys::bpf_link__fd(self.ptr.as_ptr()) };
         // SAFETY: `bpf_link__fd` always returns a valid fd and the underlying
@@ -142,6 +151,7 @@ impl AsFd for Link {
 }
 
 impl Drop for Link {
+    #[doc(alias = "bpf_link__destroy")]
     fn drop(&mut self) {
         let _ = unsafe { libbpf_sys::bpf_link__destroy(self.ptr.as_ptr()) };
     }

--- a/libbpf-rs/src/linker.rs
+++ b/libbpf-rs/src/linker.rs
@@ -15,6 +15,7 @@ use crate::Result;
 /// <https://lwn.net/ml/bpf/20210310040431.916483-6-andrii@kernel.org/> for
 /// additional details.
 #[derive(Debug)]
+#[doc(alias = "bpf_linker")]
 pub struct Linker {
     /// The `libbpf` linker object.
     linker: NonNull<libbpf_sys::bpf_linker>,
@@ -22,6 +23,7 @@ pub struct Linker {
 
 impl Linker {
     /// Instantiate a `Linker` object.
+    #[doc(alias = "bpf_linker__new")]
     pub fn new<P>(output: P) -> Result<Self>
     where
         P: AsRef<Path>,
@@ -36,6 +38,7 @@ impl Linker {
     }
 
     /// Add a file to the set of files to link.
+    #[doc(alias = "bpf_linker__add_file")]
     pub fn add_file<P>(&mut self, file: P) -> Result<()>
     where
         P: AsRef<Path>,
@@ -53,6 +56,7 @@ impl Linker {
     }
 
     /// Add a buffer to the set of objects to link.
+    #[doc(alias = "bpf_linker__add_buf")]
     pub fn add_buf(&mut self, buf: &[u8]) -> Result<()> {
         let opts = null_mut();
         // SAFETY: `linker` and `buf` are valid pointers.
@@ -73,6 +77,7 @@ impl Linker {
 
     /// Link all BPF object files [added](Self::add_file) to this object into
     /// a single one.
+    #[doc(alias = "bpf_linker__finalize")]
     pub fn link(&self) -> Result<()> {
         // SAFETY: `linker` is a valid pointer.
         let err = unsafe { libbpf_sys::bpf_linker__finalize(self.linker.as_ptr()) };
@@ -96,6 +101,7 @@ impl AsRawLibbpf for Linker {
 unsafe impl Send for Linker {}
 
 impl Drop for Linker {
+    #[doc(alias = "bpf_linker__free")]
     fn drop(&mut self) {
         // SAFETY: `linker` is a valid pointer returned by `bpf_linker__new`.
         unsafe { libbpf_sys::bpf_linker__free(self.linker.as_ptr()) }

--- a/libbpf-rs/src/map.rs
+++ b/libbpf-rs/src/map.rs
@@ -55,6 +55,7 @@ pub type OpenMapMut<'obj> = OpenMapImpl<'obj, Mut>;
 /// [`plain`](https://crates.io/crates/plain) helpful.
 #[derive(Debug)]
 #[repr(transparent)]
+#[doc(alias = "bpf_map")]
 pub struct OpenMapImpl<'obj, T = ()> {
     ptr: NonNull<libbpf_sys::bpf_map>,
     _phantom: PhantomData<&'obj T>,
@@ -72,6 +73,7 @@ impl<'obj> OpenMap<'obj> {
     }
 
     /// Retrieve the [`OpenMap`]'s name.
+    #[doc(alias = "bpf_map__name")]
     pub fn name(&self) -> &'obj OsStr {
         // SAFETY: We ensured `ptr` is valid during construction.
         let name_ptr = unsafe { libbpf_sys::bpf_map__name(self.ptr.as_ptr()) };
@@ -82,6 +84,7 @@ impl<'obj> OpenMap<'obj> {
     }
 
     /// Retrieve type of the map.
+    #[doc(alias = "bpf_map__type")]
     pub fn map_type(&self) -> MapType {
         let ty = unsafe { libbpf_sys::bpf_map__type(self.ptr.as_ptr()) };
         MapType::from(ty)
@@ -96,6 +99,7 @@ impl<'obj> OpenMap<'obj> {
     }
 
     /// Retrieve the initial value of the map.
+    #[doc(alias = "bpf_map__initial_value")]
     pub fn initial_value(&self) -> Option<&[u8]> {
         let (ptr, size) = self.initial_value_raw();
         if ptr.is_null() {
@@ -107,31 +111,37 @@ impl<'obj> OpenMap<'obj> {
     }
 
     /// Retrieve the maximum number of entries of the map.
+    #[doc(alias = "bpf_map__max_entries")]
     pub fn max_entries(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__max_entries(self.ptr.as_ptr()) }
     }
 
     /// Return `true` if the map is set to be auto-created during load, `false` otherwise.
+    #[doc(alias = "bpf_map__autocreate")]
     pub fn autocreate(&self) -> bool {
         unsafe { libbpf_sys::bpf_map__autocreate(self.ptr.as_ptr()) }
     }
 
     /// Retrieve the map flags.
+    #[doc(alias = "bpf_map__map_flags")]
     pub fn map_flags(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__map_flags(self.ptr.as_ptr()) }
     }
 
     /// Retrieve the map numa node.
+    #[doc(alias = "bpf_map__numa_node")]
     pub fn numa_node(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__numa_node(self.ptr.as_ptr()) }
     }
 
     /// Retrieve the key size of the map in bytes.
+    #[doc(alias = "bpf_map__key_size")]
     pub fn key_size(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__key_size(self.ptr.as_ptr()) }
     }
 
     /// Retrieve the value size of the map in bytes.
+    #[doc(alias = "bpf_map__value_size")]
     pub fn value_size(&self) -> u32 {
         unsafe { libbpf_sys::bpf_map__value_size(self.ptr.as_ptr()) }
     }
@@ -147,6 +157,7 @@ impl<'obj> OpenMapMut<'obj> {
     }
 
     /// Retrieve the initial value of the map.
+    #[doc(alias = "bpf_map__initial_value")]
     pub fn initial_value_mut(&mut self) -> Option<&mut [u8]> {
         let (ptr, size) = self.initial_value_raw();
         if ptr.is_null() {
@@ -160,11 +171,13 @@ impl<'obj> OpenMapMut<'obj> {
     /// Bind map to a particular network device.
     ///
     /// Used for offloading maps to hardware.
+    #[doc(alias = "bpf_map__set_ifindex")]
     pub fn set_map_ifindex(&mut self, idx: u32) {
         unsafe { libbpf_sys::bpf_map__set_ifindex(self.ptr.as_ptr(), idx) };
     }
 
     /// Set the initial value of the map.
+    #[doc(alias = "bpf_map__set_initial_value")]
     pub fn set_initial_value(&mut self, data: &[u8]) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::bpf_map__set_initial_value(
@@ -178,30 +191,35 @@ impl<'obj> OpenMapMut<'obj> {
     }
 
     /// Set the type of the map.
+    #[doc(alias = "bpf_map__set_type")]
     pub fn set_type(&mut self, ty: MapType) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_type(self.ptr.as_ptr(), ty as u32) };
         util::parse_ret(ret)
     }
 
     /// Set the key size of the map in bytes.
+    #[doc(alias = "bpf_map__set_key_size")]
     pub fn set_key_size(&mut self, size: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_key_size(self.ptr.as_ptr(), size) };
         util::parse_ret(ret)
     }
 
     /// Set the value size of the map in bytes.
+    #[doc(alias = "bpf_map__set_value_size")]
     pub fn set_value_size(&mut self, size: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_value_size(self.ptr.as_ptr(), size) };
         util::parse_ret(ret)
     }
 
     /// Set the maximum number of entries this map can have.
+    #[doc(alias = "bpf_map__set_max_entries")]
     pub fn set_max_entries(&mut self, count: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_max_entries(self.ptr.as_ptr(), count) };
         util::parse_ret(ret)
     }
 
     /// Set flags on this map.
+    #[doc(alias = "bpf_map__set_map_flags")]
     pub fn set_map_flags(&mut self, flags: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_map_flags(self.ptr.as_ptr(), flags) };
         util::parse_ret(ret)
@@ -211,6 +229,7 @@ impl<'obj> OpenMapMut<'obj> {
     ///
     /// This can be used to ensure that the map is allocated on a particular
     /// NUMA node, which can be useful for performance-critical applications.
+    #[doc(alias = "bpf_map__set_numa_node")]
     pub fn set_numa_node(&mut self, numa_node: u32) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_numa_node(self.ptr.as_ptr(), numa_node) };
         util::parse_ret(ret)
@@ -220,6 +239,7 @@ impl<'obj> OpenMapMut<'obj> {
     ///
     /// This is used for nested maps, where the value type of the outer map is a pointer to the
     /// inner map.
+    #[doc(alias = "bpf_map__set_inner_map_fd")]
     pub fn set_inner_map_fd(&mut self, inner_map_fd: BorrowedFd<'_>) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::bpf_map__set_inner_map_fd(self.ptr.as_ptr(), inner_map_fd.as_raw_fd())
@@ -235,12 +255,14 @@ impl<'obj> OpenMapMut<'obj> {
     ///
     /// This can be used to pass data to the kernel that is not otherwise
     /// representable via the existing `bpf_map_def` fields.
+    #[doc(alias = "bpf_map__set_map_extra")]
     pub fn set_map_extra(&mut self, map_extra: u64) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_map_extra(self.ptr.as_ptr(), map_extra) };
         util::parse_ret(ret)
     }
 
     /// Set whether or not libbpf should automatically create this map during load phase.
+    #[doc(alias = "bpf_map__set_autocreate")]
     pub fn set_autocreate(&mut self, autocreate: bool) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__set_autocreate(self.ptr.as_ptr(), autocreate) };
         util::parse_ret(ret)
@@ -249,6 +271,7 @@ impl<'obj> OpenMapMut<'obj> {
     /// Set where the map should be pinned.
     ///
     /// Note this does not actually create the pin.
+    #[doc(alias = "bpf_map__set_pin_path")]
     pub fn set_pin_path<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -258,12 +281,14 @@ impl<'obj> OpenMapMut<'obj> {
     }
 
     /// Reuse an fd for a BPF map
+    #[doc(alias = "bpf_map__reuse_fd")]
     pub fn reuse_fd(&mut self, fd: BorrowedFd<'_>) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map__reuse_fd(self.ptr.as_ptr(), fd.as_raw_fd()) };
         util::parse_ret(ret)
     }
 
     /// Reuse an already-pinned map for `self`.
+    #[doc(alias = "bpf_obj_get")]
     pub fn reuse_pinned_map<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let cstring = util::path_to_cstring(path)?;
 
@@ -519,22 +544,28 @@ mod private {
 /// A trait representing core functionality common to fully initialized maps.
 pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Retrieve the map's name.
+    #[doc(alias = "bpf_map__name")]
     fn name(&self) -> &OsStr;
 
     /// Retrieve type of the map.
+    #[doc(alias = "bpf_map__type")]
     fn map_type(&self) -> MapType;
 
     /// Retrieve the size of the map's keys.
+    #[doc(alias = "bpf_map__key_size")]
     fn key_size(&self) -> u32;
 
     /// Retrieve the size of the map's values.
+    #[doc(alias = "bpf_map__value_size")]
     fn value_size(&self) -> u32;
 
     /// Retrieve `max_entries` of the map.
+    #[doc(alias = "bpf_map__max_entries")]
     fn max_entries(&self) -> u32;
 
     /// Fetch extra map information
     #[inline]
+    #[doc(alias = "bpf_obj_get_info_by_fd")]
     fn info(&self) -> Result<MapInfo> {
         MapInfo::new(self.as_fd())
     }
@@ -553,6 +584,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Note that if the map is not stable (stable meaning no updates or deletes) during iteration,
     /// iteration can skip keys, restart from the beginning, or duplicate keys. In other words,
     /// iteration becomes unpredictable.
+    #[doc(alias = "bpf_map_get_next_key")]
     fn keys(&self) -> MapKeyIter<'_> {
         MapKeyIter::new(self.as_fd(), self.key_size())
     }
@@ -565,6 +597,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// must be used.
     /// If the map is of type `bloom_filter` the function [`Self::lookup_bloom_filter()`] must be
     /// used
+    #[doc(alias = "bpf_map_lookup_elem_flags")]
     fn lookup(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<u8>>> {
         check_not_bloom_or_percpu(self)?;
         let out_size = self.value_size() as usize;
@@ -583,6 +616,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     ///
     /// If the map is one of the per-cpu data structures, this function cannot be used.
     /// If the map is of type `bloom_filter`, this function cannot be used.
+    #[doc(alias = "bpf_map_lookup_elem_flags")]
     fn lookup_into(&self, key: &[u8], value: &mut [u8], flags: MapFlags) -> Result<bool> {
         check_not_bloom_or_percpu(self)?;
 
@@ -607,6 +641,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Returns many elements in batch mode from the map.
     ///
     /// `count` specifies the batch size.
+    #[doc(alias = "bpf_map_lookup_batch")]
     fn lookup_batch(
         &self,
         count: u32,
@@ -620,6 +655,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Returns many elements in batch mode from the map.
     ///
     /// `count` specifies the batch size.
+    #[doc(alias = "bpf_map_lookup_and_delete_batch")]
     fn lookup_and_delete_batch(
         &self,
         count: u32,
@@ -633,6 +669,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Returns if the given value is likely present in `bloom_filter` as `bool`.
     ///
     /// `value` must have exactly [`Self::value_size()`] elements.
+    #[doc(alias = "bpf_map_lookup_elem")]
     fn lookup_bloom_filter(&self, value: &[u8]) -> Result<bool> {
         let ret = unsafe {
             libbpf_sys::bpf_map_lookup_elem(
@@ -657,6 +694,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Returns one value per cpu as `Vec` of `Vec` of `u8` for per per-cpu maps.
     ///
     /// For normal maps, [`Self::lookup()`] must be used.
+    #[doc(alias = "bpf_map_lookup_elem_flags")]
     fn lookup_percpu(&self, key: &[u8], flags: MapFlags) -> Result<Option<Vec<Vec<u8>>>> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
@@ -684,6 +722,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Deletes an element from the map.
     ///
     /// `key` must have exactly [`Self::key_size()`] elements.
+    #[doc(alias = "bpf_map_delete_elem")]
     fn delete(&self, key: &[u8]) -> Result<()> {
         if key.len() != self.key_size() as usize {
             return Err(Error::with_invalid_data(format!(
@@ -702,6 +741,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// Deletes many elements in batch mode from the map.
     ///
     /// `keys` must have exactly `Self::key_size() * count` elements.
+    #[doc(alias = "bpf_map_delete_batch")]
     fn delete_batch(
         &self,
         keys: &[u8],
@@ -746,6 +786,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// [`MapType::PercpuHash`] / [`MapType::LruPercpuHash`].
     ///
     /// `key` must have exactly [`Self::key_size()`] elements.
+    #[doc(alias = "bpf_map_lookup_and_delete_elem")]
     fn lookup_and_delete(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let out_size = self.value_size() as usize;
         lookup_raw_vec(self, key, LookupOp::LookupAndDelete, out_size)
@@ -762,6 +803,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// `Ok(false)` if the key was not found, or an error.
     ///
     /// See [`Self::lookup_and_delete()`] for kernel support details.
+    #[doc(alias = "bpf_map_lookup_and_delete_elem")]
     fn lookup_into_and_delete(&self, key: &[u8], value: &mut [u8]) -> Result<bool> {
         if value.len() != self.value_size() as usize {
             return Err(Error::with_invalid_data(format!(
@@ -787,6 +829,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// [`Self::value_size()`] elements.
     ///
     /// For per-cpu maps, [`Self::update_percpu()`] must be used.
+    #[doc(alias = "bpf_map_update_elem")]
     fn update(&self, key: &[u8], value: &[u8], flags: MapFlags) -> Result<()> {
         if self.map_type().is_percpu() {
             return Err(Error::with_invalid_data(format!(
@@ -810,6 +853,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     ///
     /// `keys` must have exactly `Self::key_size() * count` elements. `values` must have exactly
     /// `Self::key_size() * count` elements.
+    #[doc(alias = "bpf_map_update_batch")]
     fn update_batch(
         &self,
         keys: &[u8],
@@ -866,6 +910,7 @@ pub trait MapCore: Debug + AsFd + private::Sealed {
     /// with exactly [`Self::value_size()`] elements each.
     ///
     /// For per-cpu maps, [`Self::update_percpu()`] must be used.
+    #[doc(alias = "bpf_map_update_elem")]
     fn update_percpu(&self, key: &[u8], values: &[Vec<u8>], flags: MapFlags) -> Result<()> {
         if !self.map_type().is_percpu() && self.map_type() != MapType::Unknown {
             return Err(Error::with_invalid_data(format!(
@@ -916,6 +961,7 @@ pub type MapMut<'obj> = MapImpl<'obj, Mut>;
 /// Some methods require working with raw bytes. You may find libraries such as
 /// [`plain`](https://crates.io/crates/plain) helpful.
 #[derive(Debug)]
+#[doc(alias = "bpf_map")]
 pub struct MapImpl<'obj, T = ()> {
     ptr: NonNull<libbpf_sys::bpf_map>,
     _phantom: PhantomData<&'obj T>,
@@ -956,12 +1002,14 @@ impl<'obj> Map<'obj> {
     }
 
     /// Returns whether map is pinned or not flag
+    #[doc(alias = "bpf_map__is_pinned")]
     pub fn is_pinned(&self) -> bool {
         unsafe { libbpf_sys::bpf_map__is_pinned(self.ptr.as_ptr()) }
     }
 
     /// Returns the `pin_path` if the map is pinned, otherwise, `None`
     /// is returned.
+    #[doc(alias = "bpf_map__pin_path")]
     pub fn get_pin_path(&self) -> Option<&OsStr> {
         let path_ptr = unsafe { libbpf_sys::bpf_map__pin_path(self.ptr.as_ptr()) };
         if path_ptr.is_null() {
@@ -973,6 +1021,7 @@ impl<'obj> Map<'obj> {
     }
 
     /// Return `true` if the map was set to be auto-created during load, `false` otherwise.
+    #[doc(alias = "bpf_map__autocreate")]
     pub fn autocreate(&self) -> bool {
         unsafe { libbpf_sys::bpf_map__autocreate(self.ptr.as_ptr()) }
     }
@@ -997,6 +1046,7 @@ impl<'obj> MapMut<'obj> {
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this map to bpffs.
+    #[doc(alias = "bpf_map__pin")]
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -1007,6 +1057,7 @@ impl<'obj> MapMut<'obj> {
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this map from bpffs.
+    #[doc(alias = "bpf_map__unpin")]
     pub fn unpin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -1015,6 +1066,7 @@ impl<'obj> MapMut<'obj> {
     }
 
     /// Attach a struct ops map
+    #[doc(alias = "bpf_map__attach_struct_ops")]
     pub fn attach_struct_ops(&mut self) -> Result<Link> {
         if self.map_type() != MapType::StructOps {
             return Err(Error::with_invalid_data(format!(
@@ -1041,6 +1093,7 @@ impl<'obj> Deref for MapMut<'obj> {
 
 impl<T> AsFd for MapImpl<'_, T> {
     #[inline]
+    #[doc(alias = "bpf_map__fd")]
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SANITY: Our map must always have a file descriptor associated with
         //         it.
@@ -1123,6 +1176,7 @@ pub struct MapHandle {
 
 impl MapHandle {
     /// Create a bpf map whose data is not managed by libbpf.
+    #[doc(alias = "bpf_map_create")]
     pub fn create<T: AsRef<OsStr>>(
         map_type: MapType,
         name: Option<T>,
@@ -1174,6 +1228,7 @@ impl MapHandle {
     ///
     /// # Panics
     /// If the path contains null bytes.
+    #[doc(alias = "bpf_obj_get_opts")]
     pub fn from_pinned_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         Self::from_pinned_path_with_file_flags(path, 0)
     }
@@ -1185,6 +1240,7 @@ impl MapHandle {
     ///
     /// # Panics
     /// If the path contains null bytes.
+    #[doc(alias = "bpf_obj_get_opts")]
     pub fn from_pinned_path_with_file_flags<P: AsRef<Path>>(
         path: P,
         file_flags: u32,
@@ -1213,6 +1269,7 @@ impl MapHandle {
     }
 
     /// Open a loaded map from its map id.
+    #[doc(alias = "bpf_map_get_fd_by_id")]
     pub fn from_map_id(id: u32) -> Result<Self> {
         parse_ret_i32(unsafe {
             // SAFETY
@@ -1246,6 +1303,7 @@ impl MapHandle {
     /// `bpf()` system call. This operation is not reversible, and the map remains
     /// immutable from user space until its destruction. However, read and write
     /// permissions for BPF programs to the map remain unchanged.
+    #[doc(alias = "bpf_map_freeze")]
     pub fn freeze(&self) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_map_freeze(self.fd.as_raw_fd()) };
 
@@ -1254,6 +1312,7 @@ impl MapHandle {
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this map to bpffs.
+    #[doc(alias = "bpf_obj_pin")]
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -1362,6 +1421,7 @@ bitflags! {
 #[non_exhaustive]
 #[repr(u32)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[doc(alias = "bpf_map_type")]
 pub enum MapType {
     /// An unspecified map type.
     Unspec = libbpf_sys::BPF_MAP_TYPE_UNSPEC,
@@ -1540,6 +1600,7 @@ impl MapType {
     ///
     /// Make sure the process has required set of CAP_* permissions (or runs as
     /// root) when performing feature checking.
+    #[doc(alias = "libbpf_probe_bpf_map_type")]
     pub fn is_supported(&self) -> Result<bool> {
         let ret = unsafe { libbpf_sys::libbpf_probe_bpf_map_type(*self as u32, ptr::null()) };
         match ret {
@@ -1600,6 +1661,7 @@ impl From<MapType> for u32 {
 
 /// An iterator over the keys of a BPF map.
 #[derive(Debug)]
+#[doc(alias = "bpf_map_get_next_key")]
 pub struct MapKeyIter<'map> {
     map_fd: BorrowedFd<'map>,
     prev: Option<Vec<u8>>,
@@ -1640,6 +1702,8 @@ impl Iterator for MapKeyIter<'_> {
 
 /// An iterator over batches of key value pairs of a BPF map.
 #[derive(Debug)]
+#[doc(alias = "bpf_map_lookup_batch")]
+#[doc(alias = "bpf_map_lookup_and_delete_batch")]
 pub struct BatchedMapIter<'map> {
     map_fd: BorrowedFd<'map>,
     delete: bool,
@@ -1757,6 +1821,7 @@ impl Iterator for BatchedMapIter<'_> {
 /// A convenience wrapper for [`bpf_map_info`]. It provides the ability
 /// to retrieve the details of a certain map.
 #[derive(Debug)]
+#[doc(alias = "bpf_map_info")]
 pub struct MapInfo {
     /// The inner [`bpf_map_info`] object.
     pub info: bpf_map_info,
@@ -1764,6 +1829,7 @@ pub struct MapInfo {
 
 impl MapInfo {
     /// Create a `MapInfo` object from a fd.
+    #[doc(alias = "bpf_obj_get_info_by_fd")]
     pub fn new(fd: BorrowedFd<'_>) -> Result<Self> {
         let mut map_info = bpf_map_info::default();
         let mut size = mem::size_of_val(&map_info) as u32;

--- a/libbpf-rs/src/netfilter.rs
+++ b/libbpf-rs/src/netfilter.rs
@@ -18,6 +18,7 @@ pub const NF_INET_POST_ROUTING: i32 = libc::NF_INET_POST_ROUTING;
 
 /// Options to be provided when attaching a program to a netfilter hook.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_netfilter_opts")]
 pub struct NetfilterOpts {
     /// Protocol family for netfilter; supported values are `NFPROTO_IPV4` (2) for IPv4
     /// and `NFPROTO_IPV6` (10) for IPv6.

--- a/libbpf-rs/src/object.rs
+++ b/libbpf-rs/src/object.rs
@@ -29,6 +29,7 @@ use crate::Result;
 
 /// An iterator over the maps in a BPF object.
 #[derive(Debug)]
+#[doc(alias = "bpf_object__next_map")]
 pub struct MapIter<'obj> {
     obj: &'obj libbpf_sys::bpf_object,
     last: *mut libbpf_sys::bpf_map,
@@ -56,6 +57,7 @@ impl Iterator for MapIter<'_> {
 
 /// An iterator over the programs in a BPF object.
 #[derive(Debug)]
+#[doc(alias = "bpf_object__next_program")]
 pub struct ProgIter<'obj> {
     obj: &'obj libbpf_sys::bpf_object,
     last: *mut libbpf_sys::bpf_program,
@@ -103,6 +105,7 @@ pub trait AsRawLibbpf {
 
 /// Builder for creating an [`OpenObject`]. Typically the entry point into libbpf-rs.
 #[derive(Debug)]
+#[doc(alias = "bpf_object_open_opts")]
 pub struct ObjectBuilder {
     name: Option<CString>,
     pin_root_path: Option<CString>,
@@ -208,6 +211,7 @@ impl ObjectBuilder {
     }
 
     /// Open an object using the provided path on the file system.
+    #[doc(alias = "bpf_object__open_file")]
     pub fn open_file<P: AsRef<Path>>(&mut self, path: P) -> Result<OpenObject> {
         let path = path.as_ref();
         let path_c = util::path_to_cstring(path)?;
@@ -223,6 +227,7 @@ impl ObjectBuilder {
     }
 
     /// Open an object from memory.
+    #[doc(alias = "bpf_object__open_mem")]
     pub fn open_memory(&mut self, mem: &[u8]) -> Result<OpenObject> {
         let opts_ptr = self.as_libbpf_object().as_ptr();
         let ptr = unsafe {
@@ -254,6 +259,7 @@ impl AsRawLibbpf for ObjectBuilder {
 /// Use this object to access [`OpenMap`]s and [`OpenProgram`]s.
 #[derive(Debug)]
 #[repr(transparent)]
+#[doc(alias = "bpf_object")]
 pub struct OpenObject {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }
@@ -285,6 +291,7 @@ impl OpenObject {
     }
 
     /// Retrieve the object's name.
+    #[doc(alias = "bpf_object__name")]
     pub fn name(&self) -> Option<&OsStr> {
         // SAFETY: We ensured `ptr` is valid during construction.
         let name_ptr = unsafe { libbpf_sys::bpf_object__name(self.ptr.as_ptr()) };
@@ -322,6 +329,7 @@ impl OpenObject {
     }
 
     /// Load the maps and programs contained in this BPF object into the system.
+    #[doc(alias = "bpf_object__load")]
     pub fn load(self) -> Result<Object> {
         let ret = unsafe { libbpf_sys::bpf_object__load(self.ptr.as_ptr()) };
         let () = util::parse_ret(ret)?;
@@ -347,6 +355,7 @@ impl AsRawLibbpf for OpenObject {
 }
 
 impl Drop for OpenObject {
+    #[doc(alias = "bpf_object__close")]
     fn drop(&mut self) {
         // `self.ptr` may be null if `load()` was called. This is ok: libbpf noops
         unsafe {
@@ -367,6 +376,7 @@ impl Drop for OpenObject {
 /// enforcing this invariant.
 #[derive(Debug)]
 #[repr(transparent)]
+#[doc(alias = "bpf_object")]
 pub struct Object {
     ptr: NonNull<libbpf_sys::bpf_object>,
 }
@@ -385,6 +395,7 @@ impl Object {
     }
 
     /// Retrieve the object's name.
+    #[doc(alias = "bpf_object__name")]
     pub fn name(&self) -> Option<&OsStr> {
         // SAFETY: We ensured `ptr` is valid during construction.
         let name_ptr = unsafe { libbpf_sys::bpf_object__name(self.ptr.as_ptr()) };
@@ -399,6 +410,7 @@ impl Object {
     }
 
     /// Parse the btf information associated with this bpf object.
+    #[doc(alias = "bpf_object__btf")]
     pub fn btf(&self) -> Result<Option<Btf<'_>>> {
         Btf::from_bpf_object(unsafe { &*self.ptr.as_ptr() })
     }
@@ -444,6 +456,7 @@ impl AsRawLibbpf for Object {
 }
 
 impl Drop for Object {
+    #[doc(alias = "bpf_object__close")]
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::bpf_object__close(self.ptr.as_ptr());

--- a/libbpf-rs/src/perf_buffer.rs
+++ b/libbpf-rs/src/perf_buffer.rs
@@ -110,6 +110,7 @@ where
     }
 
     /// Build the `PerfBuffer` object as configured.
+    #[doc(alias = "perf_buffer__new")]
     pub fn build(self) -> Result<PerfBuffer<'b>> {
         if self.map.map_type() != MapType::PerfEventArray {
             return Err(Error::with_invalid_data("Must use a PerfEventArray map"));
@@ -195,6 +196,7 @@ where
 /// Represents a special kind of [`MapCore`]. Typically used to transfer data between
 /// [`Program`][crate::Program]s and userspace.
 #[derive(Debug)]
+#[doc(alias = "perf_buffer")]
 pub struct PerfBuffer<'b> {
     ptr: NonNull<libbpf_sys::perf_buffer>,
     // Hold onto the box so it'll get dropped when PerfBuffer is dropped
@@ -204,21 +206,25 @@ pub struct PerfBuffer<'b> {
 // TODO: Document methods.
 #[expect(missing_docs)]
 impl PerfBuffer<'_> {
+    #[doc(alias = "perf_buffer__epoll_fd")]
     pub fn epoll_fd(&self) -> i32 {
         unsafe { libbpf_sys::perf_buffer__epoll_fd(self.ptr.as_ptr()) }
     }
 
+    #[doc(alias = "perf_buffer__poll")]
     pub fn poll(&self, timeout: Duration) -> Result<()> {
         let ret =
             unsafe { libbpf_sys::perf_buffer__poll(self.ptr.as_ptr(), timeout.as_millis() as i32) };
         util::parse_ret(ret)
     }
 
+    #[doc(alias = "perf_buffer__consume")]
     pub fn consume(&self) -> Result<()> {
         let ret = unsafe { libbpf_sys::perf_buffer__consume(self.ptr.as_ptr()) };
         util::parse_ret(ret)
     }
 
+    #[doc(alias = "perf_buffer__consume_buffer")]
     pub fn consume_buffer(&self, buf_idx: usize) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::perf_buffer__consume_buffer(
@@ -229,10 +235,12 @@ impl PerfBuffer<'_> {
         util::parse_ret(ret)
     }
 
+    #[doc(alias = "perf_buffer__buffer_cnt")]
     pub fn buffer_cnt(&self) -> usize {
         unsafe { libbpf_sys::perf_buffer__buffer_cnt(self.ptr.as_ptr()) as usize }
     }
 
+    #[doc(alias = "perf_buffer__buffer_fd")]
     pub fn buffer_fd(&self, buf_idx: usize) -> Result<i32> {
         let ret = unsafe {
             libbpf_sys::perf_buffer__buffer_fd(self.ptr.as_ptr(), buf_idx as libbpf_sys::size_t)
@@ -254,6 +262,7 @@ impl AsRawLibbpf for PerfBuffer<'_> {
 unsafe impl Send for PerfBuffer<'_> {}
 
 impl Drop for PerfBuffer<'_> {
+    #[doc(alias = "perf_buffer__free")]
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::perf_buffer__free(self.ptr.as_ptr());

--- a/libbpf-rs/src/print.rs
+++ b/libbpf-rs/src/print.rs
@@ -11,6 +11,7 @@ use crate::util::LazyLock;
 /// An enum representing the different supported print levels.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[repr(u32)]
+#[doc(alias = "libbpf_print_level")]
 pub enum PrintLevel {
     /// Print warnings and more severe messages.
     Warn = libbpf_sys::LIBBPF_WARN,
@@ -33,6 +34,7 @@ impl From<libbpf_sys::libbpf_print_level> for PrintLevel {
 }
 
 /// The type of callback functions suitable for being provided to [`set_print`].
+#[doc(alias = "libbpf_print_fn_t")]
 pub type PrintCallback = fn(PrintLevel, String);
 
 /// Mimic the default print functionality of libbpf. This way if the user calls `get_print` when no
@@ -118,6 +120,7 @@ extern "C" fn outer_print_cb(
 /// // do things quietly
 /// set_print(prev);
 /// ```
+#[doc(alias = "libbpf_set_print")]
 pub fn set_print(
     mut callback: Option<(PrintLevel, PrintCallback)>,
 ) -> Option<(PrintLevel, PrintCallback)> {

--- a/libbpf-rs/src/program.rs
+++ b/libbpf-rs/src/program.rs
@@ -47,6 +47,7 @@ use crate::TracepointOpts;
 
 /// Options to optionally be provided when attaching to a uprobe.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_uprobe_opts")]
 pub struct UprobeOpts {
     /// Offset of kernel reference counted USDT semaphore.
     pub ref_ctr_offset: usize,
@@ -72,6 +73,7 @@ pub struct UprobeOpts {
 
 /// Options to optionally be provided when attaching to a uprobe.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_uprobe_multi_opts")]
 pub struct UprobeMultiOpts {
     /// Optional, array of function symbols to attach to
     pub syms: Vec<String>,
@@ -91,6 +93,7 @@ pub struct UprobeMultiOpts {
 
 /// Options to optionally be provided when attaching to a USDT.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_usdt_opts")]
 pub struct UsdtOpts {
     /// Custom user-provided value accessible through `bpf_usdt_cookie`.
     pub cookie: u64,
@@ -116,6 +119,7 @@ impl From<UsdtOpts> for libbpf_sys::bpf_usdt_opts {
 
 /// Options to optionally be provided when attaching to a kprobe.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_kprobe_opts")]
 pub struct KprobeOpts {
     /// Custom user-provided value accessible through `bpf_get_attach_cookie`.
     pub cookie: u64,
@@ -142,6 +146,7 @@ impl From<KprobeOpts> for libbpf_sys::bpf_kprobe_opts {
 
 /// Options to optionally be provided when attaching to multiple kprobes.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_kprobe_multi_opts")]
 pub struct KprobeMultiOpts {
     /// List of symbol names to attach to.
     pub symbols: Vec<String>,
@@ -155,6 +160,7 @@ pub struct KprobeMultiOpts {
 
 /// Options to optionally be provided when attaching to a perf event.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_perf_event_opts")]
 pub struct PerfEventOpts {
     /// Custom user-provided value accessible through `bpf_get_attach_cookie`.
     pub cookie: u64,
@@ -208,6 +214,7 @@ impl<'fd> MapIterOpts<'fd> {
 #[non_exhaustive]
 #[repr(u32)]
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_cgroup_iter_order")]
 pub enum CgroupIterOrder {
     /// Use the default iteration order.
     #[default]
@@ -248,6 +255,8 @@ impl<'fd> CgroupIterOpts<'fd> {
 /// Options to optionally be provided when attaching to an iterator.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
+#[doc(alias = "bpf_iter_attach_opts")]
+#[doc(alias = "bpf_iter_link_info")]
 pub enum IterOpts<'fd> {
     /// No options used.
     None,
@@ -269,6 +278,7 @@ pub type OpenProgramMut<'obj> = OpenProgramImpl<'obj, Mut>;
 /// This object exposes operations that need to happen before the program is loaded.
 #[derive(Debug)]
 #[repr(transparent)]
+#[doc(alias = "bpf_program")]
 pub struct OpenProgramImpl<'obj, T = ()> {
     ptr: NonNull<libbpf_sys::bpf_program>,
     _phantom: PhantomData<&'obj T>,
@@ -286,11 +296,13 @@ impl<'obj> OpenProgram<'obj> {
     }
 
     /// The `ProgramType` of this `OpenProgram`.
+    #[doc(alias = "bpf_program__type")]
     pub fn prog_type(&self) -> ProgramType {
         ProgramType::from(unsafe { libbpf_sys::bpf_program__type(self.ptr.as_ptr()) })
     }
 
     /// Retrieve the name of this `OpenProgram`.
+    #[doc(alias = "bpf_program__name")]
     pub fn name(&self) -> &'obj OsStr {
         let name_ptr = unsafe { libbpf_sys::bpf_program__name(self.ptr.as_ptr()) };
         let name_c_str = unsafe { CStr::from_ptr(name_ptr) };
@@ -299,6 +311,7 @@ impl<'obj> OpenProgram<'obj> {
     }
 
     /// Retrieve the name of the section this `OpenProgram` belongs to.
+    #[doc(alias = "bpf_program__section_name")]
     pub fn section(&self) -> &'obj OsStr {
         // SAFETY: The program is always valid.
         let p = unsafe { libbpf_sys::bpf_program__section_name(self.ptr.as_ptr()) };
@@ -314,6 +327,7 @@ impl<'obj> OpenProgram<'obj> {
     /// Note: Keep in mind, libbpf can modify the program's instructions
     /// and consequently its instruction count, as it processes the BPF object file.
     /// So [`OpenProgram::insn_cnt`] and [`Program::insn_cnt`] may return different values.
+    #[doc(alias = "bpf_program__insn_cnt")]
     pub fn insn_cnt(&self) -> usize {
         unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr.as_ptr()) as usize }
     }
@@ -327,6 +341,7 @@ impl<'obj> OpenProgram<'obj> {
     /// instructions will be CO-RE-relocated, BPF subprograms instructions will be appended, ldimm64
     /// instructions will have FDs embedded, etc. So instructions returned before load and after it
     /// might be quite different.
+    #[doc(alias = "bpf_program__insns")]
     pub fn insns(&self) -> &'obj [libbpf_sys::bpf_insn] {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
@@ -334,6 +349,7 @@ impl<'obj> OpenProgram<'obj> {
     }
 
     /// Return `true` if the bpf program is set to autoload, `false` otherwise.
+    #[doc(alias = "bpf_program__autoload")]
     pub fn autoload(&self) -> bool {
         unsafe { libbpf_sys::bpf_program__autoload(self.ptr.as_ptr()) }
     }
@@ -349,12 +365,14 @@ impl<'obj> OpenProgramMut<'obj> {
     }
 
     /// Set the program type.
+    #[doc(alias = "bpf_program__set_type")]
     pub fn set_prog_type(&mut self, prog_type: ProgramType) {
         let rc = unsafe { libbpf_sys::bpf_program__set_type(self.ptr.as_ptr(), prog_type as u32) };
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
     }
 
     /// Set the attachment type of the program.
+    #[doc(alias = "bpf_program__set_expected_attach_type")]
     pub fn set_attach_type(&mut self, attach_type: ProgramAttachType) {
         let rc = unsafe {
             libbpf_sys::bpf_program__set_expected_attach_type(self.ptr.as_ptr(), attach_type as u32)
@@ -365,6 +383,7 @@ impl<'obj> OpenProgramMut<'obj> {
     /// Bind the program to a particular network device.
     ///
     /// Currently only used for hardware offload and certain XDP features such like HW metadata.
+    #[doc(alias = "bpf_program__set_ifindex")]
     pub fn set_ifindex(&mut self, idx: u32) {
         unsafe { libbpf_sys::bpf_program__set_ifindex(self.ptr.as_ptr(), idx) }
     }
@@ -377,6 +396,7 @@ impl<'obj> OpenProgramMut<'obj> {
     ///
     /// In general, a value of `0` disables logging while values `> 0` enables
     /// it.
+    #[doc(alias = "bpf_program__set_log_level")]
     pub fn set_log_level(&mut self, log_level: u32) {
         let rc = unsafe { libbpf_sys::bpf_program__set_log_level(self.ptr.as_ptr(), log_level) };
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
@@ -384,6 +404,7 @@ impl<'obj> OpenProgramMut<'obj> {
 
     /// Set whether a bpf program should be automatically loaded by default
     /// when the bpf object is loaded.
+    #[doc(alias = "bpf_program__set_autoload")]
     pub fn set_autoload(&mut self, autoload: bool) {
         let rc = unsafe { libbpf_sys::bpf_program__set_autoload(self.ptr.as_ptr(), autoload) };
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
@@ -391,11 +412,13 @@ impl<'obj> OpenProgramMut<'obj> {
 
     /// Set whether a bpf program should be automatically attached by default
     /// when the bpf object is loaded.
+    #[doc(alias = "bpf_program__set_autoattach")]
     pub fn set_autoattach(&mut self, autoattach: bool) {
         unsafe { libbpf_sys::bpf_program__set_autoattach(self.ptr.as_ptr(), autoattach) };
     }
 
     #[expect(missing_docs)]
+    #[doc(alias = "bpf_program__set_attach_target")]
     pub fn set_attach_target(
         &mut self,
         attach_prog_fd: i32,
@@ -414,6 +437,7 @@ impl<'obj> OpenProgramMut<'obj> {
     }
 
     /// Set flags on the program.
+    #[doc(alias = "bpf_program__set_flags")]
     pub fn set_flags(&mut self, flags: u32) {
         let rc = unsafe { libbpf_sys::bpf_program__set_flags(self.ptr.as_ptr(), flags) };
         debug_assert!(util::parse_ret(rc).is_ok(), "{rc}");
@@ -445,6 +469,7 @@ impl<T> AsRawLibbpf for OpenProgramImpl<'_, T> {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 // TODO: Document variants.
 #[expect(missing_docs)]
+#[doc(alias = "bpf_prog_type")]
 pub enum ProgramType {
     Unspec = 0,
     SocketFilter = libbpf_sys::BPF_PROG_TYPE_SOCKET_FILTER,
@@ -488,6 +513,7 @@ impl ProgramType {
     ///
     /// Make sure the process has required set of CAP_* permissions (or runs as
     /// root) when performing feature checking.
+    #[doc(alias = "libbpf_probe_bpf_prog_type")]
     pub fn is_supported(&self) -> Result<bool> {
         let ret = unsafe { libbpf_sys::libbpf_probe_bpf_prog_type(*self as u32, ptr::null()) };
         match ret {
@@ -502,6 +528,7 @@ impl ProgramType {
     ///
     /// Make sure the process has required set of CAP_* permissions (or runs as
     /// root) when performing feature checking.
+    #[doc(alias = "libbpf_probe_bpf_helper")]
     pub fn is_helper_supported(&self, helper_id: bpf_func_id) -> Result<bool> {
         let ret =
             unsafe { libbpf_sys::libbpf_probe_bpf_helper(*self as u32, helper_id, ptr::null()) };
@@ -562,6 +589,7 @@ impl From<u32> for ProgramType {
 #[derive(Clone, Debug)]
 // TODO: Document variants.
 #[expect(missing_docs)]
+#[doc(alias = "bpf_attach_type")]
 pub enum ProgramAttachType {
     CgroupInetIngress = libbpf_sys::BPF_CGROUP_INET_INGRESS,
     CgroupInetEgress = libbpf_sys::BPF_CGROUP_INET_EGRESS,
@@ -696,6 +724,7 @@ impl From<u32> for ProgramAttachType {
 /// This type is mostly used in conjunction with the [`Program::test_run`]
 /// facility.
 #[derive(Debug, Default)]
+#[doc(alias = "bpf_test_run_opts")]
 pub struct Input<'dat> {
     /// The input context to provide.
     ///
@@ -724,6 +753,7 @@ pub struct Input<'dat> {
 /// This type is mostly used in conjunction with the [`Program::test_run`]
 /// facility.
 #[derive(Debug)]
+#[doc(alias = "bpf_test_run_opts")]
 pub struct Output<'dat> {
     /// The value returned by the program.
     pub return_value: u32,
@@ -752,6 +782,7 @@ pub type ProgramMut<'obj> = ProgramImpl<'obj, Mut>;
 /// method will fail with the appropriate error.
 #[derive(Debug)]
 #[repr(transparent)]
+#[doc(alias = "bpf_program")]
 pub struct ProgramImpl<'obj, T = ()> {
     pub(crate) ptr: NonNull<libbpf_sys::bpf_program>,
     _phantom: PhantomData<&'obj T>,
@@ -769,6 +800,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Retrieve the name of this `Program`.
+    #[doc(alias = "bpf_program__name")]
     pub fn name(&self) -> &'obj OsStr {
         let name_ptr = unsafe { libbpf_sys::bpf_program__name(self.ptr.as_ptr()) };
         let name_c_str = unsafe { CStr::from_ptr(name_ptr) };
@@ -777,6 +809,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Retrieve the name of the section this `Program` belongs to.
+    #[doc(alias = "bpf_program__section_name")]
     pub fn section(&self) -> &'obj OsStr {
         // SAFETY: The program is always valid.
         let p = unsafe { libbpf_sys::bpf_program__section_name(self.ptr.as_ptr()) };
@@ -788,6 +821,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Retrieve the type of the program.
+    #[doc(alias = "bpf_program__type")]
     pub fn prog_type(&self) -> ProgramType {
         ProgramType::from(unsafe { libbpf_sys::bpf_program__type(self.ptr.as_ptr()) })
     }
@@ -800,6 +834,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Returns program file descriptor given a program ID.
+    #[doc(alias = "bpf_prog_get_fd_by_id")]
     pub fn fd_from_id(id: u32) -> Result<OwnedFd> {
         let ret = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(id) };
         let fd = util::parse_ret_i32(ret)?;
@@ -810,6 +845,7 @@ impl<'obj> Program<'obj> {
     }
 
     /// Returns program ID given a file descriptor.
+    #[doc(alias = "bpf_obj_get_info_by_fd")]
     pub fn id_from_fd(fd: BorrowedFd<'_>) -> Result<u32> {
         let mut prog_info = libbpf_sys::bpf_prog_info::default();
         let prog_info_ptr: *mut libbpf_sys::bpf_prog_info = &mut prog_info;
@@ -828,6 +864,7 @@ impl<'obj> Program<'obj> {
     /// Returns fd of a previously pinned program
     ///
     /// Returns error, if the pinned path doesn't represent an eBPF program.
+    #[doc(alias = "bpf_obj_get")]
     pub fn fd_from_pinned_path<P: AsRef<Path>>(path: P) -> Result<OwnedFd> {
         let path_c = util::path_to_cstring(&path)?;
         let path_ptr = path_c.as_ptr();
@@ -854,11 +891,13 @@ impl<'obj> Program<'obj> {
     }
 
     /// Returns flags that have been set for the program.
+    #[doc(alias = "bpf_program__flags")]
     pub fn flags(&self) -> u32 {
         unsafe { libbpf_sys::bpf_program__flags(self.ptr.as_ptr()) }
     }
 
     /// Retrieve the attach type of the program.
+    #[doc(alias = "bpf_program__expected_attach_type")]
     pub fn attach_type(&self) -> ProgramAttachType {
         ProgramAttachType::from(unsafe {
             libbpf_sys::bpf_program__expected_attach_type(self.ptr.as_ptr())
@@ -866,11 +905,13 @@ impl<'obj> Program<'obj> {
     }
 
     /// Return `true` if the bpf program is set to autoload, `false` otherwise.
+    #[doc(alias = "bpf_program__autoload")]
     pub fn autoload(&self) -> bool {
         unsafe { libbpf_sys::bpf_program__autoload(self.ptr.as_ptr()) }
     }
 
     /// Return the bpf program's log level.
+    #[doc(alias = "bpf_program__log_level")]
     pub fn log_level(&self) -> u32 {
         unsafe { libbpf_sys::bpf_program__log_level(self.ptr.as_ptr()) }
     }
@@ -878,6 +919,7 @@ impl<'obj> Program<'obj> {
     /// Returns the number of instructions that form the program.
     ///
     /// Please see note in [`OpenProgram::insn_cnt`].
+    #[doc(alias = "bpf_program__insn_cnt")]
     pub fn insn_cnt(&self) -> usize {
         unsafe { libbpf_sys::bpf_program__insn_cnt(self.ptr.as_ptr()) as usize }
     }
@@ -885,6 +927,7 @@ impl<'obj> Program<'obj> {
     /// Gives read-only access to BPF program's underlying BPF instructions.
     ///
     /// Please see note in [`OpenProgram::insns`].
+    #[doc(alias = "bpf_program__insns")]
     pub fn insns(&self) -> &'obj [libbpf_sys::bpf_insn] {
         let count = self.insn_cnt();
         let ptr = unsafe { libbpf_sys::bpf_program__insns(self.ptr.as_ptr()) };
@@ -903,6 +946,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this program to bpffs.
+    #[doc(alias = "bpf_program__pin")]
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -913,6 +957,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// [Unpin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this program from bpffs
+    #[doc(alias = "bpf_program__unpin")]
     pub fn unpin<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let path_ptr = path_c.as_ptr();
@@ -922,6 +967,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Auto-attach based on prog section
+    #[doc(alias = "bpf_program__attach")]
     pub fn attach(&self) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach(self.ptr.as_ptr()) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach BPF program")?;
@@ -932,6 +978,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a
     /// [cgroup](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html).
+    #[doc(alias = "bpf_program__attach_cgroup")]
     pub fn attach_cgroup(&self, cgroup_fd: i32) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_cgroup(self.ptr.as_ptr(), cgroup_fd) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach cgroup")?;
@@ -941,6 +988,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach this program to a [perf event](https://linux.die.net/man/2/perf_event_open).
+    #[doc(alias = "bpf_program__attach_perf_event")]
     pub fn attach_perf_event(&self, pfd: i32) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_perf_event(self.ptr.as_ptr(), pfd) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach perf event")?;
@@ -951,6 +999,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a [perf event](https://linux.die.net/man/2/perf_event_open),
     /// providing additional options.
+    #[doc(alias = "bpf_program__attach_perf_event_opts")]
     pub fn attach_perf_event_with_opts(&self, pfd: i32, opts: PerfEventOpts) -> Result<Link> {
         let libbpf_opts = libbpf_sys::bpf_perf_event_opts::from(opts);
         let ptr = unsafe {
@@ -964,6 +1013,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a [userspace
     /// probe](https://www.kernel.org/doc/html/latest/trace/uprobetracer.html).
+    #[doc(alias = "bpf_program__attach_uprobe")]
     pub fn attach_uprobe<T: AsRef<Path>>(
         &self,
         retprobe: bool,
@@ -991,6 +1041,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [userspace
     /// probe](https://www.kernel.org/doc/html/latest/trace/uprobetracer.html),
     /// providing additional options.
+    #[doc(alias = "bpf_program__attach_uprobe_opts")]
     pub fn attach_uprobe_with_opts(
         &self,
         pid: i32,
@@ -1042,6 +1093,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to multiple
     /// [uprobes](https://www.kernel.org/doc/html/latest/trace/uprobetracer.html) at once.
+    #[doc(alias = "bpf_program__attach_uprobe_multi")]
     pub fn attach_uprobe_multi(
         &self,
         pid: i32,
@@ -1066,6 +1118,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to multiple
     /// [uprobes](https://www.kernel.org/doc/html/latest/trace/uprobetracer.html)
     /// at once, providing additional options.
+    #[doc(alias = "bpf_program__attach_uprobe_multi")]
     pub fn attach_uprobe_multi_with_opts(
         &self,
         pid: i32,
@@ -1160,6 +1213,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a [kernel
     /// probe](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html).
+    #[doc(alias = "bpf_program__attach_kprobe")]
     pub fn attach_kprobe<T: AsRef<str>>(&self, retprobe: bool, func_name: T) -> Result<Link> {
         let func_name = util::str_to_cstring(func_name.as_ref())?;
         let func_name_ptr = func_name.as_ptr();
@@ -1175,6 +1229,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [kernel
     /// probe](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html),
     /// providing additional options.
+    #[doc(alias = "bpf_program__attach_kprobe_opts")]
     pub fn attach_kprobe_with_opts<T: AsRef<str>>(
         &self,
         retprobe: bool,
@@ -1231,6 +1286,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to multiple [kernel
     /// probes](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html)
     /// at once.
+    #[doc(alias = "bpf_program__attach_kprobe_multi_opts")]
     pub fn attach_kprobe_multi<T: AsRef<str>>(
         &self,
         retprobe: bool,
@@ -1259,6 +1315,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to multiple [kernel
     /// probes](https://www.kernel.org/doc/html/latest/trace/kprobetrace.html)
     /// at once, providing additional options.
+    #[doc(alias = "bpf_program__attach_kprobe_multi_opts")]
     pub fn attach_kprobe_multi_with_opts(&self, opts: KprobeMultiOpts) -> Result<Link> {
         let KprobeMultiOpts {
             symbols,
@@ -1293,6 +1350,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach this program to the specified syscall
+    #[doc(alias = "bpf_program__attach_ksyscall")]
     pub fn attach_ksyscall<T: AsRef<str>>(&self, retprobe: bool, syscall_name: T) -> Result<Link> {
         let opts = libbpf_sys::bpf_ksyscall_opts {
             sz: size_of::<libbpf_sys::bpf_ksyscall_opts>() as _,
@@ -1341,6 +1399,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a [kernel
     /// tracepoint](https://www.kernel.org/doc/html/latest/trace/tracepoints.html).
+    #[doc(alias = "bpf_program__attach_tracepoint")]
     pub fn attach_tracepoint(
         &self,
         tp_category: TracepointCategory,
@@ -1352,6 +1411,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [kernel
     /// tracepoint](https://www.kernel.org/doc/html/latest/trace/tracepoints.html),
     /// providing additional options.
+    #[doc(alias = "bpf_program__attach_tracepoint_opts")]
     pub fn attach_tracepoint_with_opts(
         &self,
         tp_category: TracepointCategory,
@@ -1363,6 +1423,7 @@ impl<'obj> ProgramMut<'obj> {
 
     /// Attach this program to a [raw kernel
     /// tracepoint](https://lwn.net/Articles/748352/).
+    #[doc(alias = "bpf_program__attach_raw_tracepoint")]
     pub fn attach_raw_tracepoint<T: AsRef<str>>(&self, tp_name: T) -> Result<Link> {
         let tp_name = util::str_to_cstring(tp_name.as_ref())?;
         let tp_name_ptr = tp_name.as_ptr();
@@ -1378,6 +1439,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [raw kernel
     /// tracepoint](https://lwn.net/Articles/748352/), providing additional
     /// options.
+    #[doc(alias = "bpf_program__attach_raw_tracepoint_opts")]
     pub fn attach_raw_tracepoint_with_opts<T: AsRef<str>>(
         &self,
         tp_name: T,
@@ -1400,6 +1462,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach to an [LSM](https://en.wikipedia.org/wiki/Linux_Security_Modules) hook
+    #[doc(alias = "bpf_program__attach_lsm")]
     pub fn attach_lsm(&self) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_lsm(self.ptr.as_ptr()) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach LSM")?;
@@ -1409,6 +1472,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach to a [fentry/fexit kernel probe](https://lwn.net/Articles/801479/)
+    #[doc(alias = "bpf_program__attach_trace")]
     pub fn attach_trace(&self) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_trace(self.ptr.as_ptr()) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach fentry/fexit kernel probe")?;
@@ -1418,6 +1482,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach a verdict/parser to a [sockmap/sockhash](https://lwn.net/Articles/731133/)
+    #[doc(alias = "bpf_prog_attach")]
     pub fn attach_sockmap(&self, map_fd: i32) -> Result<()> {
         let err = unsafe {
             libbpf_sys::bpf_prog_attach(
@@ -1431,6 +1496,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach this program to [XDP](https://lwn.net/Articles/825998/)
+    #[doc(alias = "bpf_program__attach_xdp")]
     pub fn attach_xdp(&self, ifindex: i32) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_xdp(self.ptr.as_ptr(), ifindex) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach XDP program")?;
@@ -1440,6 +1506,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach this program to [netns-based programs](https://lwn.net/Articles/819618/)
+    #[doc(alias = "bpf_program__attach_netns")]
     pub fn attach_netns(&self, netns_fd: i32) -> Result<Link> {
         let ptr = unsafe { libbpf_sys::bpf_program__attach_netns(self.ptr.as_ptr(), netns_fd) };
         let ptr = validate_bpf_ret(ptr).context("failed to attach network namespace program")?;
@@ -1449,6 +1516,7 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Attach this program to [netfilter programs](https://lwn.net/Articles/925082/)
+    #[doc(alias = "bpf_program__attach_netfilter")]
     pub fn attach_netfilter_with_opts(
         &self,
         netfilter_opt: netfilter::NetfilterOpts,
@@ -1507,6 +1575,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [USDT](https://lwn.net/Articles/753601/) probe
     /// point. The entry point of the program must be defined with
     /// `SEC("usdt")`.
+    #[doc(alias = "bpf_program__attach_usdt")]
     pub fn attach_usdt(
         &self,
         pid: i32,
@@ -1526,6 +1595,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a [USDT](https://lwn.net/Articles/753601/) probe
     /// point, providing additional options. The entry point of the program must
     /// be defined with `SEC("usdt")`.
+    #[doc(alias = "bpf_program__attach_usdt")]
     pub fn attach_usdt_with_opts(
         &self,
         pid: i32,
@@ -1546,6 +1616,7 @@ impl<'obj> ProgramMut<'obj> {
     /// Attach this program to a
     /// [BPF Iterator](https://www.kernel.org/doc/html/latest/bpf/bpf_iterators.html).
     /// The entry point of the program must be defined with `SEC("iter")` or `SEC("iter.s")`.
+    #[doc(alias = "bpf_program__attach_iter")]
     pub fn attach_iter(&self, map_fd: BorrowedFd<'_>) -> Result<Link> {
         let map_opts = MapIterOpts {
             fd: map_fd,
@@ -1559,6 +1630,7 @@ impl<'obj> ProgramMut<'obj> {
     /// providing additional options.
     ///
     /// The entry point of the program must be defined with `SEC("iter")` or `SEC("iter.s")`.
+    #[doc(alias = "bpf_program__attach_iter")]
     pub fn attach_iter_with_opts(&self, opts: IterOpts<'_>) -> Result<Link> {
         let mut linkinfo = match opts {
             IterOpts::None => None,
@@ -1620,6 +1692,7 @@ impl<'obj> ProgramMut<'obj> {
     ///
     /// This program must not be of type [`ProgramType::StructOps`], and
     /// the map must be of type [`MapType::StructOps`][crate::MapType::StructOps].
+    #[doc(alias = "bpf_program__assoc_struct_ops")]
     pub fn assoc_struct_ops(&self, map: &Map<'_>) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::bpf_program__assoc_struct_ops(
@@ -1636,6 +1709,7 @@ impl<'obj> ProgramMut<'obj> {
     /// This function uses the
     /// [BPF_PROG_RUN](https://www.kernel.org/doc/html/latest/bpf/bpf_prog_run.html)
     /// facility.
+    #[doc(alias = "bpf_prog_test_run_opts")]
     pub fn test_run<'dat>(&self, input: Input<'dat>) -> Result<Output<'dat>> {
         unsafe fn slice_from_array<'t, T>(items: *mut T, num_items: usize) -> Option<&'t mut [T]> {
             if items.is_null() {
@@ -1696,11 +1770,13 @@ impl<'obj> ProgramMut<'obj> {
     }
 
     /// Get the stdout BPF stream of the program.
+    #[doc(alias = "bpf_prog_stream_read")]
     pub fn stdout(&self) -> impl Read + '_ {
         Stream::new(self.as_fd(), Stream::BPF_STDOUT)
     }
 
     /// Get the stderr BPF stream of the program.
+    #[doc(alias = "bpf_prog_stream_read")]
     pub fn stderr(&self) -> impl Read + '_ {
         Stream::new(self.as_fd(), Stream::BPF_STDERR)
     }
@@ -1717,6 +1793,7 @@ impl<'obj> Deref for ProgramMut<'obj> {
 }
 
 impl<T> AsFd for ProgramImpl<'_, T> {
+    #[doc(alias = "bpf_program__fd")]
     fn as_fd(&self) -> BorrowedFd<'_> {
         let fd = unsafe { libbpf_sys::bpf_program__fd(self.ptr.as_ptr()) };
         unsafe { BorrowedFd::borrow_raw(fd) }
@@ -1777,6 +1854,7 @@ impl ProgramHandle {
     }
 
     /// Open a previously pinned program from its bpffs path.
+    #[doc(alias = "bpf_obj_get")]
     pub fn from_pinned_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         let fd = Program::fd_from_pinned_path(path)?;
         Self::from_fd(fd)
@@ -1808,6 +1886,7 @@ impl ProgramHandle {
 
     /// [Pin](https://facebookmicrosites.github.io/bpf/blog/2018/08/31/object-lifetime.html#bpffs)
     /// this program to bpffs.
+    #[doc(alias = "bpf_obj_pin")]
     pub fn pin<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let path_c = util::path_to_cstring(path)?;
         let ret = unsafe { libbpf_sys::bpf_obj_pin(self.fd.as_raw_fd(), path_c.as_ptr()) };

--- a/libbpf-rs/src/query.rs
+++ b/libbpf-rs/src/query.rs
@@ -103,6 +103,7 @@ macro_rules! gen_info_impl {
 
 /// BTF Line information.
 #[derive(Clone, Debug)]
+#[doc(alias = "bpf_line_info")]
 pub struct LineInfo {
     /// Offset of instruction in vector.
     pub insn_off: u32,
@@ -135,6 +136,7 @@ pub struct Tag(pub [u8; 8]);
 
 /// Information about a BPF program. Maps to `struct bpf_prog_info` in kernel uapi.
 #[derive(Debug, Clone)]
+#[doc(alias = "bpf_prog_info")]
 pub struct ProgramInfo {
     /// A user-defined name for the BPF program.
     pub name: OsString,
@@ -198,6 +200,7 @@ pub struct ProgramInfo {
 
 /// An iterator for the information of loaded bpf programs.
 #[derive(Default, Debug)]
+#[doc(alias = "bpf_prog_get_next_id")]
 pub struct ProgInfoIter {
     cur_id: u32,
     opts: ProgInfoQueryOptions,
@@ -473,6 +476,7 @@ impl Iterator for ProgInfoIter {
 
 /// Information about a BPF map. Maps to `struct bpf_map_info` in kernel uapi.
 #[derive(Debug, Clone)]
+#[doc(alias = "bpf_map_info")]
 pub struct MapInfo {
     /// A user-defined name for the BPF Map.
     pub name: OsString,
@@ -533,6 +537,7 @@ impl MapInfo {
 
 gen_info_impl!(
     /// Iterator that returns [`MapInfo`]s.
+    #[doc(alias = "bpf_map_get_next_id")]
     MapInfoIter,
     MapInfo,
     libbpf_sys::bpf_map_info,
@@ -542,6 +547,7 @@ gen_info_impl!(
 
 /// Information about BPF type format.
 #[derive(Debug, Clone)]
+#[doc(alias = "bpf_btf_info")]
 pub struct BtfInfo {
     /// The name associated with this btf information in the kernel.
     pub name: OsString,
@@ -593,6 +599,8 @@ impl BtfInfo {
 #[derive(Debug, Default)]
 /// An iterator for the btf type information of modules and programs
 /// in the kernel
+#[doc(alias = "bpf_btf_get_next_id")]
+#[doc(alias = "bpf_btf_get_fd_by_id")]
 pub struct BtfInfoIter {
     cur_id: u32,
 }
@@ -945,6 +953,7 @@ pub enum LinkTypeInfo {
 
 /// Information about a BPF link. Maps to `struct bpf_link_info` in kernel uapi.
 #[derive(Debug, Clone)]
+#[doc(alias = "bpf_link_info")]
 pub struct LinkInfo {
     /// Information about the BPF link type.
     pub info: LinkTypeInfo,
@@ -956,6 +965,7 @@ pub struct LinkInfo {
 
 impl LinkInfo {
     /// Create a `LinkInfo` object from a fd.
+    #[doc(alias = "bpf_obj_get_info_by_fd")]
     pub fn from_fd(fd: BorrowedFd<'_>) -> Result<Self> {
         // See comment in gen_info_impl!() for why we use std::mem::zeroed()
         let mut link_info: libbpf_sys::bpf_link_info = unsafe { zeroed() };
@@ -1346,6 +1356,8 @@ impl LinkInfo {
 
 gen_info_impl!(
     /// Iterator that returns [`LinkInfo`]s.
+    #[doc(alias = "bpf_link_get_next_id")]
+    #[doc(alias = "bpf_link_get_fd_by_id")]
     LinkInfoIter,
     LinkInfo,
     libbpf_sys::bpf_link_info,

--- a/libbpf-rs/src/ringbuf.rs
+++ b/libbpf-rs/src/ringbuf.rs
@@ -72,6 +72,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
     ///
     /// The callback provides a raw byte slice. You may find libraries such as
     /// [`plain`](https://crates.io/crates/plain) helpful.
+    #[doc(alias = "ring_buffer__add")]
     pub fn add<NewF>(&mut self, map: &'slf dyn MapCore, callback: NewF) -> Result<&mut Self>
     where
         NewF: FnMut(&[u8]) -> i32 + 'cb,
@@ -85,6 +86,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
     }
 
     /// Build a new [`RingBuffer`]. Must have added at least one ringbuf.
+    #[doc(alias = "ring_buffer__new")]
     pub fn build(self) -> Result<RingBuffer<'cb>> {
         let mut cbs = vec![];
         let mut rb_ptr: Option<NonNull<libbpf_sys::ring_buffer>> = None;
@@ -158,6 +160,7 @@ impl<'slf, 'cb: 'slf> RingBufferBuilder<'slf, 'cb> {
 /// between [`Program`][crate::Program]s and userspace. As of Linux 5.8, the
 /// `ringbuf` map is now preferred over the `perf buffer`.
 #[derive(Debug)]
+#[doc(alias = "ring_buffer")]
 pub struct RingBuffer<'cb> {
     ptr: NonNull<libbpf_sys::ring_buffer>,
     #[expect(clippy::vec_box)]
@@ -171,6 +174,7 @@ impl RingBuffer<'_> {
     /// indefinitely until an event occurs.
     ///
     /// Return the amount of events consumed, or a negative value in case of error.
+    #[doc(alias = "ring_buffer__poll")]
     pub fn poll_raw(&self, timeout: Duration) -> i32 {
         let mut timeout_ms = -1;
         if timeout != Duration::MAX {
@@ -184,6 +188,7 @@ impl RingBuffer<'_> {
     /// each one. Polls continually until we either run out of events to consume
     /// or `timeout` is reached. If `timeout` is `Duration::MAX`, this will block
     /// indefinitely until an event occurs.
+    #[doc(alias = "ring_buffer__poll")]
     pub fn poll(&self, timeout: Duration) -> Result<()> {
         let ret = self.poll_raw(timeout);
 
@@ -195,6 +200,7 @@ impl RingBuffer<'_> {
     /// to consume or one of the callbacks returns a non-zero integer.
     ///
     /// Return the amount of events consumed, or a negative value in case of error.
+    #[doc(alias = "ring_buffer__consume")]
     pub fn consume_raw(&self) -> i32 {
         unsafe { libbpf_sys::ring_buffer__consume(self.ptr.as_ptr()) }
     }
@@ -204,6 +210,7 @@ impl RingBuffer<'_> {
     /// no more events are available, or a callback returns a non-zero value.
     ///
     /// Return the amount of events consumed, or a negative value in case of error.
+    #[doc(alias = "ring_buffer__consume_n")]
     pub fn consume_raw_n(&self, len: usize) -> i32 {
         unsafe { libbpf_sys::ring_buffer__consume_n(self.ptr.as_ptr(), len as libbpf_sys::size_t) }
     }
@@ -211,6 +218,7 @@ impl RingBuffer<'_> {
     /// Greedily consume from all open ring buffers, calling the registered
     /// callback for each one. Consumes continually until we run out of events
     /// to consume or one of the callbacks returns a non-zero integer.
+    #[doc(alias = "ring_buffer__consume")]
     pub fn consume(&self) -> Result<()> {
         let ret = self.consume_raw();
 
@@ -218,6 +226,7 @@ impl RingBuffer<'_> {
     }
 
     /// Get an fd that can be used to sleep until data is available
+    #[doc(alias = "ring_buffer__epoll_fd")]
     pub fn epoll_fd(&self) -> i32 {
         unsafe { libbpf_sys::ring_buffer__epoll_fd(self.ptr.as_ptr()) }
     }
@@ -236,6 +245,7 @@ impl AsRawLibbpf for RingBuffer<'_> {
 unsafe impl Send for RingBuffer<'_> {}
 
 impl Drop for RingBuffer<'_> {
+    #[doc(alias = "ring_buffer__free")]
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::ring_buffer__free(self.ptr.as_ptr());

--- a/libbpf-rs/src/tc.rs
+++ b/libbpf-rs/src/tc.rs
@@ -7,6 +7,7 @@ use crate::Error;
 use crate::Result;
 
 /// See [`libbpf_sys::bpf_tc_attach_point`].
+#[doc(alias = "bpf_tc_attach_point")]
 pub type TcAttachPoint = libbpf_sys::bpf_tc_attach_point;
 /// See [`libbpf_sys::BPF_TC_INGRESS`].
 pub const TC_INGRESS: TcAttachPoint = libbpf_sys::BPF_TC_INGRESS;
@@ -48,6 +49,8 @@ pub const TC_H_MIN_MASK: u32 = 0x0000FFFF;
 /// An example of using a BPF TC program can found
 /// [here](https://github.com/libbpf/libbpf-rs/tree/master/examples/tc_port_whitelist).
 #[derive(Clone, Copy, Debug)]
+#[doc(alias = "bpf_tc_hook")]
+#[doc(alias = "bpf_tc_opts")]
 pub struct TcHook {
     hook: libbpf_sys::bpf_tc_hook,
     opts: libbpf_sys::bpf_tc_opts,
@@ -75,6 +78,7 @@ impl TcHook {
     /// [`Self::create()`], this function will still succeed.
     ///
     /// Will always fail on a `TC_CUSTOM` hook
+    #[doc(alias = "bpf_tc_hook_create")]
     pub fn create(&mut self) -> Result<Self> {
         let err = unsafe { libbpf_sys::bpf_tc_hook_create(&mut self.hook as *mut _) };
         if err != 0 {
@@ -166,6 +170,7 @@ impl TcHook {
     }
 
     /// Query a hook to inspect the program identifier (`prog_id`)
+    #[doc(alias = "bpf_tc_query")]
     pub fn query(&mut self) -> Result<u32> {
         let mut opts = self.opts;
         opts.prog_id = 0;
@@ -191,6 +196,7 @@ impl TcHook {
     ///
     /// NOTE: Once a [`TcHook`] is attached, it, and the maps it uses, will outlive the userspace
     /// application that spawned them Make sure to detach if this is not desired
+    #[doc(alias = "bpf_tc_attach")]
     pub fn attach(&mut self) -> Result<Self> {
         self.opts.prog_id = 0;
         let err =
@@ -203,6 +209,7 @@ impl TcHook {
     }
 
     /// Detach a filter from a [`TcHook`]
+    #[doc(alias = "bpf_tc_detach")]
     pub fn detach(&mut self) -> Result<()> {
         let mut opts = self.opts;
         opts.prog_id = 0;
@@ -231,6 +238,7 @@ impl TcHook {
     ///
     /// It is good practice to query before destroying as the tc qdisc may be used by multiple
     /// programs
+    #[doc(alias = "bpf_tc_hook_destroy")]
     pub fn destroy(&mut self) -> Result<()> {
         let err = unsafe { libbpf_sys::bpf_tc_hook_destroy(&mut self.hook as *mut _) };
         if err != 0 {

--- a/libbpf-rs/src/tracepoint.rs
+++ b/libbpf-rs/src/tracepoint.rs
@@ -3,6 +3,7 @@ use std::mem::size_of;
 
 /// Options to optionally be provided when attaching to a tracepoint.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_tracepoint_opts")]
 pub struct TracepointOpts {
     /// Custom user-provided value accessible through `bpf_get_attach_cookie`.
     pub cookie: u64,
@@ -29,6 +30,7 @@ impl From<TracepointOpts> for libbpf_sys::bpf_tracepoint_opts {
 
 /// Options to optionally be provided when attaching to a raw tracepoint.
 #[derive(Clone, Debug, Default)]
+#[doc(alias = "bpf_raw_tracepoint_opts")]
 pub struct RawTracepointOpts {
     /// Custom user-provided value accessible through `bpf_get_attach_cookie`.
     pub cookie: u64,

--- a/libbpf-rs/src/user_ringbuf.rs
+++ b/libbpf-rs/src/user_ringbuf.rs
@@ -54,6 +54,7 @@ impl DerefMut for UserRingBufferSample<'_> {
 }
 
 impl Drop for UserRingBufferSample<'_> {
+    #[doc(alias = "user_ring_buffer__discard")]
     fn drop(&mut self) {
         // If the sample has not been submitted, explicitly discard it.
         // This is necessary to avoid leaking ring buffer memory.
@@ -68,6 +69,7 @@ impl Drop for UserRingBufferSample<'_> {
 /// Represents a user ring buffer. This is a special kind of map that is used to
 /// transfer data between user space and kernel space.
 #[derive(Debug)]
+#[doc(alias = "user_ring_buffer")]
 pub struct UserRingBuffer {
     // A non-null pointer to the underlying user ring buffer.
     ptr: NonNull<libbpf_sys::user_ring_buffer>,
@@ -79,6 +81,7 @@ impl UserRingBuffer {
     /// # Errors
     /// * If the map is not a user ring buffer.
     /// * If the underlying libbpf function fails.
+    #[doc(alias = "user_ring_buffer__new")]
     pub fn new(map: &dyn MapCore) -> Result<Self> {
         if map.map_type() != MapType::UserRingBuf {
             return Err(Error::with_invalid_data("must use a UserRingBuf map"));
@@ -107,6 +110,7 @@ impl UserRingBuffer {
     ///
     /// This function is *not* thread-safe. It is necessary to synchronize
     /// amongst multiple producers when invoking this function.
+    #[doc(alias = "user_ring_buffer__reserve")]
     pub fn reserve(&self, size: usize) -> Result<UserRingBufferSample<'_>> {
         let sample_ptr =
             unsafe { libbpf_sys::user_ring_buffer__reserve(self.ptr.as_ptr(), size as c_uint) };
@@ -137,6 +141,7 @@ impl UserRingBuffer {
     ///
     /// This function is thread-safe. It is *not* necessary to synchronize
     /// amongst multiple producers when invoking this function.
+    #[doc(alias = "user_ring_buffer__submit")]
     pub fn submit(&self, mut sample: UserRingBufferSample<'_>) -> Result<()> {
         unsafe {
             libbpf_sys::user_ring_buffer__submit(self.ptr.as_ptr(), sample.ptr.as_ptr());
@@ -161,6 +166,7 @@ impl AsRawLibbpf for UserRingBuffer {
 }
 
 impl Drop for UserRingBuffer {
+    #[doc(alias = "user_ring_buffer__free")]
     fn drop(&mut self) {
         unsafe {
             libbpf_sys::user_ring_buffer__free(self.ptr.as_ptr());

--- a/libbpf-rs/src/util.rs
+++ b/libbpf-rs/src/util.rs
@@ -51,6 +51,7 @@ pub fn roundup(num: usize, r: usize) -> usize {
 }
 
 /// Get the number of CPUs in the system, e.g., to interact with per-cpu maps.
+#[doc(alias = "libbpf_num_possible_cpus")]
 pub fn num_possible_cpus() -> Result<usize> {
     let ret = unsafe { libbpf_sys::libbpf_num_possible_cpus() };
     parse_ret(ret).map(|()| ret as usize)

--- a/libbpf-rs/src/xdp.rs
+++ b/libbpf-rs/src/xdp.rs
@@ -34,6 +34,8 @@ bitflags! {
 ///
 /// This struct exposes operations to attach, detach and query a XDP program
 #[derive(Debug)]
+#[doc(alias = "bpf_xdp_attach_opts")]
+#[doc(alias = "bpf_xdp_query_opts")]
 pub struct Xdp<'fd> {
     fd: BorrowedFd<'fd>,
     attach_opts: libbpf_sys::bpf_xdp_attach_opts,
@@ -60,6 +62,7 @@ impl<'fd> Xdp<'fd> {
     /// # Notes
     /// Once a program is attached, it will outlive the userspace program. Make
     /// sure to detach the program if its not desired.
+    #[doc(alias = "bpf_xdp_attach")]
     pub fn attach(&self, ifindex: i32, flags: XdpFlags) -> Result<()> {
         let ret = unsafe {
             libbpf_sys::bpf_xdp_attach(
@@ -73,12 +76,14 @@ impl<'fd> Xdp<'fd> {
     }
 
     /// Detach the XDP program from the interface
+    #[doc(alias = "bpf_xdp_detach")]
     pub fn detach(&self, ifindex: i32, flags: XdpFlags) -> Result<()> {
         let ret = unsafe { libbpf_sys::bpf_xdp_detach(ifindex, flags.bits(), &self.attach_opts) };
         util::parse_ret(ret)
     }
 
     /// Query to inspect the program
+    #[doc(alias = "bpf_xdp_query")]
     pub fn query(&self, ifindex: i32, flags: XdpFlags) -> Result<libbpf_sys::bpf_xdp_query_opts> {
         let mut opts = self.query_opts;
         let err = unsafe { libbpf_sys::bpf_xdp_query(ifindex, flags.bits() as i32, &mut opts) };
@@ -86,6 +91,7 @@ impl<'fd> Xdp<'fd> {
     }
 
     /// Query to inspect the program identifier (`prog_id`)
+    #[doc(alias = "bpf_xdp_query_id")]
     pub fn query_id(&self, ifindex: i32, flags: XdpFlags) -> Result<u32> {
         let mut prog_id = 0;
         let err =
@@ -94,6 +100,7 @@ impl<'fd> Xdp<'fd> {
     }
 
     /// Replace an existing xdp program (identified by `old_prog_fd`) with this xdp program
+    #[doc(alias = "bpf_xdp_attach")]
     pub fn replace(&self, ifindex: i32, old_prog_fd: BorrowedFd<'_>) -> Result<()> {
         let mut opts = self.attach_opts;
         opts.old_prog_fd = old_prog_fd.as_raw_fd();


### PR DESCRIPTION
As of some time ago, rustdoc supports the addition of doc aliases that allow users to discover functionality via developer-defined aliases used in the search index [1]. For us this seems like very relevant functionality because in many cases users come from a C background and want to understand what Rust functionality wraps a certain concept.

Sprinkle a bunch of `#[doc(alias = "..."]` annotations for the corresponding C functionality on our types to make them discoverable more easily via the C names.

[1] https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#alias