### PR TITLE
Release 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bitflags 2.13.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 rust-version = "1.82"
 license = "LGPL-2.1-only OR BSD-2-Clause"

--- a/libbpf-cargo/CHANGELOG.md
+++ b/libbpf-cargo/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.27.1
+------
+- Removed requirement for `.o` extension for object files
+
+
 0.26.2
 ------
 - Included `missing-docs` lint suppression on generated skeleton

--- a/libbpf-rs/CHANGELOG.md
+++ b/libbpf-rs/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.27.1
+------
+- Added documentation aliases for underlying `libbpf` C functionality to
+  various types/functions
+
+
 0.27.0
 ------
 - Added `KprobeMultiLinkInfo` & `UprobeMultiLinkInfo` fields that required a


### PR DESCRIPTION
Prepare for release of 0.27.1 by bumping both libbpf-rs and libbpf-cargo versions accordingly.